### PR TITLE
Add VB files to default type list

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -70,6 +70,7 @@ const TYPE_EXTENSIONS: &'static [(&'static str, &'static [&'static str])] = &[
     ("txt", &["*.txt"]),
     ("toml", &["*.toml", "Cargo.lock"]),
     ("vala", &["*.vala"]),
+    ("vb", &["*.vb"]),
     ("vimscript", &["*.vim"]),
     ("xml", &["*.xml"]),
     ("yacc", &["*.y"]),


### PR DESCRIPTION
**Use-case**
While not a vogue technology, VB is still commonly taught in many university settings and used in many commercial environments. Working with VB files out-of-the-box would thusly provide a lot of potential value to `ripgrep` users.

**Example**
I'm working on converting a legacy app to a modern infrastructure. The legacy app mixes CS and VB files liberally, so I always need to check both when doing command line string searches. For portability, it would be nice to just be able to ask for `-tcsharp -tvb` without registering with `--type-add` first.

**Tests**
I didn't notice any coverage aimed at this part of the code, but if I'm mistaken I'll amend the PR.