### PR TITLE
Prefer https:// over git://

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ The syntax supported is
 `ripgrep` compiles with Rust 1.9 (stable) or newer. Building is easy:
 
 ```
-$ git clone git://github.com/BurntSushi/ripgrep
+$ git clone https://github.com/BurntSushi/ripgrep
 $ cd ripgrep
 $ cargo build --release
 $ ./target/release/rg --version


### PR DESCRIPTION
1) git is not a secure protocol and vulnerable to man-in-the-middle
   attacks.
2) git:// is a pain for users behind proxy servers :(

Change-Id: I1901bebbaf8f64b23b070dee8732a6fb13cbdfdd