### PR TITLE
Switch from .rgignore to .ignore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ files, ignore hidden files and directories and skip binary files:
 $ rg foobar
 ```
 
-The above command also respects all `.rgignore` files, including in parent
-directories. `.rgignore` files can be used when `.gitignore` files are
-insufficient. In all cases, `.rgignore` patterns take precedence over
+The above command also respects all `.ignore` files, including in parent
+directories. `.ignore` files can be used when `.gitignore` files are
+insufficient. In all cases, `.ignore` patterns take precedence over
 `.gitignore`.
 
 To ignore all ignore files, use `-u`. To additionally search hidden files

--- a/doc/rg.1
+++ b/doc/rg.1
@@ -211,8 +211,8 @@ Never use memory maps, even when they might be faster.
 .RE
 .TP
 .B \-\-no\-ignore
-Don\[aq]t respect ignore files (.gitignore, .rgignore, etc.) This
-implies \-\-no\-ignore\-parent.
+Don\[aq]t respect ignore files (.gitignore, .ignore, etc.) This implies
+\-\-no\-ignore\-parent.
 .RS
 .RE
 .TP

--- a/doc/rg.1.md
+++ b/doc/rg.1.md
@@ -137,7 +137,7 @@ the raw speed of grep.
 : Never use memory maps, even when they might be faster.
 
 --no-ignore
-: Don't respect ignore files (.gitignore, .rgignore, etc.)
+: Don't respect ignore files (.gitignore, .ignore, etc.)
   This implies --no-ignore-parent.
 
 --no-ignore-parent

--- a/src/args.rs
+++ b/src/args.rs
@@ -137,7 +137,7 @@ Less common options:
         Never use memory maps, even when they might be faster.
 
     --no-ignore
-        Don't respect ignore files (.gitignore, .rgignore, etc.)
+        Don't respect ignore files (.gitignore, .ignore, etc.)
         This implies --no-ignore-parent.
 
     --no-ignore-parent

--- a/src/gitignore.rs
+++ b/src/gitignore.rs
@@ -9,7 +9,7 @@ The motivation for this submodule is performance and portability:
 2. We could shell out to a `git` sub-command like ls-files or status, but it
    seems better to not rely on the existence of external programs for a search
    tool. Besides, we need to implement this logic anyway to support things like
-   an .rgignore file.
+   an .ignore file.
 
 The key implementation detail here is that a single gitignore file is compiled
 into a single RegexSet, which can be used to report which globs match a

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -5,7 +5,7 @@ whether a *single* file path should be searched or not.
 In general, there are two ways to ignore a particular file:
 
 1. Specify an ignore rule in some "global" configuration, such as a
-   $HOME/.rgignore or on the command line.
+   $HOME/.ignore or on the command line.
 2. A specific ignore file (like .gitignore) found during directory traversal.
 
 The `IgnoreDir` type handles ignore patterns for any one particular directory
@@ -24,6 +24,7 @@ use types::Types;
 
 const IGNORE_NAMES: &'static [&'static str] = &[
     ".gitignore",
+    ".ignore",
     ".rgignore",
 ];
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -377,6 +377,11 @@ sherlock!(ignore_git, "Sherlock", ".", |wd: WorkDir, mut cmd: Command| {
     wd.assert_err(&mut cmd);
 });
 
+sherlock!(ignore_generic, "Sherlock", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create(".ignore", "sherlock\n");
+    wd.assert_err(&mut cmd);
+});
+
 sherlock!(ignore_ripgrep, "Sherlock", ".", |wd: WorkDir, mut cmd: Command| {
     wd.create(".rgignore", "sherlock\n");
     wd.assert_err(&mut cmd);


### PR DESCRIPTION
But don't actually remove support for .rgignore until the next semver
bump.

Note that this puts us in line with the silver searcher:
https://github.com/ggreer/the_silver_searcher/pull/974

Fixes #40