### PR TITLE
Add support for the Swift programming language file type

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -66,6 +66,7 @@ const TYPE_EXTENSIONS: &'static [(&'static str, &'static [&'static str])] = &[
     ("scala", &["*.scala"]),
     ("sh", &["*.bash", "*.csh", "*.ksh", "*.sh", "*.tcsh"]),
     ("sql", &["*.sql"]),
+    ("swift", &["*.swift"]),
     ("tex", &["*.tex", "*.cls", "*.sty"]),
     ("txt", &["*.txt"]),
     ("toml", &["*.toml", "Cargo.lock"]),


### PR DESCRIPTION
This pull request add the Swift filetype `*.swift` to the know filetypes of ripgrep