### PR TITLE
--type js: include more extensions

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -41,7 +41,9 @@ const TYPE_EXTENSIONS: &'static [(&'static str, &'static [&'static str])] = &[
     ("haskell", &["*.hs", "*.lhs"]),
     ("html", &["*.htm", "*.html"]),
     ("java", &["*.java"]),
-    ("js", &["*.js"]),
+    ("js", &[
+        "*.js", "*.jsx", "*.vue",
+    ]),
     ("json", &["*.json"]),
     ("jsonl", &["*.jsonl"]),
     ("lisp", &["*.el", "*.jl", "*.lisp", "*.lsp", "*.sc", "*.scm"]),


### PR DESCRIPTION
Includes more commonly used extensions to the js type.

* coffe, used by coffescript
* ts, tsx, used by typescript
* jsx, used by react.js
* vue, used by vue.js