### PR TITLE
[Fixes #46] Use 1 less worker thread than number of threads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use std::process;
 use std::result;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::cmp;
 
 use deque::{Stealer, Stolen};
 use grep::Grep;
@@ -102,7 +103,7 @@ fn run(args: Args) -> Result<u64> {
 
     let workq = {
         let (workq, stealer) = deque::new();
-        for _ in 0..args.threads() {
+        for _ in 0..cmp::max(1, args.threads() - 1) {
             let worker = MultiWorker {
                 chan_work: stealer.clone(),
                 out: out.clone(),


### PR DESCRIPTION
The main thread does directory traversal. Hence
number of threads = main Thread + number of worker threads.
We should have atleast one worker thread.