### PR TITLE
Recognise cljc and cljx extensions as Clojure(script)

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -18,7 +18,7 @@ const TYPE_EXTENSIONS: &'static [(&'static str, &'static [&'static str])] = &[
     ("awk", &["*.awk"]),
     ("c", &["*.c", "*.h", "*.H"]),
     ("cbor", &["*.cbor"]),
-    ("clojure", &["*.clj", "*.cljs"]),
+    ("clojure", &["*.clj", "*.cljc", "*.cljs", "*.cljx"]),
     ("cmake", &["CMakeLists.txt"]),
     ("coffeescript", &["*.coffee"]),
     ("cpp", &[


### PR DESCRIPTION
(see https://github.com/clojure/clojurescript/wiki/Using-cljc)