### PR TITLE
Add SystemVerilog (SV) type

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -70,6 +70,7 @@ const TYPE_EXTENSIONS: &'static [(&'static str, &'static [&'static str])] = &[
     ("scala", &["*.scala"]),
     ("sh", &["*.bash", "*.csh", "*.ksh", "*.sh", "*.tcsh"]),
     ("sql", &["*.sql"]),
+    ("sv", &["*.v", "*.vg", "*.sv", "*.svh", "*.h"]),
     ("swift", &["*.swift"]),
     ("tex", &["*.tex", "*.cls", "*.sty"]),
     ("ts", &["*.ts", "*.tsx"]),


### PR DESCRIPTION
Add type for hardware design and verification language SystemVerilog; known as SV in the industry.