### PR TITLE
Create Colour Choice struct to adjust colours depending on platform 

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -37,6 +37,36 @@ pub struct Printer<W> {
     replace: Option<Vec<u8>>,
     /// Whether to prefix each match with the corresponding file name.
     with_filename: bool,
+
+    /// The choice of Colours
+    color_choice: ColorChoice
+}
+
+struct ColorChoice {
+    matched_line: color::Color,
+    heading: color::Color,
+    line_number: color::Color
+}
+
+impl ColorChoice {
+
+    #[cfg(unix)]
+    pub fn new() -> ColorChoice {
+        ColorChoice {
+            matched_line: color::RED,
+            heading: color::GREEN,
+            line_number: color::BLUE
+        }
+    }
+
+    #[cfg(not(unix))]
+    pub fn new() -> ColorChoice {
+        ColorChoice {
+            matched_line: color::BRIGHT_RED,
+            heading: color::BRIGHT_GREEN,
+            line_number: color::BRIGHT_BLUE
+        }
+    }
 }
 
 impl<W: Terminal + Send> Printer<W> {
@@ -53,6 +83,7 @@ impl<W: Terminal + Send> Printer<W> {
             quiet: false,
             replace: None,
             with_filename: false,
+            color_choice: ColorChoice::new()
         }
     }
 
@@ -243,7 +274,7 @@ impl<W: Terminal + Send> Printer<W> {
         let mut last_written = 0;
         for (s, e) in re.find_iter(buf) {
             self.write(&buf[last_written..s]);
-            let _ = self.wtr.fg(color::BRIGHT_RED);
+            let _ = self.wtr.fg(self.color_choice.matched_line);
             let _ = self.wtr.attr(Attr::Bold);
             self.write(&buf[s..e]);
             let _ = self.wtr.reset();
@@ -277,7 +308,7 @@ impl<W: Terminal + Send> Printer<W> {
 
     fn write_heading<P: AsRef<Path>>(&mut self, path: P) {
         if self.wtr.supports_color() {
-            let _ = self.wtr.fg(color::BRIGHT_GREEN);
+            let _ = self.wtr.fg(self.color_choice.heading);
             let _ = self.wtr.attr(Attr::Bold);
         }
         self.write_path(path.as_ref());
@@ -289,7 +320,7 @@ impl<W: Terminal + Send> Printer<W> {
 
     fn line_number(&mut self, n: u64, sep: u8) {
         if self.wtr.supports_color() {
-            let _ = self.wtr.fg(color::BRIGHT_BLUE);
+            let _ = self.wtr.fg(self.color_choice.line_number);
             let _ = self.wtr.attr(Attr::Bold);
         }
         self.write(n.to_string().as_bytes());


### PR DESCRIPTION
Relates to https://github.com/BurntSushi/ripgrep/issues/96 but actually paves the way to have it configurable in the future as per this enhancement: https://github.com/BurntSushi/ripgrep/issues/51

Could expand upon this to include attributes for each of the types of colours.

I've kept the spelling american for consistency.