### PR TITLE
Update brew 0.2.1 package hashes

### DIFF
--- a/pkg/brew/ripgrep.rb
+++ b/pkg/brew/ripgrep.rb
@@ -6,10 +6,10 @@ class Ripgrep < Formula
 
   if Hardware::CPU.is_64_bit?
     url "https://github.com/BurntSushi/ripgrep/releases/download/#{version}/ripgrep-#{version}-x86_64-apple-darwin.tar.gz"
-    sha256 "f55ef5dac04178bcae0d6c5ba2d09690d326e8c7c3f28e561025b04e1ab81d80"
+    sha256 "f8b208239b988708da2e58f848a75bf70ad144e201b3ed99cd323cc5a699625f"
   else
     url "https://github.com/BurntSushi/ripgrep/releases/download/#{version}/ripgrep-#{version}-i686-apple-darwin.tar.gz"
-    sha256 "d901d55ccb48c19067f563d42652dfd8642bf50d28a40c0e2a4d3e866857a93b"
+    sha256 "3880ffbc169ea7a884d6c803f3b227a9a3acafff160cdaf830f930e065ae2b38"
   end
 
   def install


### PR DESCRIPTION
https://github.com/BurntSushi/ripgrep/commit/9fa38c62327b5e72111bc68b4c299fbf970d3f7c updated the package version in the Homebrew formula but didn't update the SHA256 hashes.