### PR TITLE
Make the repo a Homebrew Tap

### DIFF
--- a/HomebrewFormula
+++ b/HomebrewFormula
@@ -1,0 +1,1 @@
+pkg/brew

--- a/README.md
+++ b/README.md
@@ -97,12 +97,11 @@ but you'll need to have the
 [Microsoft VC++ 2015 redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145)
 installed.
 
-If you're a **Homebrew** user, then you can install it with a custom formula
-(N.B. `ripgrep` isn't actually in Homebrew yet. This just installs the binary
-directly):
+If you're a **Homebrew** user, then you can install it with a custom tap:
 
 ```
-$ brew install https://raw.githubusercontent.com/BurntSushi/ripgrep/master/pkg/brew/ripgrep.rb
+$ brew tap burntsushi/ripgrep https://github.com/BurntSushi/ripgrep.git
+$ brew install burntsushi/ripgrep/ripgrep
 ```
 
 If you're an **Arch Linux** user, then you can install `ripgrep` from the official repos:

--- a/pkg/brew/ripgrep.rb
+++ b/pkg/brew/ripgrep.rb
@@ -1,16 +1,9 @@
-require  'formula'
 class Ripgrep < Formula
   version '0.2.1'
   desc "Search tool like grep and The Silver Searcher."
   homepage "https://github.com/BurntSushi/ripgrep"
-
-  if Hardware::CPU.is_64_bit?
-    url "https://github.com/BurntSushi/ripgrep/releases/download/#{version}/ripgrep-#{version}-x86_64-apple-darwin.tar.gz"
-    sha256 "f8b208239b988708da2e58f848a75bf70ad144e201b3ed99cd323cc5a699625f"
-  else
-    url "https://github.com/BurntSushi/ripgrep/releases/download/#{version}/ripgrep-#{version}-i686-apple-darwin.tar.gz"
-    sha256 "3880ffbc169ea7a884d6c803f3b227a9a3acafff160cdaf830f930e065ae2b38"
-  end
+  url "https://github.com/BurntSushi/ripgrep/releases/download/#{version}/ripgrep-#{version}-x86_64-apple-darwin.tar.gz"
+  sha256 "f8b208239b988708da2e58f848a75bf70ad144e201b3ed99cd323cc5a699625f"
 
   def install
     bin.install "rg"


### PR DESCRIPTION
Because there have been several comments on the builds provided by @BurntSushi [having `simd-accel` enabled](https://github.com/BurntSushi/ripgrep/issues/10#issuecomment-250612979), vs [HomeBrew using rust stable to build](https://github.com/Homebrew/homebrew-core/pull/5268).  I thought I would create this PR to enable the BurntSushi/ripgrep repo to be used as a Homebrew tap.  This would allow those who are tracking these releases (built with rust nightly?) to have easy updates, at least until the official Homebrew build can enable `simd-accel`.

Another aside, this PR removes the non-64-bit releases from the `Formula`.  This is because everything Mac OS 10.7 and newer has to be running on an x86_64 cpu.  If you want to continue supporting non-64-bit installs, I can add it back to this PR.