### PR TITLE
Fix brew formula name to not conflict with core

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you're a **Homebrew** user, then you can install it with a custom tap:
 
 ```
 $ brew tap burntsushi/ripgrep https://github.com/BurntSushi/ripgrep.git
-$ brew install burntsushi/ripgrep/ripgrep
+$ brew install burntsushi/ripgrep/ripgrep-bin
 ```
 
 If you're an **Arch Linux** user, then you can install `ripgrep` from the official repos:

--- a/pkg/brew/ripgrep-bin.rb
+++ b/pkg/brew/ripgrep-bin.rb
@@ -1,9 +1,11 @@
-class Ripgrep < Formula
+class RipgrepBin < Formula
   version '0.2.1'
   desc "Search tool like grep and The Silver Searcher."
   homepage "https://github.com/BurntSushi/ripgrep"
   url "https://github.com/BurntSushi/ripgrep/releases/download/#{version}/ripgrep-#{version}-x86_64-apple-darwin.tar.gz"
   sha256 "f8b208239b988708da2e58f848a75bf70ad144e201b3ed99cd323cc5a699625f"
+
+  conflicts_with "ripgrep"
 
   def install
     bin.install "rg"


### PR DESCRIPTION
Since the homebrew-core formula was accepted, we should differentiate
the prebuilt formula available in this tap

Only after my previous PR was accepted (and I tried it again), did I notice that there may be an issue with conflicting formula names:

![image](https://cloud.githubusercontent.com/assets/168513/19055204/7049a34e-8988-11e6-9832-c20d294e146c.png)

This is failing because the cache I have from installing the `homebrew-core` version of ripgrep doesn't match the sha of the prebuilt download.