### PR TITLE
Added *.cmake extension to cmake file type.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -19,7 +19,7 @@ const TYPE_EXTENSIONS: &'static [(&'static str, &'static [&'static str])] = &[
     ("c", &["*.c", "*.h", "*.H"]),
     ("cbor", &["*.cbor"]),
     ("clojure", &["*.clj", "*.cljc", "*.cljs", "*.cljx"]),
-    ("cmake", &["CMakeLists.txt"]),
+    ("cmake", &["*.cmake", "CMakeLists.txt"]),
     ("coffeescript", &["*.coffee"]),
     ("cpp", &[
         "*.C", "*.cc", "*.cpp", "*.cxx",


### PR DESCRIPTION
.cmake is a common extension used by CMake modules and includes.

For example, the include macro searches for .cmake files - https://cmake.org/cmake/help/v3.5/command/include.html?highlight=include.