### PR TITLE
add jinja type for *.jinja and *.jinja2

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -42,6 +42,7 @@ const TYPE_EXTENSIONS: &'static [(&'static str, &'static [&'static str])] = &[
     ("haskell", &["*.hs", "*.lhs"]),
     ("html", &["*.htm", "*.html"]),
     ("java", &["*.java"]),
+    ("jinja", &["*.jinja", "*.jinja2"]),
     ("js", &[
         "*.js", "*.jsx", "*.vue",
     ]),


### PR DESCRIPTION
see #145.

I guess this is quite niche, it's just one templating language (although popular) but without the option for an override or extension locally I guess this is the best option.