### PR TITLE
Change Arch Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ brew install burntsushi/ripgrep/ripgrep-bin
 If you're an **Arch Linux** user, then you can install `ripgrep` from the official repos:
 
 ```
-$ pacman -Syu ripgrep
+$ pacman -S ripgrep
 ```
 
 If you're a **Rust programmer**, `ripgrep` can be installed with `cargo`:


### PR DESCRIPTION
The `-Syu` flag will do a full system upgrade and then install the package, which is not necessarily the desired behavior. Only the `-S` flag is necessary to install a single package.
See https://wiki.archlinux.org/index.php/Pacman#Installing_specific_packages
https://wiki.archlinux.org/index.php/Pacman#Upgrading_packages