### PR TITLE
Adding extra .md filetype for ease of access to Markdown filetypes

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -53,6 +53,7 @@ const TYPE_EXTENSIONS: &'static [(&'static str, &'static [&'static str])] = &[
     ("m4", &["*.ac", "*.m4"]),
     ("make", &["gnumakefile", "Gnumakefile", "makefile", "Makefile", "*.mk"]),
     ("markdown", &["*.md"]),
+    ("md", &["*.md"]),
     ("matlab", &["*.m"]),
     ("mk", &["mkfile"]),
     ("ml", &["*.ml"]),


### PR DESCRIPTION
`-tmarkdown` is somewhat lengthy and unwieldy in practice, we could easily use `-tmd` in addition for ease of access.