### PR TITLE
Always follow symlinks on explicit file arguments

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -708,7 +708,9 @@ impl Args {
 
     /// Create a new recursive directory iterator at the path given.
     pub fn walker(&self, path: &Path) -> Result<walk::Iter> {
-        let mut wd = WalkDir::new(path).follow_links(self.follow);
+        // Always follow symlinks for explicitly specified files.
+        let mut wd = WalkDir::new(path).follow_links(self.follow
+                                                     || path.is_file());
         if let Some(maxdepth) = self.maxdepth {
             wd = wd.max_depth(maxdepth);
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -567,6 +567,25 @@ baz/sherlock:be, to a very large extent, the result of luck. Sherlock Holmes
     assert_eq!(lines, path(expected));
 });
 
+// Follow symlinks on explicit file arguments.
+sherlock!(symlink_explicit_file, "Sherlock", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.link("sherlock", "sym1");
+    wd.link("sherlock", "sym2");
+    cmd.arg("sym1");
+    cmd.arg("sym2");
+
+    let lines: String = wd.stdout(&mut cmd);
+    let expected = "\
+sherlock:For the Doctor Watsons of this world, as opposed to the Sherlock
+sherlock:be, to a very large extent, the result of luck. Sherlock Holmes
+sym1:For the Doctor Watsons of this world, as opposed to the Sherlock
+sym1:be, to a very large extent, the result of luck. Sherlock Holmes
+sym2:For the Doctor Watsons of this world, as opposed to the Sherlock
+sym2:be, to a very large extent, the result of luck. Sherlock Holmes
+";
+    assert_eq!(lines, path(expected));
+});
+
 sherlock!(unrestricted1, "Sherlock", ".", |wd: WorkDir, mut cmd: Command| {
     wd.create(".gitignore", "sherlock\n");
     cmd.arg("-u");


### PR DESCRIPTION
Fixes #137.  I have no prior knowledge, but it looks like Args.walker() is the correct place to locate this...

Let me know if you think this should be documented anyplace.