### PR TITLE
Add .gradle as a groovy extension pattern

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -39,7 +39,7 @@ const TYPE_EXTENSIONS: &'static [(&'static str, &'static [&'static str])] = &[
     ]),
     ("fsharp", &["*.fs", "*.fsx", "*.fsi"]),
     ("go", &["*.go"]),
-    ("groovy", &["*.groovy"]),
+    ("groovy", &["*.groovy", "*.gradle"]),
     ("haskell", &["*.hs", "*.lhs"]),
     ("html", &["*.htm", "*.html"]),
     ("java", &["*.java"]),


### PR DESCRIPTION
Gradle is a build system for JVM-based languages that is configured via a Groovy DSL.