### PR TITLE
Add instructions for installation on Fedora 24+ and RHEL/CentOS 7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ If you're an **Arch Linux** user, then you can install `ripgrep` from the offici
 $ pacman -S ripgrep
 ```
 
+If you're a **Fedora 24+** user, you can install `ripgrep` from [copr](https://copr.fedorainfracloud.org/coprs/carlgeorge/ripgrep/):
+
+```
+$ dnf copr enable carlgeorge/ripgrep
+$ dnf install ripgrep
+```
+
+If you're a **RHEL/CentOS 7** user, you can install `ripgrep` from [copr](https://copr.fedorainfracloud.org/coprs/carlgeorge/ripgrep/):
+
+```
+$ yum-config-manager --add-repo=https://copr.fedorainfracloud.org/coprs/carlgeorge/ripgrep/repo/epel-7/carlgeorge-ripgrep-epel-7.repo
+$ yum install ripgrep
+```
+
 If you're a **Rust programmer**, `ripgrep` can be installed with `cargo`:
 
 ```


### PR DESCRIPTION
Please note that the referenced copr repository should just be a temporary home while the Fedora/EPEL package review is pending.

https://bugzilla.redhat.com/show_bug.cgi?id=1380442