### PR TITLE
Reset the terminal when Ctrl-C is pressed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,7 @@
 name = "ripgrep"
 version = "0.2.3"
 dependencies = [
+ "ctrlc 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -28,6 +29,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ctrlc"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -240,6 +251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum ctrlc 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77f98bb69e3fefadcc5ca80a1368a55251f70295168203e01165bcaecb270891"
 "checksum deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1614659040e711785ed8ea24219140654da1729f3ec8a47a9719d041112fe7bf"
 "checksum docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)" = "4a7ef30445607f6fc8720f0a0a2c7442284b629cf0d049286860fae23e71c4d9"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ name = "integration"
 path = "tests/tests.rs"
 
 [dependencies]
+ctrlc = "2.0"
 deque = "0.3"
 docopt = "0.6"
 env_logger = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+extern crate ctrlc;
 extern crate deque;
 extern crate docopt;
 extern crate env_logger;
@@ -24,6 +25,7 @@ extern crate winapi;
 use std::error::Error;
 use std::fs::File;
 use std::io;
+use std::io::Write;
 use std::path::Path;
 use std::process;
 use std::result;
@@ -88,6 +90,18 @@ fn main() {
 
 fn run(args: Args) -> Result<u64> {
     let args = Arc::new(args);
+
+    let handler_args = args.clone();
+    ctrlc::set_handler(move || {
+        let stdout = io::stdout();
+        let mut stdout = stdout.lock();
+
+        let _ = handler_args.stdout().reset();
+        let _ = stdout.flush();
+
+        process::exit(1);
+    });
+
     let paths = args.paths();
     let threads = cmp::max(1, args.threads() - 1);
     let isone =


### PR DESCRIPTION
If a user hits Ctrl-C to exit out of a search in the middle of printing
a line, we don't want to leave the terminal colors screwed up for them.
Catch Ctrl-C using the ctrlc crate, obtain a stdout lock to ensure that
other threads don't continue writing after we do so, reset the terminal,
and exit the program.

Closes #119