### PR TITLE
Add zsh type

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -88,6 +88,7 @@ const TYPE_EXTENSIONS: &'static [(&'static str, &'static [&'static str])] = &[
     ("xml", &["*.xml"]),
     ("yacc", &["*.y"]),
     ("yaml", &["*.yaml", "*.yml"]),
+    ("zsh", &["*.zsh", ".zshenv", ".zlogin", ".zprofile", ".zshrc"]),
 ];
 
 /// Describes all the possible failure conditions for building a file type


### PR DESCRIPTION
Like discussed in #196 

Filenames are the ones from oh-my-zsh (`*.zsh`) and the ones from here: https://www-s.acm.illinois.edu/workshops/zsh/startup_files.html