### PR TITLE
update python types to include Cython files

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -65,7 +65,7 @@ const TYPE_EXTENSIONS: &'static [(&'static str, &'static [&'static str])] = &[
     ("ocaml", &["*.ml", "*.mli", "*.mll", "*.mly"]),
     ("perl", &["*.perl", "*.pl", "*.PL", "*.plh", "*.plx", "*.pm"]),
     ("php", &["*.php", "*.php3", "*.php4", "*.php5", "*.phtml"]),
-    ("py", &["*.py"]),
+    ("py", &["*.py", "*.pyx"]),
     ("readme", &["README*", "*README"]),
     ("r", &["*.R", "*.r", "*.Rmd", "*.Rnw"]),
     ("rst", &["*.rst"]),


### PR DESCRIPTION
Cython a tool to compile python (or possibly 'pseudo' python i.e. python with a few type annotations thrown in) to down to C. Commonly, Cython files have the extension pyx (see https://en.wikipedia.org/wiki/Cython). Personally I think it makes sense to include these files in the python type filter. Cython is widely used in the scientific python community.