### PR TITLE
Snapcraft definition for building ripgrep snaps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target
 /grep/Cargo.lock
 /globset/Cargo.lock
 /ignore/Cargo.lock
+parts/
+prime/
+stage/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: rg
+version: 0.2.6
+summary: a command line search tool
+description: |
+  ripgrep is a command line search tool that
+  combines the usability of The Silver Searcher
+  (an ack clone) with the raw speed of GNU grep.
+confinement: strict
+apps:
+  rg:
+    command: rg
+    plugs: [home]
+parts:
+  rg:
+    plugin: rust
+    source: .


### PR DESCRIPTION
Snaps are a new application packaging approach that allows for better isolation. This PR introduces a snapcraft.yaml file that allows building ripgrep snaps using the [snapcraft](http://snapcraft.io) tool.