### PR TITLE
Add Gentoo info to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ If you're an **Arch Linux** user, then you can install `ripgrep` from the offici
 $ pacman -S ripgrep
 ```
 
+If you're a **Gentoo** user, you can install `ripgrep` from the [official repo](https://packages.gentoo.org/packages/sys-apps/ripgrep):
+
+```
+$ emerge ripgrep
+```
+
 If you're a **Fedora 24+** user, you can install `ripgrep` from [copr](https://copr.fedorainfracloud.org/coprs/carlgeorge/ripgrep/):
 
 ```


### PR DESCRIPTION
ripgrep is now in the main gentoo repo, courtesy of me. :smile: