### PR TITLE
Add textile, org, creole, rdoc, wiki filetype

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -137,6 +137,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("py", &["*.py"]),
     ("readme", &["README*", "*README"]),
     ("r", &["*.R", "*.r", "*.Rmd", "*.Rnw"]),
+    ("rdoc", &["*.rdoc"]),
     ("rst", &["*.rst"]),
     ("ruby", &["*.rb"]),
     ("rust", &["*.rs"]),

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -89,6 +89,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("clojure", &["*.clj", "*.cljc", "*.cljs", "*.cljx"]),
     ("cmake", &["*.cmake", "CMakeLists.txt"]),
     ("coffeescript", &["*.coffee"]),
+    ("creole", &["*.creole"]),
     ("config", &["*.config"]),
     ("cpp", &[
         "*.C", "*.cc", "*.cpp", "*.cxx",

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -132,6 +132,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("objc", &["*.h", "*.m"]),
     ("objcpp", &["*.h", "*.mm"]),
     ("ocaml", &["*.ml", "*.mli", "*.mll", "*.mly"]),
+    ("org", &["*.org"]),
     ("perl", &["*.perl", "*.pl", "*.PL", "*.plh", "*.plx", "*.pm"]),
     ("php", &["*.php", "*.php3", "*.php4", "*.php5", "*.phtml"]),
     ("py", &["*.py"]),

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -136,6 +136,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("org", &["*.org"]),
     ("perl", &["*.perl", "*.pl", "*.PL", "*.plh", "*.plx", "*.pm"]),
     ("php", &["*.php", "*.php3", "*.php4", "*.php5", "*.phtml"]),
+    ("pod", &["*.pod"]),
     ("py", &["*.py"]),
     ("readme", &["README*", "*README"]),
     ("r", &["*.R", "*.r", "*.Rmd", "*.Rnw"]),

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -149,6 +149,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("taskpaper", &["*.taskpaper"]),
     ("tcl", &["*.tcl"]),
     ("tex", &["*.tex", "*.ltx", "*.cls", "*.sty", "*.bib"]),
+    ("textile", &["*.textile"]),
     ("ts", &["*.ts", "*.tsx"]),
     ("txt", &["*.txt"]),
     ("toml", &["*.toml", "Cargo.lock"]),

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -159,6 +159,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("vala", &["*.vala"]),
     ("vb", &["*.vb"]),
     ("vimscript", &["*.vim"]),
+    ("wiki", &["*.mediawiki", "*.wiki"]),
     ("xml", &["*.xml"]),
     ("yacc", &["*.y"]),
     ("yaml", &["*.yaml", "*.yml"]),


### PR DESCRIPTION
I remembered this article ["Rendering differences in prose documents"](https://help.github.com/articles/rendering-differences-in-prose-documents/). So I add filetypes refered in it. These filetypes can be previewed in Github.

## Filetypes

- [Textile](https://github.com/textile) : a lightweight markup language that uses a text formatting syntax to convert plain text into structured HTML markup.
- [Org(Org Mode)](http://orgmode.org) : for keeping notes, maintaining TODO lists, planning projects, and authoring documents with a fast and effective plain-text system
- [Rdoc](http://rdoc.sourceforge.net) : Documentation from Ruby Source Files
- [MediaWiki](https://www.mediawiki.org/wiki/Help:Formatting) : wiki markup used by [MediaWiki](https://www.mediawiki.org)
- [Pod](http://perldoc.perl.org/perlpod.html) : "Plain Old Documentation", is a simple-to-use markup language used for writing documentation for Perl, Perl programs, and Perl modules.
- [Creole](http://wikicreole.org) : A common wiki markup for the wiki ohana