### PR TITLE
Add parallel recursive directory iterator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,6 @@ name = "ripgrep"
 version = "0.2.6"
 dependencies = [
  "ctrlc 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "grep 0.1.3",
@@ -30,6 +29,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ctrlc"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,14 +41,6 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "deque"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -109,6 +105,7 @@ dependencies = [
 name = "ignore"
 version = "0.1.3"
 dependencies = [
+ "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.1.1",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -164,14 +161,6 @@ dependencies = [
 [[package]]
 name = "num_cpus"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -293,8 +282,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum ctrlc 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77f98bb69e3fefadcc5ca80a1368a55251f70295168203e01165bcaecb270891"
-"checksum deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1614659040e711785ed8ea24219140654da1729f3ec8a47a9719d041112fe7bf"
 "checksum docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)" = "4a7ef30445607f6fc8720f0a0a2c7442284b629cf0d049286860fae23e71c4d9"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
@@ -306,7 +295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memmap 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "065ce59af31c18ea2c419100bda6247dd4ec3099423202b12f0bd32e529fabd2"
 "checksum num_cpus 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8890e6084723d57d0df8d2720b0d60c6ee67d6c93e7169630e4371e88765dcad"
-"checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ path = "tests/tests.rs"
 
 [dependencies]
 ctrlc = "2.0"
-deque = "0.3"
 docopt = "0.6"
 env_logger = "0.3"
 grep = { version = "0.1.3", path = "grep" }

--- a/ignore/Cargo.toml
+++ b/ignore/Cargo.toml
@@ -18,6 +18,7 @@ name = "ignore"
 bench = false
 
 [dependencies]
+crossbeam = "0.2"
 globset = { version = "0.1.1", path = "../globset" }
 lazy_static = "0.2"
 log = "0.3"

--- a/ignore/examples/walk.rs
+++ b/ignore/examples/walk.rs
@@ -1,28 +1,92 @@
-/*
+#![allow(dead_code, unused_imports, unused_mut, unused_variables)]
+
+extern crate crossbeam;
 extern crate ignore;
 extern crate walkdir;
 
 use std::env;
 use std::io::{self, Write};
-use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
 
-use ignore::ignore::IgnoreBuilder;
+use crossbeam::sync::MsQueue;
+use ignore::WalkBuilder;
 use walkdir::WalkDir;
 
 fn main() {
-    let path = env::args().nth(1).unwrap();
-    let ig = IgnoreBuilder::new().build();
-    let wd = WalkDir::new(path);
-    let walker = ignore::walk::Iter::new(ig, wd);
-
-    let mut stdout = io::BufWriter::new(io::stdout());
-    // let mut count = 0;
-    for dirent in walker {
-        // count += 1;
-        stdout.write(dirent.path().as_os_str().as_bytes()).unwrap();
-        stdout.write(b"\n").unwrap();
+    let mut path = env::args().nth(1).unwrap();
+    let mut parallel = false;
+    let mut simple = false;
+    let queue: Arc<MsQueue<Option<DirEntry>>> = Arc::new(MsQueue::new());
+    if path == "parallel" {
+        path = env::args().nth(2).unwrap();
+        parallel = true;
+    } else if path == "walkdir" {
+        path = env::args().nth(2).unwrap();
+        simple = true;
     }
-    // println!("{}", count);
+
+    let stdout_queue = queue.clone();
+    let stdout_thread = thread::spawn(move || {
+        let mut stdout = io::BufWriter::new(io::stdout());
+        while let Some(dent) = stdout_queue.pop() {
+            write_path(&mut stdout, dent.path());
+        }
+    });
+
+    if parallel {
+        let walker = WalkBuilder::new(path).threads(6).build_parallel();
+        walker.run(|| {
+            let queue = queue.clone();
+            Box::new(move |result| {
+                use ignore::WalkState::*;
+
+                queue.push(Some(DirEntry::Y(result.unwrap())));
+                Continue
+            })
+        });
+    } else if simple {
+        let mut stdout = io::BufWriter::new(io::stdout());
+        let walker = WalkDir::new(path);
+        for result in walker {
+            queue.push(Some(DirEntry::X(result.unwrap())));
+        }
+    } else {
+        let mut stdout = io::BufWriter::new(io::stdout());
+        let walker = WalkBuilder::new(path).build();
+        for result in walker {
+            queue.push(Some(DirEntry::Y(result.unwrap())));
+        }
+    }
+    queue.push(None);
+    stdout_thread.join().unwrap();
 }
-*/
-fn main() {}
+
+enum DirEntry {
+    X(walkdir::DirEntry),
+    Y(ignore::DirEntry),
+}
+
+impl DirEntry {
+    fn path(&self) -> &Path {
+        match *self {
+            DirEntry::X(ref x) => x.path(),
+            DirEntry::Y(ref y) => y.path(),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn write_path<W: Write>(mut wtr: W, path: &Path) {
+    use std::os::unix::ffi::OsStrExt;
+    wtr.write(path.as_os_str().as_bytes()).unwrap();
+    wtr.write(b"\n").unwrap();
+}
+
+#[cfg(not(unix))]
+fn write_path<W: Write>(mut wtr: W, path: &Path) {
+    wtr.write(path.to_string_lossy().as_bytes()).unwrap();
+    wtr.write(b"\n").unwrap();
+}

--- a/ignore/src/dir.rs
+++ b/ignore/src/dir.rs
@@ -137,6 +137,11 @@ impl Ignore {
         self.0.parent.is_none()
     }
 
+    /// Returns true if this matcher was added via the `add_parents` method.
+    pub fn is_absolute_parent(&self) -> bool {
+        self.0.is_absolute_parent
+    }
+
     /// Return this matcher's parent, if one exists.
     pub fn parent(&self) -> Option<Ignore> {
         self.0.parent.clone()
@@ -376,7 +381,7 @@ impl Ignore {
     }
 
     /// Returns an iterator over parent ignore matchers, including this one.
-    fn parents(&self) -> Parents {
+    pub fn parents(&self) -> Parents {
         Parents(Some(self))
     }
 
@@ -387,7 +392,10 @@ impl Ignore {
     }
 }
 
-struct Parents<'a>(Option<&'a Ignore>);
+/// An iterator over all parents of an ignore matcher, including itself.
+///
+/// The lifetime `'a` refers to the lifetime of the initial `Ignore` matcher.
+pub struct Parents<'a>(Option<&'a Ignore>);
 
 impl<'a> Iterator for Parents<'a> {
     type Item = &'a Ignore;

--- a/ignore/src/lib.rs
+++ b/ignore/src/lib.rs
@@ -44,6 +44,7 @@ for result in WalkBuilder::new("./").hidden(false).build() {
 See the documentation for `WalkBuilder` for many other options.
 */
 
+extern crate crossbeam;
 extern crate globset;
 #[macro_use]
 extern crate lazy_static;
@@ -61,7 +62,7 @@ use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 
-pub use walk::{DirEntry, Walk, WalkBuilder};
+pub use walk::{DirEntry, Walk, WalkBuilder, WalkParallel, WalkState};
 
 mod dir;
 pub mod gitignore;
@@ -80,6 +81,12 @@ pub enum Error {
     WithLineNumber { line: u64, err: Box<Error> },
     /// An error associated with a particular file path.
     WithPath { path: PathBuf, err: Box<Error> },
+    /// An error associated with a particular directory depth when recursively
+    /// walking a directory.
+    WithDepth { depth: usize, err: Box<Error> },
+    /// An error that occurs when a file loop is detected when traversing
+    /// symbolic links.
+    Loop { ancestor: PathBuf, child: PathBuf },
     /// An error that occurs when doing I/O, such as reading an ignore file.
     Io(io::Error),
     /// An error that occurs when trying to parse a glob.
@@ -101,6 +108,7 @@ impl Error {
             Error::Partial(_) => true,
             Error::WithLineNumber { ref err, .. } => err.is_partial(),
             Error::WithPath { ref err, .. } => err.is_partial(),
+            Error::WithDepth { ref err, .. } => err.is_partial(),
             _ => false,
         }
     }
@@ -111,6 +119,8 @@ impl Error {
             Error::Partial(ref errs) => errs.len() == 1 && errs[0].is_io(),
             Error::WithLineNumber { ref err, .. } => err.is_io(),
             Error::WithPath { ref err, .. } => err.is_io(),
+            Error::WithDepth { ref err, .. } => err.is_io(),
+            Error::Loop { .. } => false,
             Error::Io(_) => true,
             Error::Glob(_) => false,
             Error::UnrecognizedFileType(_) => false,
@@ -118,10 +128,28 @@ impl Error {
         }
     }
 
+    /// Returns a depth associated with recursively walking a directory (if
+    /// this error was generated from a recursive directory iterator).
+    pub fn depth(&self) -> Option<usize> {
+        match *self {
+            Error::WithPath { ref err, .. } => err.depth(),
+            Error::WithDepth { depth, .. } => Some(depth),
+            _ => None,
+        }
+    }
+
     /// Turn an error into a tagged error with the given file path.
     fn with_path<P: AsRef<Path>>(self, path: P) -> Error {
         Error::WithPath {
             path: path.as_ref().to_path_buf(),
+            err: Box::new(self),
+        }
+    }
+
+    /// Turn an error into a tagged error with the given depth.
+    fn with_depth(self, depth: usize) -> Error {
+        Error::WithDepth {
+            depth: depth,
             err: Box::new(self),
         }
     }
@@ -146,6 +174,8 @@ impl error::Error for Error {
             Error::Partial(_) => "partial error",
             Error::WithLineNumber { ref err, .. } => err.description(),
             Error::WithPath { ref err, .. } => err.description(),
+            Error::WithDepth { ref err, .. } => err.description(),
+            Error::Loop { .. } => "file system loop found",
             Error::Io(ref err) => err.description(),
             Error::Glob(ref msg) => msg,
             Error::UnrecognizedFileType(_) => "unrecognized file type",
@@ -168,6 +198,12 @@ impl fmt::Display for Error {
             Error::WithPath { ref path, ref err } => {
                 write!(f, "{}: {}", path.display(), err)
             }
+            Error::WithDepth { ref err, .. } => err.fmt(f),
+            Error::Loop { ref ancestor, ref child } => {
+                write!(f, "File system loop found: \
+                           {} points to an ancestor {}",
+                          child.display(), ancestor.display())
+            }
             Error::Io(ref err) => err.fmt(f),
             Error::Glob(ref msg) => write!(f, "{}", msg),
             Error::UnrecognizedFileType(ref ty) => {
@@ -184,6 +220,30 @@ impl fmt::Display for Error {
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
         Error::Io(err)
+    }
+}
+
+impl From<walkdir::Error> for Error {
+    fn from(err: walkdir::Error) -> Error {
+        let depth = err.depth();
+        if let (Some(anc), Some(child)) = (err.loop_ancestor(), err.path()) {
+            return Error::WithDepth {
+                depth: depth,
+                err: Box::new(Error::Loop {
+                    ancestor: anc.to_path_buf(),
+                    child: child.to_path_buf(),
+                }),
+            };
+        }
+        let path = err.path().map(|p| p.to_path_buf());
+        let mut ig_err = Error::Io(io::Error::from(err));
+        if let Some(path) = path {
+            ig_err = Error::WithPath {
+                path: path,
+                err: Box::new(ig_err),
+            };
+        }
+        ig_err
     }
 }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -158,6 +158,7 @@ impl<W: Terminal + Send> Printer<W> {
     }
 
     /// Flushes the underlying writer and returns it.
+    #[allow(dead_code)]
     pub fn into_inner(mut self) -> W {
         let _ = self.wtr.flush();
         self.wtr

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,0 +1,253 @@
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+use grep::Grep;
+use ignore::DirEntry;
+use memmap::{Mmap, Protection};
+use term::Terminal;
+
+use pathutil::strip_prefix;
+use printer::Printer;
+use search_buffer::BufferSearcher;
+use search_stream::{InputBuffer, Searcher};
+
+use Result;
+
+pub enum Work {
+    Stdin,
+    DirEntry(DirEntry),
+}
+
+pub struct WorkerBuilder {
+    grep: Grep,
+    opts: Options,
+}
+
+#[derive(Clone, Debug)]
+struct Options {
+    mmap: bool,
+    after_context: usize,
+    before_context: usize,
+    count: bool,
+    files_with_matches: bool,
+    eol: u8,
+    invert_match: bool,
+    line_number: bool,
+    quiet: bool,
+    text: bool,
+}
+
+impl Default for Options {
+    fn default() -> Options {
+        Options {
+            mmap: false,
+            after_context: 0,
+            before_context: 0,
+            count: false,
+            files_with_matches: false,
+            eol: b'\n',
+            invert_match: false,
+            line_number: false,
+            quiet: false,
+            text: false,
+        }
+    }
+}
+
+impl WorkerBuilder {
+    /// Create a new builder for a worker.
+    ///
+    /// A reusable input buffer and a grep matcher are required, but there
+    /// are numerous additional options that can be configured on this builder.
+    pub fn new(grep: Grep) -> WorkerBuilder {
+        WorkerBuilder {
+            grep: grep,
+            opts: Options::default(),
+        }
+    }
+
+    /// Create the worker from this builder.
+    pub fn build(self) -> Worker {
+        let mut inpbuf = InputBuffer::new();
+        inpbuf.eol(self.opts.eol);
+        Worker {
+            grep: self.grep,
+            inpbuf: inpbuf,
+            opts: self.opts,
+        }
+    }
+
+    /// The number of contextual lines to show after each match. The default
+    /// is zero.
+    pub fn after_context(mut self, count: usize) -> Self {
+        self.opts.after_context = count;
+        self
+    }
+
+    /// The number of contextual lines to show before each match. The default
+    /// is zero.
+    pub fn before_context(mut self, count: usize) -> Self {
+        self.opts.before_context = count;
+        self
+    }
+
+    /// If enabled, searching will print a count instead of each match.
+    ///
+    /// Disabled by default.
+    pub fn count(mut self, yes: bool) -> Self {
+        self.opts.count = yes;
+        self
+    }
+
+    /// If enabled, searching will print the path instead of each match.
+    ///
+    /// Disabled by default.
+    pub fn files_with_matches(mut self, yes: bool) -> Self {
+        self.opts.files_with_matches = yes;
+        self
+    }
+
+    /// Set the end-of-line byte used by this searcher.
+    pub fn eol(mut self, eol: u8) -> Self {
+        self.opts.eol = eol;
+        self
+    }
+
+    /// If enabled, matching is inverted so that lines that *don't* match the
+    /// given pattern are treated as matches.
+    pub fn invert_match(mut self, yes: bool) -> Self {
+        self.opts.invert_match = yes;
+        self
+    }
+
+    /// If enabled, compute line numbers and prefix each line of output with
+    /// them.
+    pub fn line_number(mut self, yes: bool) -> Self {
+        self.opts.line_number = yes;
+        self
+    }
+
+    /// If enabled, try to use memory maps for searching if possible.
+    pub fn mmap(mut self, yes: bool) -> Self {
+        self.opts.mmap = yes;
+        self
+    }
+
+    /// If enabled, don't show any output and quit searching after the first
+    /// match is found.
+    pub fn quiet(mut self, yes: bool) -> Self {
+        self.opts.quiet = yes;
+        self
+    }
+
+    /// If enabled, search binary files as if they were text.
+    pub fn text(mut self, yes: bool) -> Self {
+        self.opts.text = yes;
+        self
+    }
+}
+
+/// Worker is responsible for executing searches on file paths, while choosing
+/// streaming search or memory map search as appropriate.
+pub struct Worker {
+    inpbuf: InputBuffer,
+    grep: Grep,
+    opts: Options,
+}
+
+impl Worker {
+    /// Execute the worker with the given printer and work item.
+    ///
+    /// A work item can either be stdin or a file path.
+    pub fn run<W: Terminal + Send>(
+        &mut self,
+        printer: &mut Printer<W>,
+        work: Work,
+    ) -> u64 {
+        let result = match work {
+            Work::Stdin => {
+                let stdin = io::stdin();
+                let stdin = stdin.lock();
+                self.search(printer, &Path::new("<stdin>"), stdin)
+            }
+            Work::DirEntry(dent) => {
+                let mut path = dent.path();
+                let file = match File::open(path) {
+                    Ok(file) => file,
+                    Err(err) => {
+                        eprintln!("{}: {}", path.display(), err);
+                        return 0;
+                    }
+                };
+                if let Some(p) = strip_prefix("./", path) {
+                    path = p;
+                }
+                if self.opts.mmap {
+                    self.search_mmap(printer, path, &file)
+                } else {
+                    self.search(printer, path, file)
+                }
+            }
+        };
+        match result {
+            Ok(count) => {
+                count
+            }
+            Err(err) => {
+                eprintln!("{}", err);
+                0
+            }
+        }
+    }
+
+    fn search<R: io::Read, W: Terminal + Send>(
+        &mut self,
+        printer: &mut Printer<W>,
+        path: &Path,
+        rdr: R,
+    ) -> Result<u64> {
+        let searcher = Searcher::new(
+            &mut self.inpbuf, printer, &self.grep, path, rdr);
+        searcher
+            .after_context(self.opts.after_context)
+            .before_context(self.opts.before_context)
+            .count(self.opts.count)
+            .files_with_matches(self.opts.files_with_matches)
+            .eol(self.opts.eol)
+            .line_number(self.opts.line_number)
+            .invert_match(self.opts.invert_match)
+            .quiet(self.opts.quiet)
+            .text(self.opts.text)
+            .run()
+            .map_err(From::from)
+    }
+
+    fn search_mmap<W: Terminal + Send>(
+        &mut self,
+        printer: &mut Printer<W>,
+        path: &Path,
+        file: &File,
+    ) -> Result<u64> {
+        if try!(file.metadata()).len() == 0 {
+            // Opening a memory map with an empty file results in an error.
+            // However, this may not actually be an empty file! For example,
+            // /proc/cpuinfo reports itself as an empty file, but it can
+            // produce data when it's read from. Therefore, we fall back to
+            // regular read calls.
+            return self.search(printer, path, file);
+        }
+        let mmap = try!(Mmap::open(file, Protection::Read));
+        let searcher = BufferSearcher::new(
+            printer, &self.grep, path, unsafe { mmap.as_slice() });
+        Ok(searcher
+            .count(self.opts.count)
+            .files_with_matches(self.opts.files_with_matches)
+            .eol(self.opts.eol)
+            .line_number(self.opts.line_number)
+            .invert_match(self.opts.invert_match)
+            .quiet(self.opts.quiet)
+            .text(self.opts.text)
+            .run())
+    }
+}


### PR DESCRIPTION
This adds a new walk type in the `ignore` crate, `WalkParallel`, which
provides a way for recursively iterating over a set of paths in parallel
while respecting various ignore rules.

The API is a bit strange, as a closure producing a closure isn't
something one often sees, but it does seem to work well.

This also allowed us to simplify much of the worker logic in ripgrep
proper, where MultiWorker is now gone.