### PR TITLE
Avoid heap allocations in lazy_static when using nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ kernel32-sys = "0.2"
 winapi = "0.2"
 
 [features]
+nightly = ["lazy_static/nightly"]
 avx-accel = ["bytecount/avx-accel"]
 simd-accel = ["bytecount/simd-accel", "regex/simd-accel"]
 

--- a/compile
+++ b/compile
@@ -2,4 +2,4 @@
 
 # export RUSTFLAGS="-C target-feature=+ssse3"
 export RUSTFLAGS="-C target-cpu=native"
-cargo build --release --features 'simd-accel avx-accel'
+cargo build --release --features 'nightly simd-accel avx-accel'


### PR DESCRIPTION
On nightly, the lazy_static crate is able to use `const fn` to avoid a heap allocation for each `lazy_static!`.