### PR TITLE
Added elixir to types

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -102,6 +102,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("dart", &["*.dart"]),
     ("d", &["*.d"]),
     ("elisp", &["*.el"]),
+    ("elixir", &["*.ex", "*.exs"]),
     ("erlang", &["*.erl", "*.hrl"]),
     ("fish", &["*.fish"]),
     ("fortran", &[


### PR DESCRIPTION
While using ripgrep, I noticed that elixir wasn't one of the types included, so I added it into the types.rs.