### PR TITLE
Limit line lengths

### DIFF
--- a/src/atty.rs
+++ b/src/atty.rs
@@ -48,18 +48,24 @@ pub fn on_stdout() -> bool {
 
 /// Returns tty width
 #[cfg(unix)]
-pub fn width() -> usize {
+pub fn width() -> Option<usize> {
     use libc;
 
     let wsz = libc::winsize {
         ws_row: 0, ws_col: 0,
         ws_xpixel: 0, ws_ypixel: 0,
     };
-    let w: u16;
+    let rc: usize;
 
-    unsafe { libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &wsz); }
-    w = wsz.ws_col;
-    return w as usize;
+    unsafe {
+        rc = libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &wsz) as usize;
+    }
+    if rc == 0 {
+        let w = wsz.ws_col;
+        return Some(w as usize);
+    } else {
+        return None;
+    }
 }
 
 /// Returns true if there is a tty on stdin.

--- a/src/atty.rs
+++ b/src/atty.rs
@@ -46,6 +46,22 @@ pub fn on_stdout() -> bool {
     0 < unsafe { libc::isatty(libc::STDOUT_FILENO) }
 }
 
+/// Returns tty width
+#[cfg(unix)]
+pub fn width() -> usize {
+    use libc;
+
+    let wsz = libc::winsize {
+        ws_row: 0, ws_col: 0,
+        ws_xpixel: 0, ws_ypixel: 0,
+    };
+    let w: u16;
+
+    unsafe { libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &wsz); }
+    w = wsz.ws_col;
+    return w as usize;
+}
+
 /// Returns true if there is a tty on stdin.
 #[cfg(windows)]
 pub fn on_stdin() -> bool {


### PR DESCRIPTION
Possible fix for https://github.com/BurntSushi/ripgrep/issues/129
Python to generate a test:
```
with open("long_line_test", "w") as f:
    for n in range(1, 10):
        for i in range(1, 100):
            i_z = str(i).zfill(5)
            f.write("_{}:{}_,".format(n, i_z))
        f.write("\n")
```