### PR TITLE
Less and Sass types

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -148,6 +148,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("rst", &["*.rst"]),
     ("ruby", &["*.rb"]),
     ("rust", &["*.rs"]),
+    ("sass", &["*.scss"]),
     ("scala", &["*.scala"]),
     ("sh", &["*.bash", "*.csh", "*.ksh", "*.sh", "*.tcsh"]),
     ("spark", &["*.spark"]),

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -123,6 +123,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ]),
     ("json", &["*.json"]),
     ("jsonl", &["*.jsonl"]),
+    ("less", &["*.less"]),
     ("lisp", &["*.el", "*.jl", "*.lisp", "*.lsp", "*.sc", "*.scm"]),
     ("lua", &["*.lua"]),
     ("m4", &["*.ac", "*.m4"]),


### PR DESCRIPTION
Just noticed that Less and Sass are not supported by default. This PR adds types for both.