### PR TITLE
Re-add zsh types

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -170,6 +170,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("xml", &["*.xml"]),
     ("yacc", &["*.y"]),
     ("yaml", &["*.yaml", "*.yml"]),
+    ("zsh", &["zshenv", ".zshenv", "zprofile", ".zprofile", "zshrc", ".zshrc", "zlogin", ".zlogin", "zlogout", ".zlogout", "*.zsh"]),
 ];
 
 /// Glob represents a single glob in a set of file type definitions.


### PR DESCRIPTION
Seems like #197 got lost in #202 

I added the missing `.zlogout`, and also search the ones without a leading `.` (which should be in `/etc`). Is there syntax for making a char optional (like `?` in regex)?
The entries are sorted in the order they're read by zsh, with the addition of a `*.zsh` at the end