### PR TITLE
Resolve symbolic links for all input files

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -344,6 +344,16 @@ impl<'a> ArgMatches<'a> {
         if paths.is_empty() {
             paths.push(self.default_path());
         }
+
+        for path in &mut paths {
+            use std::fs::canonicalize;
+            use std::mem::replace;
+
+            if let Ok(canon) = canonicalize(&path) {
+                replace(path, canon);
+            }
+        }
+
         paths
     }
 


### PR DESCRIPTION
Closes #256.

Question: is this the right place to do this? This gives `paths` an IO/filesystem dependency that it didn't already have, which makes this function impure when you might expect it to return the same thing each time.