### PR TITLE
Minor code and doc fixes

### DIFF
--- a/doc/rg.1
+++ b/doc/rg.1
@@ -364,7 +364,7 @@ single thread.
 .TP
 .B \-j, \-\-threads \f[I]ARG\f[]
 The number of threads to use.
-0 means use the number of logical CPUs (capped at 6).
+0 means use the number of logical CPUs (capped at 12).
 [default: 0]
 .RS
 .RE

--- a/doc/rg.1.md
+++ b/doc/rg.1.md
@@ -245,7 +245,7 @@ Project home page: https://github.com/BurntSushi/ripgrep
 
 -j, --threads *ARG*
 : The number of threads to use. 0 means use the number of logical CPUs
-  (capped at 6). [default: 0]
+  (capped at 12). [default: 0]
 
 --version
 : Show the version number of ripgrep and exit.

--- a/src/search_stream.rs
+++ b/src/search_stream.rs
@@ -307,7 +307,7 @@ impl<'a, R: io::Read, W: WriteColor> Searcher<'a, R, W> {
             } else if self.opts.files_with_matches {
                 self.printer.path(self.path);
             }
-        } else if self.match_count == 0 && self.opts.files_without_matches {
+        } else if self.opts.files_without_matches {
             self.printer.path(self.path);
         }
         Ok(self.match_count)


### PR DESCRIPTION
The first commit is an oversight I spotted immediately after having #239 accepted.

The second one is just a minor divergence between the documentation and the actual code ([`Args::threads()`](/BurntSushi/ripgrep/blob/851799f42be4409d4e2498960725e11d0514a0e7/src/args.rs#L667)). I'm assuming the code has the actual intended cap, as it's not too uncommon to find desktop machines with 12+ logical cores, it's still low enough not to accidentally overwhelm a modest (albeit modern) CPU, and it seems to be the more recent commit.