### PR TITLE
File types: add Crystal and Kotlin + expand Perl + Ruby

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -166,7 +166,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("r", &["*.R", "*.r", "*.Rmd", "*.Rnw"]),
     ("rdoc", &["*.rdoc"]),
     ("rst", &["*.rst"]),
-    ("ruby", &["*.rb"]),
+    ("ruby", &["Gemfile", "*.gemspec", ".irbrc", "Rakefile", "*.rb"]),
     ("rust", &["*.rs"]),
     ("sass", &["*.scss"]),
     ("scala", &["*.scala"]),

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -141,6 +141,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ]),
     ("json", &["*.json"]),
     ("jsonl", &["*.jsonl"]),
+    ("kotlin", &["*.kt", "*.kts"]),
     ("less", &["*.less"]),
     ("lisp", &["*.el", "*.jl", "*.lisp", "*.lsp", "*.sc", "*.scm"]),
     ("lua", &["*.lua"]),

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -156,7 +156,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("objcpp", &["*.h", "*.mm"]),
     ("ocaml", &["*.ml", "*.mli", "*.mll", "*.mly"]),
     ("org", &["*.org"]),
-    ("perl", &["*.perl", "*.pl", "*.PL", "*.plh", "*.plx", "*.pm"]),
+    ("perl", &["*.perl", "*.pl", "*.PL", "*.plh", "*.plx", "*.pm", "*.t"]),
     ("pdf", &["*.pdf"]),
     ("php", &["*.php", "*.php3", "*.php4", "*.php5", "*.phtml"]),
     ("pod", &["*.pod"]),

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -112,6 +112,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
         "*.C", "*.cc", "*.cpp", "*.cxx",
         "*.h", "*.H", "*.hh", "*.hpp",
     ]),
+    ("crystal", &["Projectfile", "*.cr"]),
     ("cs", &["*.cs"]),
     ("csharp", &["*.cs"]),
     ("css", &["*.css"]),


### PR DESCRIPTION
This PR adds support for two new file types:

* [Crystal](https://github.com/crystal-lang/crystal)
* [Kotlin](https://github.com/JetBrains/kotlin)

And adds a few common filename patterns to two existing file types:

* Perl
* Ruby