### PR TITLE
Support colorized output to standard error

### DIFF
--- a/termcolor/src/lib.rs
+++ b/termcolor/src/lib.rs
@@ -21,10 +21,10 @@ analogous to `std::io::Stderr` and `std::io::StderrLock`.
 
 `Buffer` is an in memory buffer that supports colored text. In a parallel
 program, each thread might write to its own buffer. A buffer can be printed to
-stdout or stderr using a `BufferWriter`. The advantage of this design is that
-each thread can work in parallel on a buffer without having to synchronize
-access to global resources such as the Windows console. Moreover, this design
-also prevents interleaving of buffer output.
+stdout or stderr using a `StandardStreamWriter`. The advantage of this design
+is that each thread can work in parallel on a buffer without having to
+synchronize access to global resources such as the Windows console. Moreover,
+this design also prevents interleaving of buffer output.
 
 `Ansi` and `NoColor` both satisfy `WriteColor` for arbitrary implementors of
 `io::Write`. These types are useful when you know exactly what you need. An
@@ -47,26 +47,29 @@ try!(writeln!(&mut stdout, "green text!"));
 # Ok(()) }
 ```
 
-# Example: using `BufferWriter`
+# Example: using `StandardStreamWriter`
 
-A `BufferWriter` can create buffers and write buffers to stdout or stderr. It
-does *not* implement `io::Write` or `WriteColor` itself. Instead, `Buffer`
-implements `io::Write` and `io::WriteColor`.
+A `StandardStreamWriter` can create buffers and write buffers to stdout or
+stderr. It does *not* implement `io::Write` or `WriteColor` itself. Instead,
+`Buffer` implements `io::Write` and `io::WriteColor`.
 
 This example shows how to print some green text to stdout.
 
 ```rust,no_run
 # fn test() -> Result<(), Box<::std::error::Error>> {
-use std::io::Write;
-use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
+use std::io::{self, Write};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStreamWriter, WriteColor};
 
-let mut bufwtr = BufferWriter::stdout(ColorChoice::Always);
-let mut buffer = bufwtr.buffer();
+let mut sswtr = StandardStreamWriter::<io::Stdout>::create(ColorChoice::Always);
+let mut buffer = sswtr.buffer();
 try!(buffer.set_color(ColorSpec::new().set_fg(Some(Color::Green))));
 try!(writeln!(&mut buffer, "green text!"));
-try!(bufwtr.print(&buffer));
+try!(sswtr.print(&buffer));
 # Ok(()) }
 ```
+
+The type `BufferWriter` is a compatibility alias for
+`StandardStreamWriter<io::Stdout>`.
 */
 
 #![deny(missing_docs)]

--- a/termcolor/src/lib.rs
+++ b/termcolor/src/lib.rs
@@ -16,11 +16,12 @@ The `WriteColor` trait extends the `io::Write` trait with methods for setting
 colors or resetting them.
 
 `Stdout` and `StdoutLock` both satisfy `WriteColor` and are analogous to
-`std::io::Stdout` and `std::io::StdoutLock`.
+`std::io::Stdout` and `std::io::StdoutLock`. `Stderr` and `StderrLock` are
+analogous to `std::io::Stderr` and `std::io::StderrLock`.
 
 `Buffer` is an in memory buffer that supports colored text. In a parallel
-program, each thread might write to its own buffer. A buffer can be printed
-to stdout using a `BufferWriter`. The advantage of this design is that
+program, each thread might write to its own buffer. A buffer can be printed to
+stdout or stderr using a `BufferWriter`. The advantage of this design is that
 each thread can work in parallel on a buffer without having to synchronize
 access to global resources such as the Windows console. Moreover, this design
 also prevents interleaving of buffer output.
@@ -48,9 +49,9 @@ try!(writeln!(&mut stdout, "green text!"));
 
 # Example: using `BufferWriter`
 
-A `BufferWriter` can create buffers and write buffers to stdout. It does *not*
-implement `io::Write` or `WriteColor` itself. Instead, `Buffer` implements
-`io::Write` and `io::WriteColor`.
+A `BufferWriter` can create buffers and write buffers to stdout or stderr. It
+does *not* implement `io::Write` or `WriteColor` itself. Instead, `Buffer`
+implements `io::Write` and `io::WriteColor`.
 
 This example shows how to print some green text to stdout.
 
@@ -184,21 +185,267 @@ impl ColorChoice {
     }
 }
 
-/// Satisfies `io::Write` and `WriteColor`, and supports optional coloring
-/// to stdout.
-pub struct Stdout {
-    wtr: LossyStdout<WriterInner<'static, io::Stdout>>,
+
+/// We want to provide generic support for colorized output to both the
+/// standard output and the standard error streams. In Rust, however,
+/// io::Stdout and io::Stderr are distinct types. This enum helps us deal with
+/// that. You might like to to use a trait associated type to express how to
+/// get a locked stream from an unlocked stream, but trait associated types
+/// cannot currently have a lifetime (cf.
+/// https://users.rust-lang.org/t/how-to-specify-lifetime-for-associated-type/5736).
+/// So we need to use this hacky enum.
+pub enum StandardStreamLockObject<'a> {
+    /// This is a stdout lock object.
+    Stdout(io::StdoutLock<'a>),
+
+    /// This is a stderr Lock object.
+    Stderr(io::StderrLock<'a>),
 }
 
-/// `StdoutLock` is a locked reference to a `Stdout`.
+
+/// We implement this trait for `io::Stdout` and `io::Stderr` so that we can
+/// use a generic structure to wrap them. We use long-winded function names
+/// since no one besides us is going to want to use these functions.
+pub trait LockableStandardStream: Write {
+    /// Create an instance of the stream.
+    fn create_standard_stream() -> Self;
+
+    /// Locks the stream.
+    fn lock_this_standard_stream<'a>(&'a self) -> StandardStreamLockObject<'a>;
+}
+
+impl LockableStandardStream for io::Stdout {
+    fn create_standard_stream() -> Self {
+        io::stdout()
+    }
+
+    fn lock_this_standard_stream<'a>(&'a self) -> StandardStreamLockObject<'a> {
+        StandardStreamLockObject::Stdout(self.lock())
+    }
+}
+
+impl LockableStandardStream for io::Stderr {
+    fn create_standard_stream() -> Self {
+        io::stderr()
+    }
+
+    fn lock_this_standard_stream<'a>(&'a self) -> StandardStreamLockObject<'a> {
+        StandardStreamLockObject::Stderr(self.lock())
+    }
+}
+
+
+/// A `LockedStandardStream` trait represents a type that is a locked version
+/// of a `LockableStandardStream`. The parent type does *not* have an
+/// associated lifetime, so we can make it a trait associated type here. We
+/// implement this trait for `io::StdoutLock` and `io::StderrLock`.
+pub trait LockedStandardStream<'a>: Write {
+    /// The LockableStandardStream that produces this object.
+    type Parent: LockableStandardStream;
+
+    /// This method is second part of the hack to abstract over the
+    /// `StdoutLock` and `StderrLock` types. It allows us to create one of
+    /// those from a `StandardStreamLockObject`.
+    fn make_from_lock_object(lock_obj: StandardStreamLockObject<'a>) -> Self;
+}
+
+impl<'a> LockedStandardStream<'a> for io::StdoutLock<'a> {
+    type Parent = io::Stdout;
+
+    fn make_from_lock_object(lock_obj: StandardStreamLockObject<'a>) -> Self {
+        match lock_obj {
+            StandardStreamLockObject::Stdout(x) => x,
+            _ => panic!("internal consistency failure for StdoutLock"),
+        }
+    }
+}
+
+impl<'a> LockedStandardStream<'a> for io::StderrLock<'a> {
+    type Parent = io::Stderr;
+
+    fn make_from_lock_object(lock_obj: StandardStreamLockObject<'a>) -> Self {
+        match lock_obj {
+            StandardStreamLockObject::Stderr(x) => x,
+            _ => panic!("internal consistency failure for StderrLock"),
+        }
+    }
+}
+
+
+/// A `StandardStream` is either standard output (stdout) or standard error
+/// (stderr). It satisfies `io::Write` and `WriteColor`, and supports optional
+/// coloring.
+pub struct StandardStream<T: LockableStandardStream> {
+    wtr: LossyStdout<WriterInner<'static, T>>,
+}
+
+impl<T: LockableStandardStream> StandardStream<T> {
+    /// Create a new `StandardStream<T>` with the given color preferences.
+    ///
+    /// The specific color/style settings can be configured when writing via
+    /// the `WriteColor` trait.
+    #[cfg(not(windows))]
+    pub fn new(choice: ColorChoice) -> StandardStream<T> {
+        let wtr =
+            if choice.should_attempt_color() {
+                WriterInner::Ansi(Ansi(T::create_standard_stream()))
+            } else {
+                WriterInner::NoColor(NoColor(T::create_standard_stream()))
+            };
+        StandardStream { wtr: LossyStdout::new(wtr) }
+    }
+
+    /// Create a new `StandardStream<T>` with the given color preferences.
+    ///
+    /// If coloring is desired and a Windows console could not be found, then
+    /// ANSI escape sequences are used instead.
+    ///
+    /// The specific color/style settings can be configured when writing via
+    /// the `WriteColor` trait.
+    #[cfg(windows)]
+    pub fn new(choice: ColorChoice) -> StandardStream<T> {
+        let con = wincolor::Console::stdout();
+        let is_win_console = con.is_ok();
+        let wtr =
+            if choice.should_attempt_color() {
+                if choice.should_ansi() {
+                    WriterInner::Ansi(Ansi(T::create_standard_stream()))
+                } else if let Ok(console) = con {
+                    WriterInner::Windows {
+                        wtr: T::create_standard_stream(),
+                        console: Mutex::new(console),
+                    }
+                } else {
+                    WriterInner::Ansi(Ansi(T::create_standard_stream()))
+                }
+            } else {
+                WriterInner::NoColor(NoColor(T::create_standard_stream()))
+            };
+        StandardStream { wtr: LossyStdout::new(wtr).is_console(is_win_console) }
+    }
+}
+
+impl<T: LockableStandardStream> io::Write for StandardStream<T> {
+    fn write(&mut self, b: &[u8]) -> io::Result<usize> { self.wtr.write(b) }
+    fn flush(&mut self) -> io::Result<()> { self.wtr.flush() }
+}
+
+impl<T: LockableStandardStream> WriteColor for StandardStream<T> {
+    fn supports_color(&self) -> bool { self.wtr.supports_color() }
+    fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
+        self.wtr.set_color(spec)
+    }
+    fn reset(&mut self) -> io::Result<()> { self.wtr.reset() }
+}
+
+
+/// A `StandardStreamLock` is a locked reference to a `StandardStream`.
 ///
 /// This implements the `io::Write` and `WriteColor` traits, and is constructed
 /// via the `Write::lock` method.
 ///
-/// The lifetime `'a` refers to the lifetime of the corresponding `Stdout`.
-pub struct StdoutLock<'a> {
-    wtr: LossyStdout<WriterInner<'a, io::StdoutLock<'a>>>,
+/// The lifetime `'a` refers to the lifetime of the corresponding `LockedStandardStream`.
+pub struct StandardStreamLock<'a, T: LockedStandardStream<'a>> {
+    wtr: LossyStdout<WriterInner<'a, T>>,
 }
+
+impl<'a, T: 'a + LockedStandardStream<'a>> StandardStreamLock<'a, T> {
+    #[cfg(not(windows))]
+    fn from_parent(parent: &'a StandardStream<T::Parent>) -> StandardStreamLock<'a, T> {
+        let locked = match *parent.wtr.get_ref() {
+            WriterInner::Unreachable(_) => unreachable!(),
+            WriterInner::NoColor(ref w) => {
+                let s = T::make_from_lock_object(w.0.lock_this_standard_stream());
+                WriterInner::NoColor(NoColor(s))
+            }
+            WriterInner::Ansi(ref w) => {
+                let s = T::make_from_lock_object(w.0.lock_this_standard_stream());
+                WriterInner::Ansi(Ansi(s))
+            }
+        };
+        StandardStreamLock { wtr: parent.wtr.wrap(locked) }
+    }
+
+    #[cfg(windows)]
+    fn from_parent(parent: &'a StandardStream<T::Parent>) -> StandardStreamLock<'a, T> {
+        let locked = match *parent.wtr.get_ref() {
+            WriterInner::Unreachable(_) => unreachable!(),
+            WriterInner::NoColor(ref w) => {
+                let s = T::make_from_lock_object(w.0.lock_this_standard_stream());
+                WriterInner::NoColor(NoColor(s))
+            }
+            WriterInner::Ansi(ref w) => {
+                let s = T::make_from_lock_object(w.0.lock_this_standard_stream());
+                WriterInner::Ansi(Ansi(s))
+            }
+            #[cfg(windows)]
+            WriterInner::Windows { ref wtr, ref console } => {
+                WriterInner::WindowsLocked {
+                    wtr: wtr.lock(),
+                    console: console.lock().unwrap(),
+                }
+            }
+            #[cfg(windows)]
+            WriterInner::WindowsLocked{..} => {
+                panic!("cannot call StandardStream.lock while a StandardStreamLock is alive");
+            }
+        };
+        StandardStreamLock { wtr: stdout.wtr.wrap(locked) }
+    }
+}
+
+impl<'a, T: 'a + LockedStandardStream<'a>> io::Write for StandardStreamLock<'a, T> {
+    fn write(&mut self, b: &[u8]) -> io::Result<usize> { self.wtr.write(b) }
+    fn flush(&mut self) -> io::Result<()> { self.wtr.flush() }
+}
+
+impl<'a, T: 'a + LockedStandardStream<'a>> WriteColor for StandardStreamLock<'a, T> {
+    fn supports_color(&self) -> bool { self.wtr.supports_color() }
+    fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
+        self.wtr.set_color(spec)
+    }
+    fn reset(&mut self) -> io::Result<()> { self.wtr.reset() }
+}
+
+
+/// This alias is provided for compactness and backwards-compatibility.
+pub type Stdout = StandardStream<io::Stdout>;
+
+impl Stdout {
+    /// Lock the underlying writer.
+    ///
+    /// The lock guard returned also satisfies `io::Write` and
+    /// `WriteColor`.
+    ///
+    /// This method is **not reentrant**. It may panic if `lock` is called
+    /// while a `StdoutLock` is still alive.
+    pub fn lock(&self) -> StdoutLock {
+        StdoutLock::from_parent(self)
+    }
+}
+
+/// This alias is provided for compactness and backwards-compatibility.
+pub type StdoutLock<'a> = StandardStreamLock<'a, io::StdoutLock<'a>>;
+
+/// This alias is provided for compactness.
+pub type Stderr = StandardStream<io::Stderr>;
+
+impl Stderr {
+    /// Lock the underlying writer.
+    ///
+    /// The lock guard returned also satisfies `io::Write` and
+    /// `WriteColor`.
+    ///
+    /// This method is **not reentrant**. It may panic if `lock` is called
+    /// while a `StderrLock` is still alive.
+    pub fn lock(&self) -> StderrLock {
+        StderrLock::from_parent(self)
+    }
+}
+
+/// This alias is provided for compactness.
+pub type StderrLock<'a> = StandardStreamLock<'a, io::StderrLock<'a>>;
+
 
 /// WriterInner is a (limited) generic representation of a writer. It is
 /// limited because W should only ever be stdout/stderr on Windows.
@@ -217,129 +464,6 @@ enum WriterInner<'a, W> {
     WindowsLocked { wtr: W, console: MutexGuard<'a, wincolor::Console> },
 }
 
-impl Stdout {
-    /// Create a new `Stdout` with the given color preferences.
-    ///
-    /// The specific color/style settings can be configured when writing via
-    /// the `WriteColor` trait.
-    #[cfg(not(windows))]
-    pub fn new(choice: ColorChoice) -> Stdout {
-        let wtr =
-            if choice.should_attempt_color() {
-                WriterInner::Ansi(Ansi(io::stdout()))
-            } else {
-                WriterInner::NoColor(NoColor(io::stdout()))
-            };
-        Stdout { wtr: LossyStdout::new(wtr) }
-    }
-
-    /// Create a new `Stdout` with the given color preferences.
-    ///
-    /// If coloring is desired and a Windows console could not be found, then
-    /// ANSI escape sequences are used instead.
-    ///
-    /// The specific color/style settings can be configured when writing via
-    /// the `WriteColor` trait.
-    #[cfg(windows)]
-    pub fn new(choice: ColorChoice) -> Stdout {
-        let con = wincolor::Console::stdout();
-        let is_win_console = con.is_ok();
-        let wtr =
-            if choice.should_attempt_color() {
-                if choice.should_ansi() {
-                    WriterInner::Ansi(Ansi(io::stdout()))
-                } else if let Ok(console) = con {
-                    WriterInner::Windows {
-                        wtr: io::stdout(),
-                        console: Mutex::new(console),
-                    }
-                } else {
-                    WriterInner::Ansi(Ansi(io::stdout()))
-                }
-            } else {
-                WriterInner::NoColor(NoColor(io::stdout()))
-            };
-        Stdout { wtr: LossyStdout::new(wtr).is_console(is_win_console) }
-    }
-
-    /// Lock the underlying writer.
-    ///
-    /// The lock guard returned also satisfies `io::Write` and
-    /// `WriteColor`.
-    ///
-    /// This method is **not reentrant**. It may panic if `lock` is called
-    /// while a `StdoutLock` is still alive.
-    pub fn lock(&self) -> StdoutLock {
-        StdoutLock::from_stdout(self)
-    }
-}
-
-impl<'a> StdoutLock<'a> {
-    #[cfg(not(windows))]
-    fn from_stdout(stdout: &Stdout) -> StdoutLock {
-        let locked = match *stdout.wtr.get_ref() {
-            WriterInner::Unreachable(_) => unreachable!(),
-            WriterInner::NoColor(ref w) => {
-                WriterInner::NoColor(NoColor(w.0.lock()))
-            }
-            WriterInner::Ansi(ref w) => {
-                WriterInner::Ansi(Ansi(w.0.lock()))
-            }
-        };
-        StdoutLock { wtr: stdout.wtr.wrap(locked) }
-    }
-
-    #[cfg(windows)]
-    fn from_stdout(stdout: &Stdout) -> StdoutLock {
-        let locked = match *stdout.wtr.get_ref() {
-            WriterInner::Unreachable(_) => unreachable!(),
-            WriterInner::NoColor(ref w) => {
-                WriterInner::NoColor(NoColor(w.0.lock()))
-            }
-            WriterInner::Ansi(ref w) => {
-                WriterInner::Ansi(Ansi(w.0.lock()))
-            }
-            #[cfg(windows)]
-            WriterInner::Windows { ref wtr, ref console } => {
-                WriterInner::WindowsLocked {
-                    wtr: wtr.lock(),
-                    console: console.lock().unwrap(),
-                }
-            }
-            #[cfg(windows)]
-            WriterInner::WindowsLocked{..} => {
-                panic!("cannot call Stdout.lock while a StdoutLock is alive");
-            }
-        };
-        StdoutLock { wtr: stdout.wtr.wrap(locked) }
-    }
-}
-
-impl io::Write for Stdout {
-    fn write(&mut self, b: &[u8]) -> io::Result<usize> { self.wtr.write(b) }
-    fn flush(&mut self) -> io::Result<()> { self.wtr.flush() }
-}
-
-impl WriteColor for Stdout {
-    fn supports_color(&self) -> bool { self.wtr.supports_color() }
-    fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
-        self.wtr.set_color(spec)
-    }
-    fn reset(&mut self) -> io::Result<()> { self.wtr.reset() }
-}
-
-impl<'a> io::Write for StdoutLock<'a> {
-    fn write(&mut self, b: &[u8]) -> io::Result<usize> { self.wtr.write(b) }
-    fn flush(&mut self) -> io::Result<()> { self.wtr.flush() }
-}
-
-impl<'a> WriteColor for StdoutLock<'a> {
-    fn supports_color(&self) -> bool { self.wtr.supports_color() }
-    fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
-        self.wtr.set_color(spec)
-    }
-    fn reset(&mut self) -> io::Result<()> { self.wtr.reset() }
-}
 
 impl<'a, W: io::Write> io::Write for WriterInner<'a, W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {


### PR DESCRIPTION
This pull request adds support for colorized output to standard error on both Unix and Windows platforms. It preserves compatibility with the existing API at the expense of being a bit verbose in some of its data structure names.

Virtually all of the changes are re-castings of the previous code to be generic over the `io::Stdout` and `io::Stderr` types. This involves the creation of a few new traits that need to be exposed in the API.