### PR TITLE
Enable LTO (Link Time Optimization)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,4 @@ simd-accel = ["bytecount/simd-accel", "regex/simd-accel"]
 
 [profile.release]
 debug = true
+lto = true


### PR DESCRIPTION
With this optimization, the size of stripped ripgrep's binary can reduce from `2137936` to `2117424` bytes on my machine 😃 