### PR TITLE
File Types: Add .eex under Elixir

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -120,7 +120,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("dart", &["*.dart"]),
     ("d", &["*.d"]),
     ("elisp", &["*.el"]),
-    ("elixir", &["*.ex", "*.exs"]),
+    ("elixir", &["*.ex", "*.eex", "*.exs"]),
     ("erlang", &["*.erl", "*.hrl"]),
     ("fish", &["*.fish"]),
     ("fortran", &[


### PR DESCRIPTION
.eex is the default file ending for templates using Elixir's template engine EEx.