### PR TITLE
Look for global git/ignore in ~/.config/git, not ~/git

### DIFF
--- a/ignore/src/gitignore.rs
+++ b/ignore/src/gitignore.rs
@@ -454,7 +454,7 @@ fn gitconfig_contents() -> Option<Vec<u8>> {
 fn excludes_file_default() -> Option<PathBuf> {
     env::var_os("XDG_CONFIG_HOME")
         .and_then(|x| if x.is_empty() { None } else { Some(PathBuf::from(x)) })
-        .or_else(|| env::home_dir())
+        .or_else(|| env::home_dir().map(|p| p.join(".config")))
         .map(|x| x.join("git/ignore"))
 }
 


### PR DESCRIPTION
The documentation says:

> If `$XDG_CONFIG_HOME` is not set or is empty, then
> `$HOME/.config/git/ignore` is used instead.

This is the expected behavior, but the code looked at ~/git/ignore
instead.

This is my first Rust code, so it might be wrong..!