### PR TITLE
add '*.sass' to sass type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -170,7 +170,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("rst", &["*.rst"]),
     ("ruby", &["Gemfile", "*.gemspec", ".irbrc", "Rakefile", "*.rb"]),
     ("rust", &["*.rs"]),
-    ("sass", &["*.scss"]),
+    ("sass", &["*.sass", "*.scss"]),
     ("scala", &["*.scala"]),
     ("sh", &["*.bash", "*.csh", "*.ksh", "*.sh", "*.tcsh"]),
     ("spark", &["*.spark"]),


### PR DESCRIPTION
Kind of self explanatory, for some reason `.sass` itself was missed from the sass type. I guess because `sass` is nowadays slightly less popular than `scss` but still very much in use.