### PR TITLE
Add option --max-columns to truncate long lines

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -165,6 +165,9 @@ fn app<F>(next_line_help: bool, doc: F) -> App<'static, 'static>
              .short("j").value_name("ARG").takes_value(true)
              .validator(validate_number))
         .arg(flag("vimgrep"))
+        .arg(flag("max-columns")
+             .value_name("NUM").takes_value(true)
+             .validator(validate_number))
         .arg(flag("type-add")
              .value_name("TYPE").takes_value(true)
              .multiple(true).number_of_values(1))
@@ -454,6 +457,10 @@ lazy_static! {
              "Show results with every match on its own line, including \
               line numbers and column numbers. With this option, a line with \
               more than one match will be printed more than once.");
+        doc!(h, "max-columns",
+             "Don't print lines wider than NUM lines.",
+             "Don't print lines wider than NUM lines.  Longer lines are \
+              omitted, and only the nubmer of matches in that line is printed.");
 
         doc!(h, "type-add",
              "Add a new glob for a file type.",

--- a/src/args.rs
+++ b/src/args.rs
@@ -55,6 +55,7 @@ pub struct Args {
     line_number: bool,
     line_per_match: bool,
     max_count: Option<u64>,
+    max_columns: Option<usize>,
     maxdepth: Option<usize>,
     mmap: bool,
     no_ignore: bool,
@@ -153,7 +154,8 @@ impl Args {
             .line_per_match(self.line_per_match)
             .null(self.null)
             .path_separator(self.path_separator)
-            .with_filename(self.with_filename);
+            .with_filename(self.with_filename)
+            .max_columns(self.max_columns);
         if let Some(ref rep) = self.replace {
             p = p.replace(rep.clone());
         }
@@ -342,6 +344,7 @@ impl<'a> ArgMatches<'a> {
             line_number: self.line_number(),
             line_per_match: self.is_present("vimgrep"),
             max_count: try!(self.usize_of("max-count")).map(|max| max as u64),
+            max_columns: try!(self.usize_of("max-columns")),
             maxdepth: try!(self.usize_of("maxdepth")),
             mmap: mmap,
             no_ignore: self.no_ignore(),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -46,6 +46,8 @@ pub struct Printer<W> {
     colors: ColorSpecs,
     /// The separator to use for file paths. If empty, this is ignored.
     path_separator: Option<u8>,
+    /// Restrict lines to this many columns.
+    max_columns: Option<usize>
 }
 
 impl<W: WriteColor> Printer<W> {
@@ -65,6 +67,7 @@ impl<W: WriteColor> Printer<W> {
             with_filename: false,
             colors: ColorSpecs::default(),
             path_separator: None,
+            max_columns: None,
         }
     }
 
@@ -141,6 +144,12 @@ impl<W: WriteColor> Printer<W> {
     /// When set, each match is prefixed with the file name that it came from.
     pub fn with_filename(mut self, yes: bool) -> Printer<W> {
         self.with_filename = yes;
+        self
+    }
+
+    /// Configure the max. number of columns used for printing matching lines.
+    pub fn max_columns(mut self, max_columns: Option<usize>) -> Printer<W> {
+        self.max_columns = max_columns;
         self
     }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -3,11 +3,25 @@ use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
 
-use regex::bytes::Regex;
+use regex::bytes::{Regex, Replacer, Captures};
 use termcolor::{Color, ColorSpec, ParseColorError, WriteColor};
 
 use pathutil::strip_prefix;
 use ignore::types::FileTypeDef;
+
+/// CountingReplacer implements the Replacer interface for Regex,
+/// and counts how often replacement is being performed.
+struct CountingReplacer<'r> {
+    replace: &'r [u8],
+    count: &'r mut usize,
+}
+
+impl<'r> Replacer for CountingReplacer<'r> {
+    fn replace_append(&mut self, caps: &Captures, dst: &mut Vec<u8>) {
+        *self.count += 1;
+        caps.expand(self.replace, dst);
+    }
+}
 
 /// Printer encapsulates all output logic for searching.
 ///
@@ -272,31 +286,57 @@ impl<W: WriteColor> Printer<W> {
             self.write(b":");
         }
         if self.replace.is_some() {
-            let line = re.replace_all(
-                &buf[start..end], &**self.replace.as_ref().unwrap());
+            let mut count = 0;
+            let line = {
+                let replacer = CountingReplacer { count: &mut count, replace : &**self.replace.as_ref().unwrap() };
+                re.replace_all(&buf[start..end], replacer)
+            };
+            if let Some(max_columns) = self.max_columns {
+                if line.len() > max_columns {
+                    let _ = self.wtr.set_color(self.colors.line());
+                    self.write(format!(" [Omitted long line with {} replacements]", count).as_bytes());
+                    let _ = self.wtr.reset();
+                    self.write_eol();
+                    return;
+                }
+            }
             self.write(&line);
+            if line.last() != Some(&self.eol) {
+                self.write_eol();
+            }
         } else {
             self.write_matched_line(re, &buf[start..end]);
-        }
-        if buf[start..end].last() != Some(&self.eol) {
-            self.write_eol();
+            // write_matched_line guarantees to write a newline.
         }
     }
 
     fn write_matched_line(&mut self, re: &Regex, buf: &[u8]) {
+        if let Some(max_columns) = self.max_columns {
+            if buf.len() > max_columns {
+                let count = re.find_iter(buf).count();
+                let _ = self.wtr.set_color(self.colors.line());
+                self.write(format!(" [Omitted long line with {} matches]", count).as_bytes());
+                let _ = self.wtr.reset();
+                self.write_eol();
+                return;
+            }
+        }
         if !self.wtr.supports_color() || self.colors.matched().is_none() {
             self.write(buf);
-            return;
+        } else {
+            let mut last_written = 0;
+            for m in re.find_iter(buf) {
+                self.write(&buf[last_written..m.start()]);
+                let _ = self.wtr.set_color(self.colors.matched());
+                self.write(&buf[m.start()..m.end()]);
+                let _ = self.wtr.reset();
+                last_written = m.end();
+            }
+            self.write(&buf[last_written..]);
         }
-        let mut last_written = 0;
-        for m in re.find_iter(buf) {
-            self.write(&buf[last_written..m.start()]);
-            let _ = self.wtr.set_color(self.colors.matched());
-            self.write(&buf[m.start()..m.end()]);
-            let _ = self.wtr.reset();
-            last_written = m.end();
+        if buf.last() != Some(&self.eol) {
+            self.write_eol();
         }
-        self.write(&buf[last_written..]);
     }
 
     pub fn context<P: AsRef<Path>>(
@@ -320,6 +360,15 @@ impl<W: WriteColor> Printer<W> {
         }
         if let Some(line_number) = line_number {
             self.line_number(line_number, b'-');
+        }
+        if let Some(max_columns) = self.max_columns {
+            if end - start > max_columns {
+                let _ = self.wtr.set_color(self.colors.line());
+                self.write(format!(" [Omitted long context line]").as_bytes());
+                let _ = self.wtr.reset();
+                self.write_eol();
+                return;
+            }
         }
         self.write(&buf[start..end]);
         if buf[start..end].last() != Some(&self.eol) {


### PR DESCRIPTION
This implements what we discussed in <https://github.com/BurntSushi/ripgrep/issues/129#issuecomment-276946474>.

One open question from my side: how bad is it that by always using `CountingReplacer`, we lose the optimization offered by returning something from `Replacer::no_expansion`? In principle, we could use `CountingReplacer` only if `max_columns` is `Some`, therefore only incurring a performance cost if `--max-columns` is set. Is that worth the additional effort?

TODO: Add some tests.

Fixes #129.