### PR TITLE
Add new -M/--max-columns option.

### DIFF
--- a/doc/rg.1.md
+++ b/doc/rg.1.md
@@ -203,6 +203,10 @@ Project home page: https://github.com/BurntSushi/ripgrep
 -L, --follow
 : Follow symlinks.
 
+-M, --max-columns *NUM*
+: Don't print lines longer than this limit in bytes. Longer lines are omitted,
+  and only the number of matches in that line is printed.
+
 -m, --max-count *NUM*
 : Limit the number of matching lines per file searched to NUM.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -169,6 +169,9 @@ fn app<F>(next_line_help: bool, doc: F) -> App<'static, 'static>
              .short("j").value_name("ARG").takes_value(true)
              .validator(validate_number))
         .arg(flag("vimgrep"))
+        .arg(flag("max-columns").short("M")
+             .value_name("NUM").takes_value(true)
+             .validator(validate_number))
         .arg(flag("type-add")
              .value_name("TYPE").takes_value(true)
              .multiple(true).number_of_values(1))
@@ -473,6 +476,11 @@ lazy_static! {
              "Show results with every match on its own line, including \
               line numbers and column numbers. With this option, a line with \
               more than one match will be printed more than once.");
+        doc!(h, "max-columns",
+             "Don't print lines longer than this limit in bytes.",
+             "Don't print lines longer than this limit in bytes. Longer lines \
+              are omitted, and only the number of matches in that line is \
+              printed.");
 
         doc!(h, "type-add",
              "Add a new glob for a file type.",

--- a/src/args.rs
+++ b/src/args.rs
@@ -56,6 +56,7 @@ pub struct Args {
     invert_match: bool,
     line_number: bool,
     line_per_match: bool,
+    max_columns: Option<usize>,
     max_count: Option<u64>,
     max_filesize: Option<u64>,
     maxdepth: Option<usize>,
@@ -156,7 +157,8 @@ impl Args {
             .line_per_match(self.line_per_match)
             .null(self.null)
             .path_separator(self.path_separator)
-            .with_filename(self.with_filename);
+            .with_filename(self.with_filename)
+            .max_columns(self.max_columns);
         if let Some(ref rep) = self.replace {
             p = p.replace(rep.clone());
         }
@@ -348,6 +350,7 @@ impl<'a> ArgMatches<'a> {
             invert_match: self.is_present("invert-match"),
             line_number: line_number,
             line_per_match: self.is_present("vimgrep"),
+            max_columns: try!(self.usize_of("max-columns")),
             max_count: try!(self.usize_of("max-count")).map(|max| max as u64),
             max_filesize: try!(self.max_filesize()),
             maxdepth: try!(self.usize_of("maxdepth")),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1314,6 +1314,36 @@ clean!(feature_109_case_sensitive_part2, "test", ".",
     wd.assert_err(&mut cmd);
 });
 
+// See: https://github.com/BurntSushi/ripgrep/issues/129
+clean!(feature_129_matches, "test", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create("foo", "test\ntest abcdefghijklmnopqrstuvwxyz test");
+    cmd.arg("-M26");
+
+    let lines: String = wd.stdout(&mut cmd);
+    let expected = "foo:test\nfoo:[Omitted long line with 2 matches]\n";
+    assert_eq!(lines, expected);
+});
+
+// See: https://github.com/BurntSushi/ripgrep/issues/129
+clean!(feature_129_context, "test", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create("foo", "test\nabcdefghijklmnopqrstuvwxyz");
+    cmd.arg("-M20").arg("-C1");
+
+    let lines: String = wd.stdout(&mut cmd);
+    let expected = "foo:test\nfoo-[Omitted long context line]\n";
+    assert_eq!(lines, expected);
+});
+
+// See: https://github.com/BurntSushi/ripgrep/issues/129
+clean!(feature_129_replace, "test", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create("foo", "test\ntest abcdefghijklmnopqrstuvwxyz test");
+    cmd.arg("-M26").arg("-rfoo");
+
+    let lines: String = wd.stdout(&mut cmd);
+    let expected = "foo:foo\nfoo:[Omitted long line with 2 replacements]\n";
+    assert_eq!(lines, expected);
+});
+
 // See: https://github.com/BurntSushi/ripgrep/issues/159
 clean!(feature_159_works, "test", ".", |wd: WorkDir, mut cmd: Command| {
     wd.create("foo", "test\ntest");


### PR DESCRIPTION
This permits setting the maximum line width with respect to the number
of bytes in a line. Omitted lines (whether part of a match, replacement
or context) are replaced with a message stating that the line was
elided.

Fixes #129