### PR TITLE
Removed debug info from release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,3 @@ lazy_static = "0.2"
 [features]
 avx-accel = ["bytecount/avx-accel"]
 simd-accel = ["bytecount/simd-accel", "regex/simd-accel"]
-
-[profile.release]
-debug = true


### PR DESCRIPTION
Having debug info enabled on release causes bloated binaries on Unix based systems. This affects people who use `cargo install ripgrep`.