### PR TITLE
Add an option similar to -o, --only-matching #34

### DIFF
--- a/doc/rg.1.md
+++ b/doc/rg.1.md
@@ -249,6 +249,10 @@ Project home page: https://github.com/BurntSushi/ripgrep
   a list of matching files such as with --count, --files-with-matches
   and --files.
 
+-o, --only-matching
+: Print only the matched (non-empty) parts of a matching line, with each such
+  part on a separate output line.
+
 --path-separator *SEPARATOR*
 : The path separator to use when printing file paths. This defaults to your
   platform's path separator, which is / on Unix and \\ on Windows. This flag is

--- a/src/app.rs
+++ b/src/app.rs
@@ -159,6 +159,7 @@ fn app<F>(next_line_help: bool, doc: F) -> App<'static, 'static>
         .arg(flag("no-ignore-parent"))
         .arg(flag("no-ignore-vcs"))
         .arg(flag("null").short("0"))
+        .arg(flag("only-matching").short("o"))
         .arg(flag("path-separator").value_name("SEPARATOR").takes_value(true))
         .arg(flag("pretty").short("p"))
         .arg(flag("replace").short("r").value_name("ARG").takes_value(true))
@@ -436,6 +437,9 @@ lazy_static! {
               printing a list of matching files such as with --count, \
               --files-with-matches and --files. This option is useful for use \
               with xargs.");
+        doc!(h, "only-matching",
+             "Print only the matched (non-empty) parts of a matching line, \
+              with each such part on a separate output line.");
         doc!(h, "path-separator",
              "Path separator to use when printing file paths.",
              "The path separator to use when printing file paths. This \

--- a/src/app.rs
+++ b/src/app.rs
@@ -159,7 +159,7 @@ fn app<F>(next_line_help: bool, doc: F) -> App<'static, 'static>
         .arg(flag("no-ignore-parent"))
         .arg(flag("no-ignore-vcs"))
         .arg(flag("null").short("0"))
-        .arg(flag("only-matching").short("o"))
+        .arg(flag("only-matching").short("o").conflicts_with("replace"))
         .arg(flag("path-separator").value_name("SEPARATOR").takes_value(true))
         .arg(flag("pretty").short("p"))
         .arg(flag("replace").short("r").value_name("ARG").takes_value(true))

--- a/src/args.rs
+++ b/src/args.rs
@@ -66,6 +66,7 @@ pub struct Args {
     no_ignore_vcs: bool,
     no_messages: bool,
     null: bool,
+    only_matching: bool,
     path_separator: Option<u8>,
     quiet: bool,
     quiet_matched: QuietMatched,
@@ -161,6 +162,7 @@ impl Args {
             .heading(self.heading)
             .line_per_match(self.line_per_match)
             .null(self.null)
+            .only_matching(self.only_matching)
             .path_separator(self.path_separator)
             .with_filename(self.with_filename)
             .max_columns(self.max_columns);
@@ -365,6 +367,7 @@ impl<'a> ArgMatches<'a> {
             no_ignore_vcs: self.no_ignore_vcs(),
             no_messages: self.is_present("no-messages"),
             null: self.is_present("null"),
+            only_matching: self.is_present("only-matching"),
             path_separator: try!(self.path_separator()),
             quiet: quiet,
             quiet_matched: QuietMatched::new(quiet),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1166,6 +1166,32 @@ be, to a very large extent, the result of luck. Sherlock Holmes
     assert_eq!(lines, expected);
 });
 
+// See: https://github.com/BurntSushi/ripgrep/issues/34
+sherlock!(feature_34_only_matching, "Sherlock", ".",
+|wd: WorkDir, mut cmd: Command| {
+    cmd.arg("--only-matching");
+
+    let lines: String = wd.stdout(&mut cmd);
+    let expected = "\
+sherlock:Sherlock
+sherlock:Sherlock
+";
+    assert_eq!(lines, expected);
+});
+
+// See: https://github.com/BurntSushi/ripgrep/issues/34
+sherlock!(feature_34_only_matching_line_column, "Sherlock", ".",
+|wd: WorkDir, mut cmd: Command| {
+    cmd.arg("--only-matching").arg("--column").arg("--line-number");
+
+    let lines: String = wd.stdout(&mut cmd);
+    let expected = "\
+sherlock:1:57:Sherlock
+sherlock:3:49:Sherlock
+";
+    assert_eq!(lines, expected);
+});
+
 // See: https://github.com/BurntSushi/ripgrep/issues/45
 sherlock!(feature_45_relative_cwd, "test", ".",
 |wd: WorkDir, mut cmd: Command| {


### PR DESCRIPTION
Fixes #34

Example:
```
~/ripgrep$ ./target/debug/rg "only-matching" -o --column
doc/rg.1.md
252:7:only-matching

tests/tests.rs
1145:16:only-matching
1158:16:only-matching

src/args.rs
370:45:only-matching

src/app.rs
162:20:only-matching
439:18:only-matching
```