### PR TITLE
Apply binary name to clap

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -24,7 +24,7 @@ const TEMPLATE: &'static str = "\
 {author}
 {about}
 
-USAGE:{usage}
+USAGE: {usage}
 
 ARGS:
 {positionals}
@@ -56,7 +56,8 @@ fn app<F>(next_line_help: bool, doc: F) -> App<'static, 'static>
     };
     let flag = |name| arg(name).long(name);
 
-    App::new("ripgrep")
+    App::new(crate_name!())
+        .bin_name("rg")
         .author(crate_authors!())
         .version(crate_version!())
         .about(ABOUT)


### PR DESCRIPTION
Fixes #426 

Example:
```
$ cargo run -- -h | head -n14 | tail -n 1
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/rg -h`
USAGE: rg [OPTIONS] <pattern> [--] [path]...
```