### PR TITLE
Use child process worker to gracefully kill it on Crtl-C. Closes #281

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,8 @@ dependencies = [
  "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecount 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clonablechild 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctrlc 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "grep 0.1.6",
@@ -77,9 +79,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "clonablechild"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ctrlc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -339,7 +359,9 @@ dependencies = [
 "checksum bytecount 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1e8f09fbc8c6726a4b616dcfbd4f54491068d6bb1b93ac03c78ac18ff9a5924a"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum clap 2.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d480c39a2e5f9b3a3798c661613e1b0e7a7ae71e005102d4aa910fc3289df484"
+"checksum clonablechild 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4a4946a850c1e921fbdd9a1f92bf1298c41a301c0f6e9bacbabf95ea7d6d0225"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
+"checksum ctrlc 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f26287fa3893461876a4851d1bee53b82f04954f85e2d7cd30ae053d0edefd72"
 "checksum encoding_rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a1cca0a26f904955d80d70b9bff1019e4f4cbc06f2fcbccf8bd3d889cc1c9b7"
 "checksum env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e3856f1697098606fc6cb97a93de88ca3f3bc35bb878c725920e6e82ecf05e83"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ name = "integration"
 path = "tests/tests.rs"
 
 [dependencies]
+ctrlc = "^3.0"
+clonablechild = "^0.1"
 atty = "0.2.2"
 bytecount = "0.1.4"
 clap = "2.23.1"


### PR DESCRIPTION
This PR should provide a graceful way to clean-up after sudden interruption by user.
It relies on libary `clonablechild` to provide way to wait and kill child in parallel
I looked briefly at code but haven't found anything bad with it.

Decided to go with setting particular environment variable instead if hidden variable.
I believe we can choose careful variable that could ensure more or less almost 100% that there will be no collision.
This way we do not need to bother correcting clap parsing and just have modification in main function.

I would appreciate help in testing on linux though

cc @BurntSushi @seabadger

**UPD**: For now it seems to bring some issues to tests as it is always reseting terminal color and therefore the extra character at the end that breaks tests