### PR TITLE
updates clap and removes home rolled -h/--help distinction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = "0.5.0"
 dependencies = [
  "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecount 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "grep 0.1.6",
@@ -63,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.22.2"
+version = "2.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -338,7 +338,7 @@ dependencies = [
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum bytecount 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1e8f09fbc8c6726a4b616dcfbd4f54491068d6bb1b93ac03c78ac18ff9a5924a"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
-"checksum clap 2.22.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae8c5a1108961e9bafb1096b8cbb6a31c17ab1a276ce9b52334be99962f653"
+"checksum clap 2.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d480c39a2e5f9b3a3798c661613e1b0e7a7ae71e005102d4aa910fc3289df484"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum encoding_rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a1cca0a26f904955d80d70b9bff1019e4f4cbc06f2fcbccf8bd3d889cc1c9b7"
 "checksum env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e3856f1697098606fc6cb97a93de88ca3f3bc35bb878c725920e6e82ecf05e83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ path = "tests/tests.rs"
 [dependencies]
 atty = "0.2.2"
 bytecount = "0.1.4"
-clap = "2.20.5"
+clap = "2.23.1"
 encoding_rs = "0.5.0"
 env_logger = { version = "0.4", default-features = false }
 grep = { version = "0.1.5", path = "grep" }
@@ -44,7 +44,7 @@ same-file = "0.1.1"
 termcolor = { version = "0.3.0", path = "termcolor" }
 
 [build-dependencies]
-clap = "2.18"
+clap = "2.23.1"
 lazy_static = "0.2"
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ fn main() {
     };
     fs::create_dir_all(&outdir).unwrap();
 
-    let mut app = app::app_short();
+    let mut app = app::app();
     app.gen_completions("rg", Shell::Bash, &outdir);
     app.gen_completions("rg", Shell::Fish, &outdir);
     app.gen_completions("rg", Shell::Zsh, &outdir);

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,16 +32,6 @@ ARGS:
 OPTIONS:
 {unified}";
 
-/// Build a clap application with short help strings.
-pub fn app_short() -> App<'static, 'static> {
-    app(false, |k| USAGES[k].short)
-}
-
-/// Build a clap application with long help strings.
-pub fn app_long() -> App<'static, 'static> {
-    app(true, |k| USAGES[k].long)
-}
-
 /// Build a clap application parameterized by usage strings.
 ///
 /// The function given should take a clap argument name and return a help
@@ -49,10 +39,9 @@ pub fn app_long() -> App<'static, 'static> {
 ///
 /// This is an intentionally stand-alone module so that it can be used easily
 /// in a `build.rs` script to build shell completion files.
-fn app<F>(next_line_help: bool, doc: F) -> App<'static, 'static>
-        where F: Fn(&'static str) -> &'static str {
+pub fn app() -> App<'static, 'static> {
     let arg = |name| {
-        Arg::with_name(name).help(doc(name)).next_line_help(next_line_help)
+        Arg::with_name(name).help(USAGES[name].short).long_help(USAGES[name].long)
     };
     let flag = |name| arg(name).long(name);
 
@@ -64,11 +53,7 @@ fn app<F>(next_line_help: bool, doc: F) -> App<'static, 'static>
         .setting(AppSettings::UnifiedHelpMessage)
         .usage(USAGE)
         .template(TEMPLATE)
-        // Handle help/version manually to make their output formatting
-        // consistent with short/long views.
-        .arg(arg("help-short").short("h"))
-        .arg(flag("help"))
-        .arg(arg("ripgrep-version").long("version").short("V"))
+	.help_message("Prints help information. Use --help for more details.")
         // First, set up primary positional/flag arguments.
         .arg(arg("pattern")
              .required_unless_one(&[

--- a/src/args.rs
+++ b/src/args.rs
@@ -5,7 +5,6 @@ use std::fs;
 use std::io::{self, BufRead};
 use std::ops;
 use std::path::{Path, PathBuf};
-use std::process;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -88,26 +87,7 @@ impl Args {
     ///
     /// Also, initialize a global logger.
     pub fn parse() -> Result<Args> {
-        use clap::ErrorKind::*;
-
-        let matches = match app::app_short().get_matches_safe() {
-            Ok(matches) => matches,
-            Err(clap::Error { kind: HelpDisplayed, .. }) => {
-                let _ = ::app::app_long().print_help();
-                println!("");
-                process::exit(0);
-            }
-            Err(err) => err.exit(),
-        };
-        if matches.is_present("help-short") {
-            let _ = ::app::app_short().print_help();
-            println!("");
-            process::exit(0);
-        }
-        if matches.is_present("ripgrep-version") {
-            println!("ripgrep {}", crate_version!());
-            process::exit(0);
-        }
+        let matches = app::app().get_matches();
 
         let mut logb = env_logger::LogBuilder::new();
         if matches.is_present("debug") {


### PR DESCRIPTION
~~**DO NOT MERGE - until clap v2.23.1 is on crates.io**~~

It's safe to merge now.

- [x] crates.io needs to contain clap v2.23.1
- [x] I need to rebase the `Cargo.lock`

This commit updates clap to v2.23.1

The update contained a bug fix in clap that results in broken code in
ripgrep. ripgrep was unknowingly relying on the bug, but this commit fixes that
issue. The bug centered around not being able to override the
auto-generated help message by supplying a flag with a long of `help`.

Normally, supplying a flag with a long of `help` means whenever the user
passes `--help`, the consuming code (e.g. ripgrep) is responsible for
displaying the help message. However, due to the bug in clap this wasn't
necessary for ripgrep to do unless the user passed `-h`. With the bug
fixed, it meant the user passing `--help` and clap expected ripgrep to
display the help, yet ripgrep expected clap to display the help. This
has been fixed in this commit of ripgrep.

All is well now!

v2.23.0 also brings the abilty to use `Arg::help` or `Arg::long_help`
allowing one to distinguish between `-h` and `--help`. This commit
leaves all doc strings in the `lazy_static!` hashmap however only for
aesthetic reasons.

This means all home rolled handling of `-h`/`--help` has been removed
from ripgrep, yet functionality *and* appearances are 100% the same.