### PR TITLE
Add extended color support

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -247,7 +247,16 @@ lazy_static! {
               color settings for {type}.\n\nFor example, the following \
               command will change the match color to magenta and the \
               background color for line numbers to yellow:\n\n\
-              rg --colors 'match:fg:magenta' --colors 'line:bg:yellow' foo.");
+              rg --colors 'match:fg:magenta' --colors 'line:bg:yellow' foo.\n\n\
+              Extended colors can be used for {value} when the terminal \
+              supports ANSI color sequences. These are specified as either \
+              'x' (256-color) or 'x,x,x' (24-bit truecolor) where x is a \
+              number between 0 and 255 inclusive. \n\nFor example, the \
+              following command will change the match background color to that \
+              represented by the rgb value (0,128,255):\n\n\
+              rg --colors 'match:bg:0,128,255'\n\nNote that the the intense \
+              and nointense style flags will have no effect when used \
+              alongside these extended color codes.");
         doc!(h, "encoding",
              "Specify the text encoding of files to search.",
              "Specify the text encoding that ripgrep will use on all files \


### PR DESCRIPTION
Fixes #261.

 - Adds support for 256 and rgb color codes. Format is simply comma separated values.
 - Mixes fine with other styles such as bold/nobold. I did write a brief thing about this in the issue but doesn't seem necessary after writing the documentation.
 - Windows falls back to white in the presence of one of these new color codes.
 - This currently uses a fixed buffer for formatting the color codes instead of the `format!` macro. Its more complicated and I'm not entirely sure the benefit but it can always be changed back if the extra allocations are favored over the more complex code.