### PR TITLE
Add snapcraft.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ target
 /ignore/Cargo.lock
 /termcolor/Cargo.lock
 /wincolor/Cargo.lock
+
+# Snapcraft files
+stage
+prime
+parts
+*.snap
+*.pyc
+ripgrep*_source.tar.bz2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: ripgrep # you probably want to 'snapcraft register <name>'
+version: '0.5.1' # just for humans, typically '1.2+git' or '1.3.2'
+summary: Fast file searcher # 79 char long summary
+description: |
+  ripgrep combines the usability of The Silver Searcher with the raw speed of grep.
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: classic # use 'strict' once you have the right plugs and slots
+parts:
+  ripgrep:
+    plugin: rust
+    source: .
+apps:
+  rg:
+    command: env PATH=$SNAP/bin:$PATH rg
+    aliases: [rg]


### PR DESCRIPTION
[Snapcraft](https://snapcraft.io/) makes Linux packaging very simple in a cross-distro
way. This adds the snapcraft.yaml file to setup a snap of ripgrep