### PR TITLE
Make --quiet flag apply when using --files option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,9 @@ fn run_files_parallel(args: Arc<Args>) -> Result<u64> {
         let mut printer = print_args.printer(stdout.lock());
         let mut file_count = 0;
         for dent in rx.iter() {
-            printer.path(dent.path());
+            if !print_args.quiet() {
+                printer.path(dent.path());
+            }
             file_count += 1;
         }
         file_count
@@ -227,7 +229,9 @@ fn run_files_one_thread(args: Arc<Args>) -> Result<u64> {
             None => continue,
             Some(dent) => dent,
         };
-        printer.path(dent.path());
+        if !args.quiet() {
+            printer.path(dent.path());
+        }
         file_count += 1;
     }
     Ok(file_count)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1652,6 +1652,35 @@ fn regression_451_only_matching() {
     assert_eq!(lines, expected);
 }
 
+// See: https://github.com/BurntSushi/ripgrep/issues/483
+#[test]
+fn regression_483_matching_no_stdout() {
+    let wd = WorkDir::new("regression_483_matching_no_stdout");
+    wd.create("file.py", "");
+
+    let mut cmd = wd.command();
+    cmd.arg("--quiet")
+       .arg("--files")
+       .arg("--glob").arg("*.py");
+
+    let lines: String = wd.stdout(&mut cmd);
+    assert!(lines.is_empty());
+}
+
+// See: https://github.com/BurntSushi/ripgrep/issues/483
+#[test]
+fn regression_483_non_matching_exit_code() {
+    let wd = WorkDir::new("regression_483_non_matching_exit_code");
+    wd.create("file.rs", "");
+
+    let mut cmd = wd.command();
+    cmd.arg("--quiet")
+       .arg("--files")
+       .arg("--glob").arg("*.py");
+
+    wd.assert_err(&mut cmd);
+}
+
 #[test]
 fn type_list() {
     let wd = WorkDir::new("type_list");


### PR DESCRIPTION
Fixes #483.

Self-explanatory, but example behavior as follows (in ripgrep base directory).

```
$ (issue-483) cargo run -- --quiet --files --glob '*.tom'; echo "$?" 
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/rg --quiet --files --glob '*.tom'`
1
$ (issue-483) cargo run -- --quiet --files --glob '*.toml'; echo "$?" 
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/rg --quiet --files --glob '*.toml'`
0
```