### PR TITLE
Should show filename for one file with vimgrep

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -532,6 +532,7 @@ impl<'a> ArgMatches<'a> {
             false
         } else {
             self.is_present("with-filename")
+            || self.is_present("vimgrep")
             || paths.len() > 1
             || paths.get(0).map_or(false, |p| p.is_dir())
         }


### PR DESCRIPTION
With vim configured with:

    set grepprg=rg\ --vimgrep
    set grepformat^=%f:%l:%c:%m

and running the command `:grep 'vimgrep' doc/rg.1`, the output should be:

    doc/rg.1:446:8:.B \-\-vimgrep

but the actual output was:

    446:8:.B \-\-vimgrep

Same issue would happen if results only match one file. Ag behaves as expected.