### PR TITLE
Update documentation for --color ansi

### DIFF
--- a/doc/rg.1
+++ b/doc/rg.1
@@ -43,8 +43,8 @@ Only show count of line matches for each file.
 .RE
 .TP
 .B \-\-color \f[I]WHEN\f[]
-Whether to use coloring in match.
-Valid values are never, always or auto.
+Whether to use color in the output.
+Valid values are never, auto, always or ansi.
 [default: auto]
 .RS
 .RE

--- a/doc/rg.1.md
+++ b/doc/rg.1.md
@@ -36,8 +36,8 @@ Project home page: https://github.com/BurntSushi/ripgrep
 : Only show count of line matches for each file.
 
 --color *WHEN*
-: Whether to use coloring in match. Valid values are never, always or auto.
-  [default: auto]
+: Whether to use color in the output. Valid values are never, auto, always or
+  ansi. [default: auto]
 
 -e, --regexp *PATTERN* ...
 : Use PATTERN to search. This option can be provided multiple times, where all

--- a/src/app.rs
+++ b/src/app.rs
@@ -228,11 +228,11 @@ lazy_static! {
              "Only show count of matches for each file.");
         doc!(h, "color",
              "When to use color. [default: auto]",
-             "When to use color in the output. The possible values are \
-              never, auto, always or ansi. The default is auto. When always \
-              is used, coloring is attempted based on your environment. When \
-              ansi used, coloring is forcefully done using ANSI escape color \
-              codes.");
+             "When to use color in the output. The possible values are never, \
+             auto, always or ansi. The default is auto. When always is used, \
+             coloring is attempted based on your environment. When ansi is \
+             used, coloring is forcefully done using ANSI escape color \
+             codes.");
         doc!(h, "colors",
              "Configure color settings and styles.",
              "This flag specifies color settings for use in the output. \


### PR DESCRIPTION
In `src/app.rs`, change typo "When ansi used" to "When ansi is used".
Update man pages with missing `ansi` option for `--color`.