### PR TITLE
Use uppercase for required argument names

### DIFF
--- a/doc/rg.1
+++ b/doc/rg.1
@@ -9,7 +9,7 @@ rg \- recursively search current directory for lines matching a pattern
 .PP
 rg [\f[I]options\f[]] \f[I]PATTERN\f[] [\f[I]path\f[] ...]
 .PP
-rg [\f[I]options\f[]] [\-e \f[I]pattern\f[] ...] [\-f \f[I]file\f[] ...]
+rg [\f[I]options\f[]] [\-e \f[I]PATTERN\f[] ...] [\-f \f[I]FILE\f[] ...]
 [\f[I]path\f[] ...]
 .PP
 rg [\f[I]options\f[]] \-\-files [\f[I]path\f[] ...]

--- a/doc/rg.1.md
+++ b/doc/rg.1.md
@@ -6,7 +6,7 @@ rg - recursively search current directory for lines matching a pattern
 
 rg [*options*] *PATTERN* [*path* ...]
 
-rg [*options*] [-e *pattern* ...] [-f *file* ...] [*path* ...]
+rg [*options*] [-e *PATTERN* ...] [-f *FILE* ...] [*path* ...]
 
 rg [*options*] --files [*path* ...]
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,7 @@ Use -h for short descriptions and --help for more details.";
 
 const USAGE: &'static str = "
     rg [options] PATTERN [path ...]
-    rg [options] [-e pattern ...] [-f file ...] [path ...]
+    rg [options] [-e PATTERN ...] [-f FILE ...] [path ...]
     rg [options] --files [path ...]
     rg [options] --type-list";
 
@@ -57,7 +57,7 @@ pub fn app() -> App<'static, 'static> {
         .template(TEMPLATE)
         .help_message("Prints help information. Use --help for more details.")
         // First, set up primary positional/flag arguments.
-        .arg(arg("pattern")
+        .arg(arg("PATTERN")
              .required_unless_one(&[
                 "file", "files", "help-short", "help", "regexp", "type-list",
                 "ripgrep-version",
@@ -66,13 +66,13 @@ pub fn app() -> App<'static, 'static> {
         .arg(flag("regexp").short("e")
              .takes_value(true).multiple(true).number_of_values(1)
              .set(ArgSettings::AllowLeadingHyphen)
-             .value_name("pattern"))
+             .value_name("PATTERN"))
         .arg(flag("files")
-             // This should also conflict with `pattern`, but the first file
-             // path will actually be in `pattern`.
+             // This should also conflict with `PATTERN`, but the first file
+             // path will actually be in `PATTERN`.
              .conflicts_with_all(&["file", "regexp", "type-list"]))
         .arg(flag("type-list")
-             .conflicts_with_all(&["file", "files", "pattern", "regexp"]))
+             .conflicts_with_all(&["file", "files", "PATTERN", "regexp"]))
         // Second, set up common flags.
         .arg(flag("text").short("a"))
         .arg(flag("count").short("c"))
@@ -201,7 +201,7 @@ lazy_static! {
         doc!(h, "ripgrep-version",
              "Prints version information.");
 
-        doc!(h, "pattern",
+        doc!(h, "PATTERN",
              "A regular expression used for searching.",
              "A regular expression used for searching. To match a pattern \
              beginning with a dash, use the -e/--regexp option.");

--- a/src/args.rs
+++ b/src/args.rs
@@ -375,7 +375,7 @@ impl<'a> ArgMatches<'a> {
         if self.is_present("file")
             || self.is_present("files")
             || self.is_present("regexp") {
-            if let Some(path) = self.value_of_os("pattern") {
+            if let Some(path) = self.value_of_os("PATTERN") {
                 paths.insert(0, Path::new(path).to_path_buf());
             }
         }
@@ -438,7 +438,7 @@ impl<'a> ArgMatches<'a> {
         match self.values_of_os("regexp") {
             None => {
                 if self.values_of_os("file").is_none() {
-                    if let Some(os_pat) = self.value_of_os("pattern") {
+                    if let Some(os_pat) = self.value_of_os("PATTERN") {
                         pats.push(try!(self.os_str_pattern(os_pat)));
                     }
                 }


### PR DESCRIPTION
This reverts a couple of changes introduced in 4c78ca8

@BurntSushi, not sure if you want to merge this. Just trying to revert some changes I introduced, plus keeping the `PATTERN` argument consistently uppercased, so error messages can look like

```
error: The following required arguments were not provided:
    <PATTERN>
```