### PR TITLE
Add "msbuild" filetype grouping, and add .inl files to the "cpp" grouping. 

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -155,6 +155,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("matlab", &["*.m"]),
     ("mk", &["mkfile"]),
     ("ml", &["*.ml"]),
+    ("msbuild", &["*.csproj", "*.fsproj", "*.vcxproj", "*.proj", "*.props", "*.targets"]),
     ("nim", &["*.nim"]),
     ("nix", &["*.nix"]),
     ("objc", &["*.h", "*.m"]),

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -111,7 +111,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("config", &["*.config"]),
     ("cpp", &[
         "*.C", "*.cc", "*.cpp", "*.cxx",
-        "*.h", "*.H", "*.hh", "*.hpp",
+        "*.h", "*.H", "*.hh", "*.hpp", "*.inl",
     ]),
     ("crystal", &["Projectfile", "*.cr"]),
     ("cs", &["*.cs"]),


### PR DESCRIPTION
This change consists of two commits:

- Add a new fietype grouping for "msbuild" related files.
- Add .inl files to be included in the cpp filetype grouping. 