### PR TITLE
fix word boundary w/ capture group

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -505,7 +505,7 @@ impl<'a> ArgMatches<'a> {
     /// flag is set. Otherwise, the pattern is returned unchanged.
     fn word_pattern(&self, pat: String) -> String {
         if self.is_present("word-regexp") {
-            format!(r"\b{}\b", pat)
+            format!(r"\b(?:{})\b", pat)
         } else {
             pat
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1690,6 +1690,23 @@ fn regression_483_non_matching_exit_code() {
 
     wd.assert_err(&mut cmd);
 }
+// See: https://github.com/BurntSushi/ripgrep/issues/506
+#[test]
+fn regression_506_word_boundaries_not_parenthesized() {
+    let wd = WorkDir::new("regression_506_word_boundaries_not_parenthesized");
+    let path = "wb.txt";
+    wd.create(path, "min minimum amin\n\
+              max maximum amax");
+
+    let mut cmd = wd.command();
+    cmd.arg("-w").arg("min|max").arg(path).arg("--only-matching");
+    let lines: String = wd.stdout(&mut cmd);
+
+    let expected = "min\nmax\n";
+
+    assert_eq!(lines, expected);
+
+}
 
 #[test]
 fn type_list() {


### PR DESCRIPTION
fixes BurntSushi/ripgrep#506. Word boundary search as arg had unexpected
behavior. added non-capturing capture group to regex to encapsulate 'or' option search and
prevent expansion and partial boundary finds.

Signed-off-by: Evan.Mattiza <emattiza@gmail.com>