### PR TITLE
Add -x/--line-regexp

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -45,6 +45,7 @@ _rg() {
     '--ignore-file=[specify additional ignore file]:file:_files'
     '(-v --invert-match)'{-v,--invert-match}'[invert matching]'
     '(-n -N --line-number --no-line-number)'{-n,--line-number}'[show line numbers]'
+    '(-w -x --line-regexp --word-regexp)'{-x,--line-regexp}'[only show matches surrounded by line boundaries]'
     '(-M --max-columns)'{-M+,--max-columns=}'[specify max length of lines to print]:number of bytes'
     '(-m --max-count)'{-m+,--max-count=}'[specify max number of matches per file]:number of matches'
     '--max-filesize=[specify size above which files should be ignored]:file size'
@@ -80,7 +81,7 @@ _rg() {
     '(: -)'{-V,--version}'[display version information]'
     '(-p --heading --no-heading --pretty)--vimgrep[show results in vim-compatible format]'
     '(-H --no-filename --with-filename)'{-H,--with-filename}'[prefix each match with name of file that contains it]'
-    '(-w --word-regexp)'{-w,--word-regexp}'[only show matches surrounded by word boundaries]'
+    '(-w -x --line-regexp --word-regexp)'{-w,--word-regexp}'[only show matches surrounded by word boundaries]'
     '(-e -f --file --files --regexp --type-list)1: :_rg_pattern'
     '(--type-list)*:file:_files'
   )

--- a/doc/convert-to-man
+++ b/doc/convert-to-man
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/sh -e
 
 pandoc -s -t man rg.1.md -o rg.1
-sed -i 's/\.TH.*/.TH "rg" "1"/g' rg.1
+sed -i.bak 's/\.TH.*/.TH "rg" "1"/g' rg.1
+rm -f rg.1.bak # BSD `sed` requires the creation of a back-up file

--- a/doc/rg.1
+++ b/doc/rg.1
@@ -156,6 +156,12 @@ Only show matches surrounded by word boundaries.
 This is equivalent to putting \\b before and after the search pattern.
 .RS
 .RE
+.TP
+.B \-x, \-\-line\-regexp
+Only show matches surrounded by line boundaries.
+This is equivalent to putting ^...$ around the search pattern.
+.RS
+.RE
 .SH LESS COMMON OPTIONS
 .TP
 .B \-A, \-\-after\-context \f[I]NUM\f[]

--- a/doc/rg.1.md
+++ b/doc/rg.1.md
@@ -105,6 +105,10 @@ Project home page: https://github.com/BurntSushi/ripgrep
 : Only show matches surrounded by word boundaries. This is equivalent to
   putting \\b before and after the search pattern.
 
+-x, --line-regexp
+: Only show matches surrounded by line boundaries. This is equivalent to
+  putting ^...$ around the search pattern.
+
 # LESS COMMON OPTIONS
 
 -A, --after-context *NUM*

--- a/src/app.rs
+++ b/src/app.rs
@@ -109,7 +109,8 @@ pub fn app() -> App<'static, 'static> {
         .arg(flag("unrestricted").short("u")
              .multiple(true))
         .arg(flag("invert-match").short("v"))
-        .arg(flag("word-regexp").short("w"))
+        .arg(flag("word-regexp").short("w").overrides_with("line-regexp"))
+        .arg(flag("line-regexp").short("x"))
         // Third, set up less common flags.
         .arg(flag("after-context").short("A")
              .value_name("NUM").takes_value(true)
@@ -348,6 +349,10 @@ lazy_static! {
              "Only show matches surrounded by word boundaries. This is \
               equivalent to putting \\b before and after all of the search \
               patterns.");
+        doc!(h, "line-regexp",
+             "Only show matches surrounded by line boundaries.",
+             "Only show matches surrounded by line boundaries. This is \
+              equivalent to putting ^...$ around all of the search patterns.");
 
         doc!(h, "after-context",
              "Show NUM lines after each match.");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -209,6 +209,16 @@ For the Doctor Watsons of this world, as opposed to the Sherlock
     assert_eq!(lines, expected);
 });
 
+sherlock!(line, "Watson|and exhibited clearly, with a label attached.",
+|wd: WorkDir, mut cmd: Command| {
+    cmd.arg("-x");
+    let lines: String = wd.stdout(&mut cmd);
+    let expected = "\
+and exhibited clearly, with a label attached.
+";
+    assert_eq!(lines, expected);
+});
+
 sherlock!(literal, "()", "file", |wd: WorkDir, mut cmd: Command| {
     wd.create("file", "blib\n()\nblab\n");
     cmd.arg("-F");


### PR DESCRIPTION
Let's try this!

This PR adds `-x`/`--line-regexp`, which essentially wraps the pattern in `^`...`$` in order to make it match whole lines only. This is an option defined in the [POSIX spec](http://pubs.opengroup.org/onlinepubs/009695399/utilities/grep.html) for `grep`, and one that i use a lot. I found it rather frustrating that `ag` didn't have it.

I will add additional notes as comments on the diff.