### PR TITLE
Improve zsh completion function

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -47,70 +47,73 @@ local -a common_options
 common_options=(
   '(-a --text)'{-a,--text}'[search binary files as if they were text]'
   '(-c, --count)'{-c,--count}'[only show count of matches for each file]'
-  '--color=[whether to use coloring in match]::when:( always never auto )'
+  '--color=[specify when to use colors in output]:when:( never auto always ansi )'
   '(1)*'{-e,--regexp=}'[specify pattern]:pattern'
-  '(-E --encoding)'{-E,--encoding=}'[specify the text encoding of files to search.]:encoding'
-  '(-F --fixed-strings)'{-F,--fixed-strings}'[treat the pattern as a literal string instead of a regular expression]'
+  '(-E --encoding)'{-E,--encoding=}'[specify text encoding of files to search]: :->encoding'
+  '(-F --fixed-strings)'{-F,--fixed-strings}'[treat pattern as literal string instead of regular expression]'
   '*'{-g,--glob=}'[include or exclude files for searching that match the given glob]:glob'
-  '(-h --help)'{-h,--help}'[prints help information]'
-  '(-i -s -S --ignore-case --case-sensitive --smart-case)'{-i,--ignore-case}'[case insensitive search]'
+  '(-h --help)'{-h,--help}'[display help information]'
+  '(-i -s -S --ignore-case --case-sensitive --smart-case)'{-i,--ignore-case}'[search case-insensitively]'
   '(-n -N --line-number --no-line-number)'{-n,--line-number}'[show line numbers]'
   '(-n -N --line-number --no-line-number)'{-N,--no-line-number}'[suppress line numbers]'
-  '(-q --quiet)'{-q,--quiet}'[do not print anything to stdout]'
+  '(-o --only-matching)'{-o,--only-matching}'[show only matching part of each line]'
+  '(-q --quiet)'{-q,--quiet}'[suppress normal output]'
   '(-T --type-not)*'{-t,--type=}'[only search files matching specified type]: :->type'
-  '(-t --type)*'{-T,--type-not=}'[do not search files matching type]: :->type'
-  '*'{-u,--unrestricted}'[reduce the level of "smart" searching]'
+  '(-t --type)*'{-T,--type-not=}"[don't search files matching specified type]: :->type"
+  '*'{-u,--unrestricted}'[reduce level of "smart" searching]'
   '(-v --invert-match)'{-v,--invert-match}'[invert matching]'
   '(-w --word-regexp)'{-w,--word-regexp}'[only show matches surrounded by word boundaries]'
 )
 
 local -a less_common_options
 less_common_options=(
-  '(-A -C --after-context --context)'{-A,--after-context=}'[specify number of lines to show after each match]:number of lines'
-  '(-B -C --before-context --context)'{-B,--before-context=}'[specify number of lines to show before each match]:number of lines'
-  '(-A -B -C --after-context --before-context --context)'{-C,--context=}'[specify number of lines to show before and after each match]:number of lines'
-  '*--colors=[configure color settings and styles]:spec'
-  '--column[show column numbers in output]'
-  '--context-separator=[the string used to separate non-continuous context lines in the output]:separator string'
-  '--debug[show debug message]'
-  '--dfa-size-limit=[the upper size limit of the generated dfa]:size'
-  "--file=[search for patterns from the given file]:file:_files"
-  "--ignore-file=[search additional ignore files]:file:_files"
-  "--files[print each file that would be searched (but don't search)]"
-  '(-l --files-with-matches)'{-l,--files-with-matches}'[only show path of each file with matches]'
-  '(-H --with-filename --no-filename)'{-H,--with-filename}'[prefix each match with the file name that contains it]'
-  '(-H --with-filename)--no-filename[never show the file name for a match]'
-  '(-p --no-heading --pretty --vimgrep)--heading[show the file name above clusters of matches from each file]'
-  "(-p --heading --pretty --vimgrep)--no-heading[don't show any file name heading]"
-  '--hidden[search hidden directories and files]'
+  '(-A -C --after-context --context)'{-A,--after-context=}'[specify lines to show after each match]:number of lines'
+  '(-B -C --before-context --context)'{-B,--before-context=}'[specify lines to show before each match]:number of lines'
+  '(-A -B -C --after-context --before-context --context)'{-C,--context=}'[specify lines to show before and after each match]:number of lines'
+  '*--colors=[specify color settings and styles]: :->colorspec'
+  '--column[show column numbers]'
+  '--context-separator=[specify string used to separate non-continuous context lines in output]:separator string'
+  '--debug[show debug messages]'
+  '--dfa-size-limit=[specify upper size limit of generated DFA]:DFA size'
+  "--file=[specify file containing patterns to search for]:file:_files"
+  "--ignore-file=[specify additional ignore file]:file:_files"
+  "--files[show each file that would be searched (but don't search)]"
+  '(-l --files-with-matches --files-without-match)'{-l,--files-with-matches}'[only show names of files with matches]'
+  '(-l --files-with-matches --files-without-match)--files-without-match[only show names of files without matches]'
+  '(-H --with-filename --no-filename)'{-H,--with-filename}'[prefix each match with name of file that contains it]'
+  '(-H --with-filename --no-filename)--no-filename[suppress all file names]'
+  '(-p --no-heading --pretty --vimgrep)--heading[show matches grouped by file name]'
+  "(-p --heading --pretty --vimgrep)--no-heading[don't group matches by file name]"
+  '--hidden[search hidden files and directories]'
   '(-L --follow)'{-L,--follow}'[follow symlinks]'
-  '(-M --max-columns)'{-M,--max-columns=}"[don't print lines longer than this limit in bytes]:number"
-  '(-m --max-count)'{-m,--max-count=}'[only show count of matches for each file]:number'
-  '--max-filesize=[ignore files larger than NUM in size]:size'
-  '--maxdepth[descend at most N directories below the command line arguments]:depth'
+  '(-M --max-columns)'{-M,--max-columns=}'[specify max length of lines to print]:number of bytes'
+  '(-m --max-count)'{-m,--max-count=}'[specify max number of matches per file]:number of matches'
+  '--max-filesize=[specify size above which files should be ignored]:size'
+  '--maxdepth[specify max number of directories to descend]:number of directories'
   '(--no-mmap)--mmap[search using memory maps when possible]'
   '--no-messages[suppress all error messages]'
-  '(--mmap)--no-mmap[never use memory maps, even when they might be faster]'
+  "(--mmap)--no-mmap[don't search using memory maps]"
   "(--no-ignore-parent)--no-ignore[don't respect ignore files]"
   "--no-ignore-parent[don't respect ignore files in parent directories]"
   "--no-ignore-vcs[don't respect version control ignore files]"
   '(-0 --null)'{-0,--null}'[print NUL byte after file names]'
-  '--path-separator=[path separator to use when printing file paths]'
+  '--path-separator=[specify path separator to use when printing file names]'
   '(-p --heading --no-heading --pretty --vimgrep)'{-p,--pretty}'[alias for --color=always --heading -n]'
-  '--regex-size-limit=[the upper size limit of the compiled regex]:size'
-  '(-r --replace)'{-r,--replace=}'[replace matches with string given]:replace string'
-  '(-i -s -S --ignore-case --case-sensitive --smart-case)'{-s,--case-sensitive}'[search case sensitively]'
-  '(-i -s -S --ignore-case --case-sensitive --smart-case)'{-S,--smart-case}'[search case insensitively if the pattern is all lowercase]'
-  '(-j --threads)'{-j,--threads=}'[the approximate number of threads to use]:number of threads'
-  '(-v --version)'{-V,--version}'[print version information]'
-  '(-p --heading --no-heading --pretty)--vimgrep[show results with every match on its own line, including line numbers and column numbers]'
+  '--regex-size-limit=[specify upper size limit of compiled regex]:regex size'
+  '(-r --replace)'{-r,--replace=}'[specify string used to replace matches]:replace string'
+  '(-i -s -S --ignore-case --case-sensitive --smart-case)'{-s,--case-sensitive}'[search case-sensitively]'
+  '(-i -s -S --ignore-case --case-sensitive --smart-case)'{-S,--smart-case}'[search case-insensitively if the pattern is all lowercase]'
+  '--sort-files[sort results by file path (disables parallelism)]'
+  '(-j --threads)'{-j,--threads=}'[specify approximate number of threads to use]:number of threads'
+  '(-v --version)'{-V,--version}'[display version information]'
+  '(-p --heading --no-heading --pretty)--vimgrep[show results in vim-compatible format]'
 )
 
 local -a file_type_management_options
 file_type_management_options=(
   '--type-list[show all supported file types and their associated globs]'
-  '*--type-add=[add a new glob for a particular file type]:type'
-  '*--type-clear=[clear the file type globs previously defined for specified type]: :->type'
+  '*--type-add=[add new glob for file type]: :->typespec'
+  '*--type-clear=[clear globs previously defined for specified file type]: :->type'
 )
 
 _arguments -S -s : \
@@ -122,11 +125,74 @@ _arguments -S -s : \
   && ret=0
 
 case "$state" in
-  type)
+  colorspec)
+    _values -S ':' 'color/style type' \
+      'column[specify coloring for column numbers]: :->attribute' \
+      'line[specify coloring for line numbers]: :->attribute' \
+      'match[specify coloring for match text]: :->attribute' \
+      'path[specify color for file names]: :->attribute' && ret=0
+
+      [[ "$state" == 'attribute' ]] &&
+      _values -S ':' 'color/style attribute' \
+        'none[clear color/style for type]' \
+        'bg[specify background color]: :->color' \
+        'fg[specify foreground color]: :->color' \
+        'style[specify text style]: :->style' && ret=0
+
+      [[ "$state" == 'color' ]] &&
+      _values -S ':' 'color value' \
+        black blue green red cyan magenta yellow white && ret=0
+
+      [[ "$state" == 'style' ]] &&
+      _values -S ':' 'style value' \
+        bold nobold intense nointense && ret=0
+    ;;
+
+  encoding)
+    # This is impossible to read, but these encodings rarely if ever change, so
+    # it probably doesn't matter. They are derived from the list given here:
+    # https://encoding.spec.whatwg.org/#concept-encoding-get
+    local -U encodings
+    encodings=(
+      {{,us-}ascii,arabic,chinese,cyrillic,greek{,8},hebrew,korean}
+      logical visual mac {,cs}macintosh x-mac-{cyrillic,roman,ukrainian}
+      866 ibm{819,866} csibm866
+      big5{,-hkscs} {cn-,cs}big5 x-x-big5
+      cp{819,866,125{0..8}} x-cp125{0..8}
+      csiso2022{jp,kr} csiso8859{6,8}{e,i}
+      csisolatin{{1..6},9} csisolatin{arabic,cyrillic,greek,hebrew}
+      ecma-{114,118} asmo-708 elot_928 sun_eu_greek
+      euc-{jp,kr} x-euc-jp cseuckr cseucpkdfmtjapanese
+      {,x-}gbk csiso58gb231280 gb18030 {,cs}gb2312 gb_2312{,-80} hz-gb-2312
+      iso-2022-{cn,cn-ext,jp,kr}
+      iso8859{,-}{{1..11},13,14,15}
+      iso-8859-{{1..11},{6,8}-{e,i},13,14,15,16} iso_8859-{{1..9},15}
+      iso_8859-{1,2,6,7}\\:1987 iso_8859-{3,4,5,8}\\:1988 iso_8859-9\\:1989
+      iso-ir-{58,100,101,109,110,126,127,138,144,148,149,157}
+      koi{,8,8-r,8-ru,8-u,8_r} cskoi8r
+      ks_c_5601-{1987,1989} ksc{,_}5691 csksc56011987
+      latin{1..6} l{{1..6},9}
+      shift{-,_}jis csshiftjis {,x-}sjis ms_kanji ms932
+      utf{,-}8 utf-16{,be,le} unicode-1-1-utf-8
+      windows-{31j,874,949,125{0..8}} dos-874 tis-620 ansi_x3.4-1968
+      x-user-defined auto
+    )
+
+    _describe -t encodings 'encoding' encodings && ret=0
+    ;;
+
+  type|typespec)
     local -U types
     types=( ${${(f)"$(_call_program types rg --type-list)"}%%:*} )
 
-    _describe -t types "type" types && ret=0
+    if [[ "$case" == 'type' ]]; then
+      _describe -t types "type" types && ret=0
+    else
+      # @todo: Would be nice to complete type names if an include: directive is
+      # provided here
+      _values -S ':' 'type spec' \
+        ${^types}':glob or include directive' && ret=0
+    fi
     ;;
 esac
 


### PR DESCRIPTION
This change is related to #532, though the actual problem there had already been fixed by the earlier addition of the hand-written completion function. In going over that function i found several issues/limitations which i've corrected:

* Added missing options (most notably `-o`)

* Fixed the confusion between `--count` and `--max-count`

* Improved the consistency of the wording — The previous descriptions had mixed usage of capitalisation, punctuation, contractions, &c., some of them were copied from the `--help` output verbatim, and so on

* Added completion for encodings — I didn't want to include a gigantic list of every single individual encoding, so i compressed them all into a few lines by making use of brace expansion. As i noted in the code, it's *super* hard to read this way, but i doubt that list will be changing any time soon, so i think the brevity is worth it (and you could expand them all by just passing them to `printf '%s\n'`, anyway)

* Added completion for colour specs — Might need revisiting if/when #452 lands

* Added partial completion for type specs — I wanted to make it so that it would complete a list of types if you gave it an `include:` directive, but i ran up against the limits of my knowledge of zsh's completion functions trying to figure out how to do that whilst making it clear that you can provide a glob *or* an `include` directive

I think the structure of this file is kind of weird, honestly — how are future maintainers supposed to intuit which options are 'common'? And is the break-down here even accurate? Is `--encoding` *really* more commonly used than `-m` or `-C`? I highly doubt it.

If i had written it i probably would have just put all of the options in alphabetical order. I was afraid it'd be bad etiquette for me to do that here, though, so i didn't.