### PR TITLE
Add test script to compare `rg --help` output to zsh completion function

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -28,6 +28,8 @@ run_test_suite() {
     cargo build --target $TARGET --verbose --manifest-path termcolor/Cargo.toml
     cargo test --target $TARGET --verbose --manifest-path termcolor/Cargo.toml
 
+    "$( dirname "${0}" )/test_complete.sh"
+
     # sanity check the file type
     file target/$TARGET/debug/rg
 }

--- a/ci/test_complete.sh
+++ b/ci/test_complete.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+# Compares options in `rg --help` output to options in zsh completion function
+
+set -e
+
+main() {
+    local rg="target/${TARGET}/release/rg"
+    local _rg='complete/_rg'
+    local ret='0'
+    local helpTemp="$( mktemp )"
+    local compTemp="$( mktemp )"
+    local diff
+
+    [ -e "${rg}" ] || rg="target/${TARGET}/debug/rg"
+
+    if [ ! -e "${rg}" ]; then
+        printf 'File not found: %s\n' "${rg}" >&2
+        ret='1'
+    elif [ ! -e "${_rg}" ]; then
+        printf 'File not found: %s\n' "${_rg}" >&2
+        ret='1'
+    else
+        # 'Parse' options out of the `--help` output. To prevent false positives
+        # we only look at lines where the first non-white-space character is `-`
+        "${rg}" --help |
+        "${rg}" -- '^\s*-' |
+        "${rg}" -io -- '[\t ,](-[a-z0-9]|--[a-z0-9-]+)\b' |
+        tr -d '\t ,' |
+        sort -u > "${helpTemp}"
+
+        # 'Parse' options out of the completion-function file. To prevent false
+        # negatives, we:
+        #
+        # * Exclude lines that look like comments
+        # * Exclude lines that don't appear to have a bracketed description
+        #   suitable for `_arguments`
+        # * Exclude those bracketed descriptions so we don't match options
+        #   which might be referenced in them
+        # * Exclude parenthetical lists of exclusive options so we don't match
+        #   those
+        #
+        # This does of course make the following assumptions:
+        #
+        # * Each option definition is on its own (single) line
+        # * Each option definition has a description
+        # * Option names are static — i.e., they aren't constructed from
+        #   variables or command substitutions. Brace expansion is OK as long as
+        #   each component of the expression is a complete option flag — in
+        #   other words, `{--foo,--bar}` is valid, but `--{foo,bar}` is not
+        "${rg}" -v -- '^\s*#' "${_rg}" |
+        "${rg}" --replace '$1' -- '^.*?(?:\(.+?\).*?)?(-.+)\[.+\].*' |
+        tr -d "\t (){}*=+:'\"" |
+        tr ',' '\n' |
+        sort -u > "${compTemp}"
+
+        diff="$(
+            if diff --help 2>&1 | grep -qF -- '--label'; then
+                diff -U2 \
+                    --label '`rg --help`' \
+                    --label "${_rg}" \
+                    "${helpTemp}" "${compTemp}" || true
+            else
+                diff -U2 \
+                    -L '`rg --help`' \
+                    -L "${_rg}" \
+                    "${helpTemp}" "${compTemp}" || true
+            fi
+        )"
+
+        [ -n "${diff}" ] && {
+            printf '%s\n' 'zsh completion options differ from `--help` options:' >&2
+            printf '%s\n' "${diff}" >&2
+            ret='1'
+        }
+    fi
+
+    rm -f "${helpTemp}" "${compTemp}"
+
+    return "${ret}"
+}
+
+main "${@}"

--- a/complete/_rg
+++ b/complete/_rg
@@ -75,7 +75,7 @@ less_common_options=(
   '--context-separator=[specify string used to separate non-continuous context lines in output]:separator string'
   '--debug[show debug messages]'
   '--dfa-size-limit=[specify upper size limit of generated DFA]:DFA size'
-  "--file=[specify file containing patterns to search for]:file:_files"
+  '*'{-f,--file=}'[specify file containing patterns to search for]:file:_files'
   "--ignore-file=[specify additional ignore file]:file:_files"
   "--files[show each file that would be searched (but don't search)]"
   '(-l --files-with-matches --files-without-match)'{-l,--files-with-matches}'[only show names of files with matches]'


### PR DESCRIPTION
Per our discussion in #536: Here's something to hopefully prevent the zsh completion function from getting out-of-synch with the actual app.

I used a slightly different strategy from the one i mentioned before, but it's the same basic idea — pull all of the options out of the `--help` output, pull all of the options out of the completion function, compare the two. I tried to address your concerns about false positives/negatives as best i could; i've documented the assumptions i make in the script, and i think it should be OK as long as nobody does anything bizarre.

I've tested this in `dash`, `bash`, and `zsh`. It also works in `ksh93` if you make `local` an alias for `typeset`... but you use `local` in your other scripts so i assume `ksh` compatibility isn't a big concern.

Anyway, it turns out actually that the `-f` option is missing from the completion function, which is fortuitous i guess because it seems to demonstrate that the script behaves as expected! Here's the output:

```
heartswap:ripgrep % ci/test_complete.sh
zsh completion options differ from `--help` options:
--- `rg --help`
+++ complete/_rg
@@ -77,5 +77,4 @@
 -c
 -e
--f
 -g
 -h
```

Unless you have concerns with it i think i'm happy with the script itself. I'm not sure how to go about integrating it with your other tests though. Should i just add it to `appveyor.yml` or does it belong somewhere else?