### PR TITLE
Update `--version` output to show compile-time features

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -50,6 +50,7 @@ pub fn app() -> App<'static, 'static> {
     App::new("ripgrep")
         .author(crate_authors!())
         .version(crate_version!())
+        .long_version(LONG_VERSION.as_str())
         .about(ABOUT)
         .max_term_width(100)
         .setting(AppSettings::UnifiedHelpMessage)
@@ -194,6 +195,24 @@ macro_rules! doc {
 }
 
 lazy_static! {
+    static ref LONG_VERSION: String = {
+        let mut features: Vec<&str> = vec![];
+
+        if cfg!(feature = "avx-accel") {
+            features.push("+avx-accel");
+        } else {
+            features.push("-avx-accel");
+        }
+
+        if cfg!(feature = "simd-accel") {
+            features.push("+simd-accel");
+        } else {
+            features.push("-simd-accel");
+        }
+
+        format!("{}, with features (+/-): {}", crate_version!(), features.join(" "))
+    };
+
     static ref USAGES: HashMap<&'static str, Usage> = {
         let mut h = HashMap::new();
         doc!(h, "help-short",


### PR DESCRIPTION
#524 sounded fun and easy. I only just barely know what i'm doing in Rust though — is this a reasonable way to go about this? I don't think the method will scale elegantly beyond three or four features, but i figured something fancier could quickly be devised if it came to that in the future.

This is the sort of output you get (i don't have Rust nightly so i added a dummy option to test; it's not present in the actual commit of course):

```
heartswap:ripgrep % cargo build -q --release --features 'foo'
heartswap:ripgrep % target/release/rg --version
ripgrep 0.5.2, with features (+/-): +foo -avx-accel -simd-accel
```