### PR TITLE
harmonize ripgrep's -w|--word-regexp with grep's

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -505,7 +505,7 @@ impl<'a> ArgMatches<'a> {
     /// flag is set. Otherwise, the pattern is returned unchanged.
     fn word_pattern(&self, pat: String) -> String {
         if self.is_present("word-regexp") {
-            format!(r"\b(?:{})\b", pat)
+            format!(r"(?:^|\W)(?:{})(?:\W|$)", pat)
         } else {
             pat
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1738,6 +1738,21 @@ fn regression_389_match_words_bounded_by_non_word_characters() {
     assert_eq!(lines, expected);
 }
 
+// See: https://github.com/BurntSushi/ripgrep/issues/389
+#[test]
+fn regression_389_match_multiple_words_bounded_by_non_word_characters() {
+    let wd = WorkDir::new("regression_389_match_multiple_words_bounded_by_non_word_characters");
+    let path = "file.txt";
+    wd.create(path, "foo-bar-bar-baz\n");
+
+    let mut cmd = wd.command();
+    cmd.arg("-w").arg("-o").arg("bar").arg(path);
+    let lines: String = wd.stdout(&mut cmd);
+
+    let expected = "bar\nbar\n";
+    assert_eq!(lines, expected);
+}
+
 #[test]
 fn type_list() {
     let wd = WorkDir::new("type_list");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1723,6 +1723,21 @@ fn regression_506_word_boundaries_not_parenthesized() {
 
 }
 
+// See: https://github.com/BurntSushi/ripgrep/issues/389
+#[test]
+fn regression_389_match_words_bounded_by_non_word_characters() {
+    let wd = WorkDir::new("regression_389_match_words_bounded_by_non_word_characters");
+    let path = "file.txt";
+    wd.create(path, "1 - 2\n");
+
+    let mut cmd = wd.command();
+    cmd.arg("-w").arg("-o").arg("\\- 2").arg(path);
+    let lines: String = wd.stdout(&mut cmd);
+
+    let expected = "- 2\n";
+    assert_eq!(lines, expected);
+}
+
 #[test]
 fn type_list() {
     let wd = WorkDir::new("type_list");


### PR DESCRIPTION
This fixes https://github.com/BurntSushi/ripgrep/issues/389

grep (and git-grep) allow a match using --word-regexp to begin and end with
non-word characters, by surrounding the match with `(^|[^[:alnum:]_])` and
`([^[:alnum:]_]|$)`.

Before this patch ripgrep, by surrounding the match with `\b`, implicitly
required the match to start with a `\w` character, and would fail to match eg.
the ` - 2` in `1 - 2`, which intuitively should be allowed.

This fixes this behavior by surrounding the match with `(?:^|\W)` and
`(?:\W|$)`, using the Unicode non-word character class `\W` rather than the
ASCII character class `[:alnum:]`

I have tested that this combines correctly with `--only-matching`, that is, leading non-word characters are not printed along with the match when that option is used.

I have *not* tested that this combines correctly with `--replace`; however, use of non-capturing matches should ensure that references are numbered correctly.