### PR TITLE
Fix invisible file path text in PowerShell

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -692,7 +692,10 @@ impl<'a> ArgMatches<'a> {
     fn color_specs(&self) -> Result<ColorSpecs> {
         // Start with a default set of color specs.
         let mut specs = vec![
+            #[cfg(unix)]
             "path:fg:magenta".parse().unwrap(),
+            #[cfg(windows)]
+            "path:fg:cyan".parse().unwrap(),
             "line:fg:green".parse().unwrap(),
             "match:fg:red".parse().unwrap(),
             "match:style:bold".parse().unwrap(),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -576,7 +576,7 @@ pub struct ColorSpecs {
 /// Valid colors are `black`, `blue`, `green`, `red`, `cyan`, `magenta`,
 /// `yellow`, `white`.
 ///
-/// Valid style instructions are `nobold` and `bold`.
+/// Valid style instructions are `nobold`, `bold`, `intense`, `nointense`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Spec {
     ty: OutType,


### PR DESCRIPTION
Fix for https://github.com/BurntSushi/ripgrep/issues/342

Root cause is that the standard Windows PowerShell launch shortcut sets the console background color to "dark magenta", then re-defines "dark magenta" as RGB(1, 36, 86) aka "powershell noble blue." Thus if a console app writes output with "dark magenta" foreground color, it will be invisible in a default PowerShell console.

Fix is to do a simple, Windows-only check for a "dark magenta" background at startup, and in this case change path output style to "intense magenta," which will render fine.

Result:

![image](https://user-images.githubusercontent.com/5943573/28249015-2bcd8166-6a03-11e7-9990-c825daa12a0d.png)

Potential concerns:
  - Arg parsing now has to know about Windows console. That's not great but it was simplest path forward for me as a rust n00b.
  - This will add "intense" styling to path output even when user has manually overridden the color themselves. Additional `path:style:nointense` will be needed to counteract this change.
    - Seems not terribly burdensome. By definition this will only affect users who are already comfortable overriding color settings.