### PR TITLE
zsh completion... again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ env:
   global:
     - PROJECT_NAME=ripgrep
     - RUST_BACKTRACE: full
+
+addons:
+  apt:
+    packages:
+      # Needed for completion-function test
+      - zsh
+
 matrix:
   include:
     # Nightly channel.

--- a/ci/test_complete.sh
+++ b/ci/test_complete.sh
@@ -1,91 +1,94 @@
-#!/bin/sh
+#!/usr/bin/env zsh
 
 ##
 # Compares options in `rg --help` output to options in zsh completion function
-#
-# @todo If we could rely on zsh being installed we could change all of this to
-# simply source the completion-function file and pull the rg_args array out...
 
-set -e
+emulate -R zsh
+setopt extended_glob
+setopt no_function_argzero
+setopt no_unset
+
+get_comp_args() {
+    setopt local_options unset
+
+    # Our completion function recognises a special variable which tells it to
+    # dump the _arguments specs and then just return. But do this in a sub-shell
+    # anyway to avoid any weirdness
+    ( _RG_COMPLETE_LIST_ARGS=1 source $1 )
+    return $?
+}
 
 main() {
-    local rg="target/${TARGET}/release/rg"
-    local _rg='complete/_rg'
-    local ret='0'
-    local helpTemp="$( mktemp )"
-    local compTemp="$( mktemp )"
     local diff
+    local  rg="${${0:a}:h}/../target/${TARGET:-}/release/rg"
+    local _rg="${${0:a}:h}/../complete/_rg"
+    local -a help_args comp_args
 
-    [ -e "${rg}" ] || rg="target/${TARGET}/debug/rg"
+    [[ -e $rg ]] || rg=${rg/%\/release\/rg/\/debug\/rg}
 
-    if [ ! -e "${rg}" ]; then
-        printf 'File not found: %s\n' "${rg}" >&2
-        ret='1'
-    elif [ ! -e "${_rg}" ]; then
-        printf 'File not found: %s\n' "${_rg}" >&2
-        ret='1'
-    else
-        # 'Parse' options out of the `--help` output. To prevent false positives
-        # we only look at lines where the first non-white-space character is `-`
-        "${rg}" --help |
-        "${rg}" -- '^\s*-' |
-        "${rg}" -io -- '[\t ,](-[a-z0-9]|--[a-z0-9-]+)\b' |
+    [[ -e $rg ]] || {
+        printf >&2 'File not found: %s\n' $rg
+        return 1
+    }
+    [[ -e $_rg ]] || {
+        printf >&2 'File not found: %s\n' $_rg
+        return 1
+    }
+
+    printf 'Comparing options:\n-%s\n+%s\n' $rg $_rg
+
+    # 'Parse' options out of the `--help` output. To prevent false positives we
+    # only look at lines where the first non-white-space character is `-`
+    help_args=( ${(f)"$(
+        $rg --help |
+        $rg -- '^\s*-' |
+        $rg -io -- '[\t ,](-[a-z0-9]|--[a-z0-9-]+)\b' |
         tr -d '\t ,' |
-        sort -u > "${helpTemp}"
+        sort -u
+    )"} )
 
-        # 'Parse' options out of the completion-function file. To prevent false
-        # negatives, we:
-        #
-        # * Exclude lines that don't start with punctuation expected of option
-        #   definitions
-        # * Exclude lines that don't appear to have a bracketed description
-        #   suitable for `_arguments`
-        # * Exclude those bracketed descriptions so we don't match options
-        #   which might be referenced in them
-        # * Exclude parenthetical lists of exclusive options so we don't match
-        #   those
-        #
-        # This does of course make the following assumptions:
-        #
-        # * Each option definition is on its own (single) line
-        # * Each option definition has a description
-        # * Option names are static — i.e., they aren't constructed from
-        #   variables or command substitutions. Brace expansion is OK as long as
-        #   each component of the expression is a complete option flag — in
-        #   other words, `{--foo,--bar}` is valid, but `--{foo,bar}` is not
-        # * Bracketed descriptions must contain at least two characters and must
-        #   not begin with `!`, `@`, or `^` (in order to avoid confusion with
-        #   shell syntax)
-        "${rg}" -- "^\s*[\"':({*-]" "${_rg}" |
-        "${rg}" --replace '$1' -- '^.*?(?:\(.+?\).*?)?(-.+)\[[^!@^].+\].*' |
-        tr -d "\t (){}*=+:'\"" |
-        tr ',' '\n' |
-        sort -u > "${compTemp}"
+    # 'Parse' options out of the completion function
+    comp_args=( ${(f)"$( get_comp_args $_rg )"} )
 
-        diff="$(
-            if diff --help 2>&1 | grep -qF -- '--label'; then
-                diff -U2 \
-                    --label '`rg --help`' \
-                    --label "${_rg}" \
-                    "${helpTemp}" "${compTemp}" || true
-            else
-                diff -U2 \
-                    -L '`rg --help`' \
-                    -L "${_rg}" \
-                    "${helpTemp}" "${compTemp}" || true
-            fi
-        )"
+    comp_args=( ${comp_args#\(*\)}    ) # Strip excluded options
+    comp_args=( ${comp_args#\*}       ) # Strip repetition indicator
+    comp_args=( ${comp_args%%-[:[]*}  ) # Strip everything after -optname-
+    comp_args=( ${comp_args%%[:+=[]*} ) # Strip everything after other optspecs
+    comp_args=( ${comp_args##[^-]*}   ) # Remove non-options
 
-        [ -n "${diff}" ] && {
-            printf '%s\n' 'zsh completion options differ from `--help` options:' >&2
-            printf '%s\n' "${diff}" >&2
-            ret='1'
-        }
-    fi
+    # This probably isn't necessary, but we should ensure the same order
+    comp_args=( ${(f)"$( printf '%s\n' $comp_args | sort -u )"} )
 
-    rm -f "${helpTemp}" "${compTemp}"
+    (( $#help_args )) || {
+        printf >&2 'Failed to get help_args\n'
+        return 1
+    }
+    (( $#comp_args )) || {
+        printf >&2 'Failed to get comp_args\n'
+        return 1
+    }
 
-    return "${ret}"
+    diff="$(
+        if diff --help 2>&1 | grep -qF -- '--label'; then
+            diff -U2 \
+                --label '`rg --help`' \
+                --label '`_rg`' \
+                =( printf '%s\n' $help_args ) =( printf '%s\n' $comp_args )
+        else
+            diff -U2 \
+                -L '`rg --help`' \
+                -L '`_rg`' \
+                =( printf '%s\n' $help_args ) =( printf '%s\n' $comp_args )
+        fi
+    )"
+
+    (( $#diff )) && {
+        printf >&2 '%s\n' 'zsh completion options differ from `--help` options:'
+        printf >&2 '%s\n' $diff
+        return 1
+    }
+    printf 'OK\n'
+    return 0
 }
 
 main "${@}"

--- a/complete/_rg
+++ b/complete/_rg
@@ -11,32 +11,32 @@
 # Based on code from the zsh-users project — see copyright notice below.
 
 _rg() {
-  local state_descr ret curcontext="${curcontext}"
+  local state_descr ret curcontext="${curcontext:-}"
   local -a context line state
   local -A opt_args val_args
   local -a rg_args
 
   # Sort by long option name to match `rg --help`
   rg_args=(
-    '(-A -C --after-context --context)'{-A,--after-context=}'[specify lines to show after each match]:number of lines'
-    '(-B -C --before-context --context)'{-B,--before-context=}'[specify lines to show before each match]:number of lines'
+    '(-A -C --after-context --context)'{-A+,--after-context=}'[specify lines to show after each match]:number of lines'
+    '(-B -C --before-context --context)'{-B+,--before-context=}'[specify lines to show before each match]:number of lines'
     '(-i -s -S --ignore-case --case-sensitive --smart-case)'{-s,--case-sensitive}'[search case-sensitively]'
     '--color=[specify when to use colors in output]:when:( never auto always ansi )'
     '*--colors=[specify color settings and styles]: :->colorspec'
     '--column[show column numbers]'
-    '(-A -B -C --after-context --before-context --context)'{-C,--context=}'[specify lines to show before and after each match]:number of lines'
+    '(-A -B -C --after-context --before-context --context)'{-C+,--context=}'[specify lines to show before and after each match]:number of lines'
     '--context-separator=[specify string used to separate non-continuous context lines in output]:separator'
     '(-c --count)'{-c,--count}'[only show count of matches for each file]'
     '--debug[show debug messages]'
     '--dfa-size-limit=[specify upper size limit of generated DFA]:DFA size'
-    '(-E --encoding)'{-E,--encoding=}'[specify text encoding of files to search]: :_rg_encodings'
-    '*'{-f,--file=}'[specify file containing patterns to search for]:file:_files'
+    '(-E --encoding)'{-E+,--encoding=}'[specify text encoding of files to search]: :_rg_encodings'
+    '*'{-f+,--file=}'[specify file containing patterns to search for]:file:_files'
     "(1)--files[show each file that would be searched (but don't search)]"
     '(-l --files-with-matches --files-without-match)'{-l,--files-with-matches}'[only show names of files with matches]'
     '(-l --files-with-matches --files-without-match)--files-without-match[only show names of files without matches]'
     '(-F --fixed-strings)'{-F,--fixed-strings}'[treat pattern as literal string instead of regular expression]'
     '(-L --follow)'{-L,--follow}'[follow symlinks]'
-    '*'{-g,--glob=}'[include or exclude files for searching that match the specified glob]:glob'
+    '*'{-g+,--glob=}'[include or exclude files for searching that match the specified glob]:glob'
     '(: -)'{-h,--help}'[display help information]'
     '(-p --no-heading --pretty --vimgrep)--heading[show matches grouped by file name]'
     '--hidden[search hidden files and directories]'
@@ -45,8 +45,8 @@ _rg() {
     '--ignore-file=[specify additional ignore file]:file:_files'
     '(-v --invert-match)'{-v,--invert-match}'[invert matching]'
     '(-n -N --line-number --no-line-number)'{-n,--line-number}'[show line numbers]'
-    '(-M --max-columns)'{-M,--max-columns=}'[specify max length of lines to print]:number of bytes'
-    '(-m --max-count)'{-m,--max-count=}'[specify max number of matches per file]:number of matches'
+    '(-M --max-columns)'{-M+,--max-columns=}'[specify max length of lines to print]:number of bytes'
+    '(-m --max-count)'{-m+,--max-count=}'[specify max number of matches per file]:number of matches'
     '--max-filesize=[specify size above which files should be ignored]:file size'
     '--maxdepth=[specify max number of directories to descend]:number of directories'
     '(--mmap --no-mmap)--mmap[search using memory maps when possible]'
@@ -64,18 +64,18 @@ _rg() {
     '(-p --heading --no-heading --pretty --vimgrep)'{-p,--pretty}'[alias for --color=always --heading -n]'
     '(-q --quiet)'{-q,--quiet}'[suppress normal output]'
     '--regex-size-limit=[specify upper size limit of compiled regex]:regex size'
-    '(1 -f --file)*'{-e,--regexp=}'[specify pattern]:pattern'
-    '(-o --only-matching -r --replace)'{-r,--replace=}'[specify string used to replace matches]:replace string'
+    '(1 -f --file)*'{-e+,--regexp=}'[specify pattern]:pattern'
+    '(-o --only-matching -r --replace)'{-r+,--replace=}'[specify string used to replace matches]:replace string'
     '(-i -s -S --ignore-case --case-sensitive --smart-case)'{-S,--smart-case}'[search case-insensitively if the pattern is all lowercase]'
     '(-j --threads)--sort-files[sort results by file path (disables parallelism)]'
     '(-a --text)'{-a,--text}'[search binary files as if they were text]'
-    '(-j --sort-files --threads)'{-j,--threads=}'[specify approximate number of threads to use]:number of threads'
-    '*'{-t,--type=}'[only search files matching specified type]: :_rg_types'
+    '(-j --sort-files --threads)'{-j+,--threads=}'[specify approximate number of threads to use]:number of threads'
+    '*'{-t+,--type=}'[only search files matching specified type]: :_rg_types'
     '*--type-add=[add new glob for file type]: :->typespec'
     '*--type-clear=[clear globs previously defined for specified file type]: :_rg_types'
     # This should actually be exclusive with everything but other type options
     '(:)--type-list[show all supported file types and their associated globs]'
-    '*'{-T,--type-not=}"[don't search files matching specified type]: :_rg_types"
+    '*'{-T+,--type-not=}"[don't search files matching specified type]: :_rg_types"
     '*'{-u,--unrestricted}'[reduce level of "smart" searching]'
     '(: -)'{-V,--version}'[display version information]'
     '(-p --heading --no-heading --pretty)--vimgrep[show results in vim-compatible format]'
@@ -84,6 +84,11 @@ _rg() {
     '(-e -f --file --files --regexp --type-list)1: :_rg_pattern'
     '(--type-list)*:file:_files'
   )
+
+  [[ ${_RG_COMPLETE_LIST_ARGS:-} == (1|t*|y*) ]] && {
+    printf '%s\n' "${rg_args[@]}"
+    return 0
+  }
 
   _arguments -s -S : "${rg_args[@]}" && return 0
 


### PR DESCRIPTION
Sorry for PR spam, found another issue with this. :/

I hadn't noticed that the old completion function didn't support completing values without a space after short options — doing something like `rg -C3 <tab>` instead of `rg -C 3 <tab>` would break the completion.

I fixed that. And, as discussed last time, i updated the test stuff so that it just pulls the optspecs straight out of the function. That should make the 'parsing' a lot more reliable (at the expense of requiring zsh for the test, obv).

Not sure if i put the zsh-installation stuff in the right place, guess we'll see what it says...