### PR TITLE
Remove unused libc dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,6 @@ dependencies = [
  "grep 0.1.6",
  "ignore 0.2.2",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ env_logger = { version = "0.4", default-features = false }
 grep = { version = "0.1.5", path = "grep" }
 ignore = { version = "0.2.2", path = "ignore" }
 lazy_static = "0.2"
-libc = "0.2"
 log = "0.3"
 memchr = "1"
 memmap = "0.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ extern crate grep;
 extern crate ignore;
 #[macro_use]
 extern crate lazy_static;
-extern crate libc;
 #[macro_use]
 extern crate log;
 extern crate memchr;


### PR DESCRIPTION
I was just having a quick look at the code and realised that you were depending on `libc` but not using it anywhere, so I removed the dependency. The effect on the benchmarks is still yet to be seen.