### PR TITLE
Do not use mmap by default.

### DIFF
--- a/doc/rg.1.md
+++ b/doc/rg.1.md
@@ -226,15 +226,12 @@ Project home page: https://github.com/BurntSushi/ripgrep
   A value of zero searches only the starting-points themselves.
 
 --mmap
-: Search using memory maps when possible. This is enabled by default
-  when ripgrep thinks it will be faster. (Note that mmap searching
-  doesn't currently support the various context related options.)
+: Search using memory maps when possible. This is disabled by default
+  because mmap on files that can be truncated is unsafe. (Note that mmap
+  searching doesn't currently support the various context related options.)
 
 --no-messages
 : Suppress all error messages.
-
---no-mmap
-: Never use memory maps, even when they might be faster.
 
 --no-ignore
 : Don't respect ignore files (.gitignore, .ignore, etc.)

--- a/src/app.rs
+++ b/src/app.rs
@@ -445,11 +445,11 @@ lazy_static! {
               direct children of dir/.");
         doc!(h, "mmap",
              "Searching using memory maps when possible.",
-             "Search using memory maps when possible. This is enabled by \
-              default when ripgrep thinks it will be faster. Note that memory \
-              map searching doesn't currently support all options, so if an \
-              incompatible option (e.g., --context) is given with --mmap, \
-              then memory maps will not be used.");
+             "Search using memory maps when possible. This is disabled by \
+              default because mmap on files that can be truncated is unsafe. \
+              Note that memory map searching doesn't currently support all \
+              options, so if an incompatible option (e.g., --context) is given \
+              with --mmap, then memory maps will not be used.");
         doc!(h, "no-messages",
              "Suppress all error messages.",
              "Suppress all error messages. This is equivalent to redirecting \

--- a/src/args.rs
+++ b/src/args.rs
@@ -582,17 +582,8 @@ impl<'a> ArgMatches<'a> {
             false
         } else if self.is_present("mmap") {
             true
-        } else if cfg!(target_os = "macos") {
-            // On Mac, memory maps appear to suck. Neat.
-            false
-        } else if enc.is_some() {
-            // There's no practical way to transcode a memory map that isn't
-            // isomorphic to searching over io::Read.
-            false
         } else {
-            // If we're only searching a few paths and all of them are
-            // files, then memory maps are probably faster.
-            paths.len() <= 10 && paths.iter().all(|p| p.is_file())
+            false
         })
     }
 


### PR DESCRIPTION
Reading memory-mapped files is inherently insecure because no safe
mechanism exists to prevent out-of-bounds reads if the file gets
truncated. The POSIX standard says “An implementation may deliver
SIGBUS signals when a reference would cause an error in the mapped
object, such as out-of-space condition.” so it seems safer to disable
mmap by default.

The bug is simply triggered using this command:

    # dd of=zob count=0 seek=16G; (sleep 0.1; truncate -s1 zob)&; rg -a lol zob
    [2]    15028 bus error  rg -a lol zob