### PR TITLE
ignore: document git_global enabled by default

### DIFF
--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -610,6 +610,8 @@ impl WalkBuilder {
     /// does not exist or does not specify `core.excludesFile`, then
     /// `$XDG_CONFIG_HOME/git/ignore` is read. If `$XDG_CONFIG_HOME` is not
     /// set or is empty, then `$HOME/.config/git/ignore` is used instead.
+    ///
+    /// This is enabled by default.
     pub fn git_global(&mut self, yes: bool) -> &mut WalkBuilder {
         self.ig_builder.git_global(yes);
         self


### PR DESCRIPTION
This function doesn't say it's enabled by default, but it looks like it is, based on my reading of `dir.rs`: https://github.com/BurntSushi/ripgrep/blob/30608f2444a2abc7aae8e7b96cd5cff4f98bfe71/ignore/src/dir.rs#L429-L435