### PR TITLE
restore the default SIGPIPE behavior as a temporary workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "grep 0.1.6",
  "ignore 0.2.2",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ env_logger = { version = "0.4", default-features = false }
 grep = { version = "0.1.5", path = "grep" }
 ignore = { version = "0.2.2", path = "ignore" }
 lazy_static = "0.2"
+libc = "0.2"
 log = "0.3"
 memchr = "1"
 memmap = "0.5"


### PR DESCRIPTION
See https://github.com/BurntSushi/ripgrep/issues/200.

This is a Unix-only workaround, until the larger refactoring mentioned in that issue is done. I'm not sure what our current behavior is on Windows, but this should't change it in any case. Are there any cases where rg has side effects, where a sudden termination like this might not be a good idea?