### PR TITLE
ignore: add grouped defaults toggle

### DIFF
--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -571,6 +571,29 @@ impl WalkBuilder {
         self
     }
 
+    /// Enables all the standard ignore filters.
+    /// 
+    /// This toggles, as a group, all the filters that are enabled by default:
+    /// 
+    /// - [hidden()](#method.hidden)
+    /// - [parents()](#method.parents)
+    /// - [ignore()](#method.ignore)
+    /// - [git_ignore()](#method.git_ignore)
+    /// - [git_global()](#method.git_global)
+    /// - [git_exclude()](#method.git_exclude)
+    /// 
+    /// They may still be toggled individually after calling this function.
+    ///
+    /// This is (by definition) enabled by default.
+    pub fn standard_filters(&mut self, yes: bool) -> &mut WalkBuilder {
+        self.hidden(yes)
+            .parents(yes)
+            .ignore(yes)
+            .git_ignore(yes)
+            .git_global(yes)
+            .git_exclude(yes)
+    }
+
     /// Enables ignoring hidden files.
     ///
     /// This is enabled by default.


### PR DESCRIPTION
Adds a single function to toggle all the enabled-by-default options on `WalkBuilder`. I implemented this for [my crate](https://github.com/haptics-nri/bible-extractor/blob/76769934d69c6cd9857884e91e30eb2f6370973a/src/main.rs#L98) because I wanted a parallel directory iterator but I don't actually need the fancy ignore stuff. Feel free to reject if that isn't an intended use case.