### PR TITLE
Add Elm file type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -125,6 +125,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("d", &["*.d"]),
     ("elisp", &["*.el"]),
     ("elixir", &["*.ex", "*.eex", "*.exs"]),
+    ("elm", &["*.elm"]),
     ("erlang", &["*.erl", "*.hrl"]),
     ("fish", &["*.fish"]),
     ("fortran", &[


### PR DESCRIPTION
Simply adds a file type filter for [Elm](elm-lang.org/).