### PR TITLE
Allow -o, --only-matching work together with -r, --replace

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -162,7 +162,7 @@ pub fn app() -> App<'static, 'static> {
         .arg(flag("no-ignore-parent"))
         .arg(flag("no-ignore-vcs"))
         .arg(flag("null").short("0"))
-        .arg(flag("only-matching").short("o").conflicts_with("replace"))
+        .arg(flag("only-matching").short("o"))
         .arg(flag("path-separator").value_name("SEPARATOR").takes_value(true))
         .arg(flag("pretty").short("p"))
         .arg(flag("replace").short("r")

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -286,7 +286,12 @@ impl<W: WriteColor> Printer<W> {
             let line = {
                 let replacer = CountingReplacer::new(
                     self.replace.as_ref().unwrap(), &mut count);
-                re.replace_all(&buf[start..end], replacer)
+                if self.only_matching {
+                    re.replace_all(
+                        &buf[start + match_start..start + match_end], replacer)
+                } else {
+                    re.replace_all(&buf[start..end], replacer)
+                }
             };
             if self.max_columns.map_or(false, |m| line.len() > m) {
                 let msg = format!(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -266,6 +266,20 @@ but Watson, Doctor has to have it taken out for him and dusted,
     assert_eq!(lines, expected);
 });
 
+sherlock!(replace_with_only_matching, "of (\\w+)",
+|wd: WorkDir, mut cmd: Command| {
+    cmd.arg("-o").arg("-r").arg("$1");
+    let lines: String = wd.stdout(&mut cmd);
+    let expected = "\
+this
+detective
+luck
+straw
+cigar
+";
+    assert_eq!(lines, expected);
+});
+
 sherlock!(file_types, "Sherlock", ".", |wd: WorkDir, mut cmd: Command| {
     wd.create("file.py", "Sherlock");
     wd.create("file.rs", "Sherlock");


### PR DESCRIPTION
Hello!

Thank you for your amazing work on much-needed and super-fast fully-featured regex search utility which is `ripgrep`.

However I’ve been missing a bit a feature similar to _ack’s_ helpful `--output` which allows printing only certain capture groups. That feature is discussed in https://github.com/BurntSushi/ripgrep/issues/320 and the discussion offers a solution. However it requires matching an entire line, which still might seem a bit less straightforward for some users.

Now, there is probably a reason why `-o` is made to conflict with `-r` so please excuse me if this PR is really out-of-place. However after implementing it, upon superficial gaze, things seem to be working fine:
<details>
<summary>
Examples outputs
</summary>

#### ripgrep
```bash
$ ./target/debug/rg 'of (\w+)' -Nor '$1' ./tests/hay.rs 
this
detective
luck
straw
cigar
```

#### ack
```bash
$ ack 'of (\w+)' --output '$1' ./tests/hay.rs 
this
detective
luck
straw
cigar
```
</details>

####

So I hope this has a chance of being considered. Thank you again!