### PR TITLE
Add support for Dockerfiles filtering

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -123,6 +123,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("cython", &["*.pyx"]),
     ("dart", &["*.dart"]),
     ("d", &["*.d"]),
+    ("docker", &["*Dockerfile*"]),
     ("elisp", &["*.el"]),
     ("elixir", &["*.ex", "*.eex", "*.exs"]),
     ("elm", &["*.elm"]),


### PR DESCRIPTION
I think this covers most usecases i.e: `Dockerfile.blah` and `blah.Dockerfile`