### PR TITLE
globset README version bump

### DIFF
--- a/globset/README.md
+++ b/globset/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-globset = "0.1"
+globset = "0.2"
 ```
 
 and this to your crate root:


### PR DESCRIPTION
The version number in globset's README is slightly behind the published version.

(I just used the GitHub editor; this isn't tested or anything)