### PR TITLE
Add purescript to built-in types

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -206,6 +206,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("php", &["*.php", "*.php3", "*.php4", "*.php5", "*.phtml"]),
     ("pod", &["*.pod"]),
     ("ps", &["*.cdxml", "*.ps1", "*.ps1xml", "*.psd1", "*.psm1"]),
+    ("purs", &["*.purs"]),
     ("py", &["*.py"]),
     ("qmake", &["*.pro", "*.pri", "*.prf"]),
     ("readme", &["README*", "*README"]),


### PR DESCRIPTION
Purescript is a functional language that compiles to javascript (https://github.com/purescript/purescript)