### PR TITLE
Skip regression 210 test on APFS

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1014,10 +1014,10 @@ fn regression_210() {
     let badutf8 = OsStr::from_bytes(&b"foo\xffbar"[..]);
 
     let wd = WorkDir::new("regression_210");
-    let mut cmd = wd.command();
     // APFS does not support creating files with invalid UTF-8 bytes.
     // https://github.com/BurntSushi/ripgrep/issues/559
     if wd.try_create(badutf8, "test").is_ok() {
+        let mut cmd = wd.command();
         cmd.arg("-H").arg("test").arg(badutf8);
 
         let out = wd.output(&mut cmd);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1015,11 +1015,14 @@ fn regression_210() {
 
     let wd = WorkDir::new("regression_210");
     let mut cmd = wd.command();
-    wd.create(badutf8, "test");
-    cmd.arg("-H").arg("test").arg(badutf8);
+    // APFS does not support creating files with invalid UTF-8 bytes.
+    // https://github.com/BurntSushi/ripgrep/issues/559
+    if wd.try_create(badutf8, "test").is_ok() {
+        cmd.arg("-H").arg("test").arg(badutf8);
 
-    let out = wd.output(&mut cmd);
-    assert_eq!(out.stdout, b"foo\xffbar:test\n".to_vec());
+        let out = wd.output(&mut cmd);
+        assert_eq!(out.stdout, b"foo\xffbar:test\n".to_vec());
+    }
 }
 
 // See: https://github.com/BurntSushi/ripgrep/issues/228

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -50,7 +50,8 @@ impl WorkDir {
     /// Try to create a new file with the given name and contents in this
     /// directory.
     pub fn try_create<P: AsRef<Path>>(&self, name: P, contents: &str) -> io::Result<()> {
-        self.try_create_bytes(name, contents.as_bytes())
+        let path = self.dir.join(name);
+        self.try_create_bytes(path, contents.as_bytes())
     }
 
     /// Create a new file with the given name and size.

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -41,12 +41,14 @@ impl WorkDir {
         }
     }
 
-    /// Create a new file with the given name and contents in this directory, or panic on error.
+    /// Create a new file with the given name and contents in this directory,
+    /// or panic on error.
     pub fn create<P: AsRef<Path>>(&self, name: P, contents: &str) {
         self.create_bytes(name, contents.as_bytes());
     }
 
-    /// Try to create a new file with the given name and contents in this directory.
+    /// Try to create a new file with the given name and contents in this
+    /// directory.
     pub fn try_create<P: AsRef<Path>>(&self, name: P, contents: &str) -> io::Result<()> {
         self.try_create_bytes(name, contents.as_bytes())
     }
@@ -58,13 +60,15 @@ impl WorkDir {
         nice_err(&path, file.set_len(filesize));
     }
 
-    /// Create a new file with the given name and contents in this directory, or panic on error.
+    /// Create a new file with the given name and contents in this directory,
+    /// or panic on error.
     pub fn create_bytes<P: AsRef<Path>>(&self, name: P, contents: &[u8]) {
         let path = self.dir.join(name);
         nice_err(&path, self.try_create_bytes(&path, contents));
     }
 
-    /// Try to create a new file with the given name and contents in this directory.
+    /// Try to create a new file with the given name and contents in this
+    /// directory.
     fn try_create_bytes<P: AsRef<Path>>(&self, path: P, contents: &[u8]) -> io::Result<()> {
         let mut file = File::create(&path)?;
         file.write_all(contents)?;


### PR DESCRIPTION
APFS does not support creating filenames with invalid UTF-8 byte codes,
thus this test doesn't make sense. Skip it on file systems where this
shouldn't be possible.

Fixes #559