### PR TITLE
Solving extra blank line error #441

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -2,6 +2,7 @@ use std::error;
 use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
+use std::io::BufRead;
 
 use regex::bytes::{Captures, Match, Regex, Replacer};
 use termcolor::{Color, ColorSpec, ParseColorError, WriteColor};
@@ -305,6 +306,9 @@ impl<W: WriteColor> Printer<W> {
             self.write_path_sep(b':');
         }
         if let Some(line_number) = line_number {
+            if line_number > buf.lines().count() as u64 {
+                return;
+            }
             self.line_number(line_number, b':');
         }
         if self.column {


### PR DESCRIPTION
Hi guys taking a stab at #441 

There are 3 tests that are failing:
* search_stream::tests::after_context_invert_one1
* search_stream::tests::before_context_invert_one1
* search_stream::tests::invert_match_line_numbers

This has to do with the way the tests are passed, since a command line test produces the correct assertion: 
```
> ../target/debug/rg 'Sherlock' -v -C 1 ./sherlock 
1-For the Doctor Watsons of this world, as opposed to the Sherlock
2:Holmeses, success in the province of detective work must always
3-be, to a very large extent, the result of luck. Sherlock Holmes
4:can extract a clew from a wisp of straw or a flake of cigar ash;
5:but Doctor Watson has to have it taken out for him and dusted,
6:and exhibited clearly, with a label attached.
```