### PR TITLE
add notebook file extensions to types

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -148,6 +148,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("json", &["*.json", "composer.lock"]),
     ("jsonl", &["*.jsonl"]),
     ("julia", &["*.jl"]),
+    ("jupyter", &["*.ipynb", "*.jpynb"]),
     ("jl", &["*.jl"]),
     ("kotlin", &["*.kt", "*.kts"]),
     ("less", &["*.less"]),
@@ -195,7 +196,6 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("msbuild", &[
         "*.csproj", "*.fsproj", "*.vcxproj", "*.proj", "*.props", "*.targets"
     ]),
-    ("nb", &["*.ipynb", "*.jpynb"]),
     ("nim", &["*.nim"]),
     ("nix", &["*.nix"]),
     ("objc", &["*.h", "*.m"]),

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -195,6 +195,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("msbuild", &[
         "*.csproj", "*.fsproj", "*.vcxproj", "*.proj", "*.props", "*.targets"
     ]),
+    ("nb", &["*.ipynb", "*.jpynb"]),
     ("nim", &["*.nim"]),
     ("nix", &["*.nix"]),
     ("objc", &["*.h", "*.m"]),


### PR DESCRIPTION
This PR adds Jupyter notebook file extensions (`.ipynb`/`.jpynb`) to the type list. 

Some context: Notebooks are widely used in the scientific computing world. Under-the-hood are json files that are a bit unwieldy (understatement) to look at when printed to the command line. 

I used the `nb` key for notebook, but am happy to change it if that is preferred.