### PR TITLE
Add Protocol Buffer file type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -205,6 +205,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("pdf", &["*.pdf"]),
     ("php", &["*.php", "*.php3", "*.php4", "*.php5", "*.phtml"]),
     ("pod", &["*.pod"]),
+    ("protobuf", &["*.proto"]),
     ("ps", &["*.cdxml", "*.ps1", "*.ps1xml", "*.psd1", "*.psm1"]),
     ("purs", &["*.purs"]),
     ("py", &["*.py"]),


### PR DESCRIPTION
Simply adds a file type filter for [Protocol Buffers](https://developers.google.com/protocol-buffers/).