### PR TITLE
Bump Cargo.toml version in Ignore's ReadMe.md from 0.2 to 0.3

### DIFF
--- a/ignore/README.md
+++ b/ignore/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ignore = "0.2"
+ignore = "0.3"
 ```
 
 and this to your crate root:


### PR DESCRIPTION
Small thing; I noticed a discrepancy between the released version and documented.