### PR TITLE
Omit context separators when using a contextless option like -c or -l

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -153,14 +153,16 @@ impl Args {
 
     /// Retrieve the configured file separator.
     pub fn file_separator(&self) -> Option<Vec<u8>> {
-        let use_heading_sep =
-            self.heading
-            && !self.count
-            && !self.files_with_matches
-            && !self.files_without_matches;
+        let contextless =
+            self.count
+            || self.files_with_matches
+            || self.files_without_matches;
+        let use_heading_sep = self.heading && !contextless;
+
         if use_heading_sep {
             Some(b"".to_vec())
-        } else if self.before_context > 0 || self.after_context > 0 {
+        } else if !contextless
+            && (self.before_context > 0 || self.after_context > 0) {
             Some(self.context_separator.clone())
         } else {
             None

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1799,6 +1799,25 @@ fn regression_568_leading_hyphen_option_arguments() {
     assert_eq!(lines, "foo -n -baz\n");
 }
 
+// See: https://github.com/BurntSushi/ripgrep/issues/693
+#[test]
+fn regression_693_context_option_in_contextless_mode() {
+    let wd = WorkDir::new("regression_693_context_option_in_contextless_mode");
+
+    wd.create("foo", "xyz\n");
+    wd.create("bar", "xyz\n");
+
+    let mut cmd = wd.command();
+    cmd.arg("-C1").arg("-c").arg("--sort-files").arg("xyz");
+
+    let lines: String = wd.stdout(&mut cmd);
+    let expected = "\
+bar:1
+foo:1
+";
+    assert_eq!(lines, expected);
+}
+
 #[test]
 fn type_list() {
     let wd = WorkDir::new("type_list");


### PR DESCRIPTION
Fixes #693.

When `rg` has been placed in a 'contextless mode' by the use of `--count`, `--files-with-matches`, or `--files-without-match`, it should omit the context separator even if given a context option like `-A` or `-C`. This matches how (e.g.) `grep` behaves.

Before:
```
% \rg -cC1 context.separator
complete/_rg:1
--
doc/rg.1.md:1
--
src/app.rs:3
--
src/printer.rs:9
--
src/args.rs:7
```

After:
```
% target/release/rg -cC1 context.separator
complete/_rg:1
doc/rg.1.md:1
src/app.rs:3
src/args.rs:7
src/printer.rs:9
```