### PR TITLE
Support ignore files with custom names

### DIFF
--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -633,8 +633,8 @@ impl WalkBuilder {
     }
 
     /// Enables reading of ignore files with custom names
-    pub fn ignorefile(&mut self, filename: String) -> &mut WalkBuilder {
-        self.ig_builder.ignorefile(String::from(filename));
+    pub fn ignorefile<S: AsRef<OsStr>>(&mut self, filename: S) -> &mut WalkBuilder {
+        self.ig_builder.ignorefile(filename);
         self
     }
 

--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -557,6 +557,20 @@ impl WalkBuilder {
         errs.into_error_option()
     }
 
+    /// Add a custom ignore file name
+    ///
+    /// These ignore files have higher precedence than all other ignore files.
+    ///
+    /// When specifying multiple names, earlier names have lower precedence than
+    /// later names.
+    pub fn add_custom_ignore_filename<S: AsRef<OsStr>>(
+        &mut self,
+        file_name: S
+    ) -> &mut WalkBuilder {
+        self.ig_builder.add_custom_ignore_filename(file_name);
+        self
+    }
+
     /// Add an override matcher.
     ///
     /// By default, no override matcher is used.
@@ -629,12 +643,6 @@ impl WalkBuilder {
     /// This is enabled by default.
     pub fn ignore(&mut self, yes: bool) -> &mut WalkBuilder {
         self.ig_builder.ignore(yes);
-        self
-    }
-
-    /// Enables reading of ignore files with custom names
-    pub fn ignorefile<S: AsRef<OsStr>>(&mut self, filename: S) -> &mut WalkBuilder {
-        self.ig_builder.ignorefile(filename);
         self
     }
 

--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -538,7 +538,7 @@ impl WalkBuilder {
         self
     }
 
-    /// Add an ignore file to the matcher.
+    /// Add a global ignore file to the matcher.
     ///
     /// This has lower precedence than all other sources of ignore rules.
     ///
@@ -629,6 +629,12 @@ impl WalkBuilder {
     /// This is enabled by default.
     pub fn ignore(&mut self, yes: bool) -> &mut WalkBuilder {
         self.ig_builder.ignore(yes);
+        self
+    }
+
+    /// Enables reading of ignore files with custom names
+    pub fn ignorefile(&mut self, filename: String) -> &mut WalkBuilder {
+        self.ig_builder.ignorefile(String::from(filename));
         self
     }
 

--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -1491,6 +1491,22 @@ mod tests {
     }
 
     #[test]
+    fn custom_ignore() {
+        let td = TempDir::new("walk-test-").unwrap();
+        let custom_ignore = ".customignore";
+        mkdirp(td.path().join("a"));
+        wfile(td.path().join(custom_ignore), "foo");
+        wfile(td.path().join("foo"), "");
+        wfile(td.path().join("a/foo"), "");
+        wfile(td.path().join("bar"), "");
+        wfile(td.path().join("a/bar"), "");
+
+        let mut builder = WalkBuilder::new(td.path());
+        builder.add_custom_ignore_filename(&custom_ignore);
+        assert_paths(td.path(), &builder, &["bar", "a", "a/bar"]);
+    }
+
+    #[test]
     fn gitignore() {
         let td = TempDir::new("walk-test-").unwrap();
         mkdirp(td.path().join("a"));

--- a/src/args.rs
+++ b/src/args.rs
@@ -287,7 +287,7 @@ impl Args {
         wd.git_exclude(!self.no_ignore && !self.no_ignore_vcs);
         wd.ignore(!self.no_ignore);
         if !self.no_ignore {
-            wd.ignorefile(".rgignore");
+            wd.add_custom_ignore_filename(".rgignore");
         }
         wd.parents(!self.no_ignore_parent);
         wd.threads(self.threads());

--- a/src/args.rs
+++ b/src/args.rs
@@ -287,7 +287,7 @@ impl Args {
         wd.git_exclude(!self.no_ignore && !self.no_ignore_vcs);
         wd.ignore(!self.no_ignore);
         if !self.no_ignore {
-            wd.ignorefile(String::from(".rgignore"));
+            wd.ignorefile(".rgignore");
         }
         wd.parents(!self.no_ignore_parent);
         wd.threads(self.threads());

--- a/src/args.rs
+++ b/src/args.rs
@@ -286,6 +286,9 @@ impl Args {
         wd.git_ignore(!self.no_ignore && !self.no_ignore_vcs);
         wd.git_exclude(!self.no_ignore && !self.no_ignore_vcs);
         wd.ignore(!self.no_ignore);
+        if !self.no_ignore {
+            wd.ignorefile(String::from(".rgignore"));
+        }
         wd.parents(!self.no_ignore_parent);
         wd.threads(self.threads());
         if self.sort_files {


### PR DESCRIPTION
This allows for application specific ignorefile names, e.g. using
`.fdignore` for `fd`.

- Moved the hardcoded `.rgignore` from the ignore crate to ripgrep

- `.ignore` is always respected and has the highest precedence