### PR TITLE
Add an `only-capture` flag for printing only the text in the specified capture group

### DIFF
--- a/doc/rg.1.md
+++ b/doc/rg.1.md
@@ -272,6 +272,9 @@ Project home page: https://github.com/BurntSushi/ripgrep
 : Print only the matched (non-empty) parts of a matching line, with each such
   part on a separate output line.
 
+--only-capture *NUM*
+: Print only capture group NUM.  Implies --only-matching.
+
 --path-separator *SEPARATOR*
 : The path separator to use when printing file paths. This defaults to your
   platform's path separator, which is / on Unix and \\ on Windows. This flag is

--- a/src/app.rs
+++ b/src/app.rs
@@ -163,6 +163,11 @@ pub fn app() -> App<'static, 'static> {
         .arg(flag("no-ignore-vcs"))
         .arg(flag("null").short("0"))
         .arg(flag("only-matching").short("o"))
+        .arg(flag("only-capture")
+             .short("O")
+             .value_name("NUM")
+             .takes_value(true)
+             .validator(validate_number))
         .arg(flag("path-separator").value_name("SEPARATOR").takes_value(true))
         .arg(flag("pretty").short("p"))
         .arg(flag("replace").short("r")
@@ -487,6 +492,8 @@ lazy_static! {
              "Print only matched parts of a line.",
              "Print only the matched (non-empty) parts of a matching line, \
               with each such part on a separate output line.");
+        doc!(h, "only-capture",
+             "Print only capture group NUM.  Implies --only-matching.");
         doc!(h, "path-separator",
              "Path separator to use when printing file paths.",
              "The path separator to use when printing file paths. This \

--- a/src/args.rs
+++ b/src/args.rs
@@ -65,6 +65,7 @@ pub struct Args {
     no_messages: bool,
     null: bool,
     only_matching: bool,
+    only_capture: usize,
     path_separator: Option<u8>,
     quiet: bool,
     quiet_matched: QuietMatched,
@@ -142,6 +143,7 @@ impl Args {
             .line_per_match(self.line_per_match)
             .null(self.null)
             .only_matching(self.only_matching)
+            .only_capture(self.only_capture)
             .path_separator(self.path_separator)
             .with_filename(self.with_filename)
             .max_columns(self.max_columns);
@@ -347,7 +349,8 @@ impl<'a> ArgMatches<'a> {
             no_ignore_vcs: self.no_ignore_vcs(),
             no_messages: self.is_present("no-messages"),
             null: self.is_present("null"),
-            only_matching: self.is_present("only-matching"),
+            only_matching: self.is_present("only-matching") || self.is_present("only-capture"),
+            only_capture: try!(self.usize_of("only-capture")).unwrap_or(0),
             path_separator: try!(self.path_separator()),
             quiet: quiet,
             quiet_matched: QuietMatched::new(quiet),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1828,3 +1828,21 @@ fn type_list() {
     // This can change over time, so just make sure we print something.
     assert!(!lines.is_empty());
 }
+
+#[test]
+fn only_capture() {
+    let wd = WorkDir::new("only_capture");
+    let path = "prices.csv";
+    wd.create(path, "banana,10\nstrawberry,5");
+
+    let mut cmd = wd.command();
+    cmd.arg("([^,]*),(\\d+)").arg(path).arg("--only-capture").arg("2");
+    let lines: String = wd.stdout(&mut cmd);
+
+    let expected = "\
+10
+5
+";
+
+    assert_eq!(lines, expected);
+}


### PR DESCRIPTION
This is the first Rust code I've ever written so I apologize in advance if it's horrible.

This option implies `--only-matching`, and will result in only the given capture group (specified by its number) being printed.

I often find myself wanting this functionality in `rg`/`ag`/`ack`... I can imitate *some* use-cases with look-behinds/look-aheads, but not all. (Look-aheads and look-behinds need to be fixed-length, in particular.)