### PR TITLE
Add armhf build to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,16 @@ matrix:
     - os: osx
       rust: nightly
       env: TARGET=x86_64-apple-darwin
+    - os: linux
+      rust: nightly
+      env: TARGET=arm-unknown-linux-gnueabihf GCC_VERSION=4.8
+      addons:
+        apt:
+          packages:
+          - gcc-4.8-arm-linux-gnueabihf
+          - binutils-arm-linux-gnueabihf
+          - libc6-armhf-cross
+          - libc6-dev-armhf-cross
     # Beta channel.
     - os: linux
       rust: beta
@@ -39,6 +49,16 @@ matrix:
     - os: linux
       rust: 1.17.0
       env: TARGET=x86_64-unknown-linux-musl
+    - os: linux
+      rust: 1.17.0
+      env: TARGET=arm-unknown-linux-gnueabihf GCC_VERSION=4.8
+      addons:
+        apt:
+          packages:
+          - gcc-4.8-arm-linux-gnueabihf
+          - binutils-arm-linux-gnueabihf
+          - libc6-armhf-cross
+          - libc6-dev-armhf-cross
 
 before_install:
   - export PATH="$PATH:$HOME/.cargo/bin"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -31,16 +31,19 @@ install_standard_crates() {
 
 configure_cargo() {
     local prefix=$(gcc_prefix)
+    if [ -n "${prefix}" ]; then
+        local gcc_suffix=
+        test -n "${GCC_VERSION}" && gcc_suffix="-${GCC_VERSION}" || :
+        local gcc="${prefix}gcc${gcc_suffix}"
 
-    if [ ! -z $prefix ]; then
         # information about the cross compiler
-        ${prefix}gcc -v
+        ${gcc} -v
 
         # tell cargo which linker to use for cross compilation
         mkdir -p .cargo
         cat >>.cargo/config <<EOF
 [target.$TARGET]
-linker = "${prefix}gcc"
+linker = "${gcc}"
 EOF
     fi
 }

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,6 +4,9 @@ set -ex
 
 . $(dirname $0)/utils.sh
 
+# "." - dot is for the current directory(ripgrep itself)
+components=( . grep globset ignore termcolor )
+
 # NOTE Workaround for rust-lang/rust#31907 - disable doc tests when cross compiling
 # This has been fixed in the nightly channel but it would take a while to reach the other channels
 disable_cross_doctests() {
@@ -15,28 +18,23 @@ disable_cross_doctests() {
     fi
 }
 
-run_test_suite() {
-    cargo clean --target $TARGET --verbose
-    cargo build --target $TARGET --verbose
-    cargo test --target $TARGET --verbose
-    cargo build --target $TARGET --verbose --manifest-path grep/Cargo.toml
-    cargo test --target $TARGET --verbose --manifest-path grep/Cargo.toml
-    cargo build --target $TARGET --verbose --manifest-path globset/Cargo.toml
-    cargo test --target $TARGET --verbose --manifest-path globset/Cargo.toml
-    cargo build --target $TARGET --verbose --manifest-path ignore/Cargo.toml
-    cargo test --target $TARGET --verbose --manifest-path ignore/Cargo.toml
-    cargo build --target $TARGET --verbose --manifest-path termcolor/Cargo.toml
-    cargo test --target $TARGET --verbose --manifest-path termcolor/Cargo.toml
-
-    "$( dirname "${0}" )/test_complete.sh"
-
-    # sanity check the file type
-    file target/$TARGET/debug/rg
+run_cargo() {
+    for component in "${components[@]}"; do
+        cargo "${1:?}" --target $TARGET --verbose --manifest-path "${component}/Cargo.toml"
+    done
 }
 
 main() {
     # disable_cross_doctests
-    run_test_suite
+    run_cargo clean
+    run_cargo build
+    if [ "$(architecture)" = "amd64" ] || [ "$(architecture)" = "i386" ]; then
+        run_cargo test
+        "$( dirname "${0}" )/test_complete.sh"
+    fi
+
+    # sanity check the file type
+    file target/$TARGET/debug/rg
 }
 
 main

--- a/ci/utils.sh
+++ b/ci/utils.sh
@@ -39,11 +39,11 @@ dobin() {
 }
 
 architecture() {
-    case $1 in
-        x86_64-unknown-linux-gnu|x86_64-unknown-linux-musl)
+    case ${TARGET:?} in
+        x86_64-*)
             echo amd64
             ;;
-        i686-unknown-linux-gnu|i686-unknown-linux-musl)
+        i686-*|i586-*|i386-*)
             echo i386
             ;;
         arm*-unknown-linux-gnueabihf)
@@ -53,4 +53,12 @@ architecture() {
             die "architecture: unexpected target $TARGET"
             ;;
     esac
+}
+
+is_ssse3_target() {
+    case "${TARGET}" in
+        i686-unknown-netbsd) return 1 ;; # i686-unknown-netbsd - SSE2
+        i686*|x86_64*)       return 0 ;;
+    esac
+    return 1
 }


### PR DESCRIPTION
The purpose of this is so that `ripgrep` will create the "release" binary for the most popular ARM target - but I did not manage to test if the binary is correctly pushed to the "releases" page...