### PR TITLE
Improve smartness of --smart-case

### DIFF
--- a/doc/rg.1
+++ b/doc/rg.1
@@ -457,6 +457,9 @@ Overrides \-\-ignore\-case and \-\-smart\-case.
 Search case insensitively if the pattern is all lowercase.
 Search case sensitively otherwise.
 This is overridden by either \-\-case\-sensitive or \-\-ignore\-case.
+Note: This feature is smart enough to treat simple classes like \\S as
+lowercase, but may not handle more complex syntax like \\p{Ll} as
+expected.
 .RS
 .RE
 .TP

--- a/doc/rg.1.md
+++ b/doc/rg.1.md
@@ -300,7 +300,9 @@ Project home page: https://github.com/BurntSushi/ripgrep
 -S, --smart-case
 : Search case insensitively if the pattern is all lowercase.
   Search case sensitively otherwise. This is overridden by either
-  --case-sensitive or --ignore-case.
+  --case-sensitive or --ignore-case. Note: This feature is smart enough
+  to treat simple classes like \\S as lowercase, but may not handle more
+  complex syntax like \\p{Ll} as expected.
 
 --sort-files
 : Sort results by file path. Note that this currently


### PR DESCRIPTION
Fixes #717 (partially)

As suggested, i changed the smart-case feature in the `grep` crate to look for upper-case characters in the pattern itself rather than the AST. I also added some tests for it, and a note in the manual.

I didn't update the `grep` version number — you don't want me to do that, right?