### PR TITLE
Add support for fixed width line number display (fixes #544)

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -45,6 +45,7 @@ _rg() {
     '--ignore-file=[specify additional ignore file]:file:_files'
     '(-v --invert-match)'{-v,--invert-match}'[invert matching]'
     '(-n -N --line-number --no-line-number)'{-n,--line-number}'[show line numbers]'
+    '(-N --no-line-number)--line-number-width=[specify width of displayed line number]:number of columns'
     '(-w -x --line-regexp --word-regexp)'{-x,--line-regexp}'[only show matches surrounded by line boundaries]'
     '(-M --max-columns)'{-M+,--max-columns=}'[specify max length of lines to print]:number of bytes'
     '(-m --max-count)'{-m+,--max-count=}'[specify max number of matches per file]:number of matches'

--- a/doc/rg.1
+++ b/doc/rg.1
@@ -335,6 +335,14 @@ Follow symlinks.
 .RS
 .RE
 .TP
+.B \-\-line\-number\-width \f[I]NUM\f[]
+Specify a width for the displayed line number.
+If number of digits in the line number is less than this number, it is
+left padded with spaces.
+Note: This setting has no effect if \-\-no\-line\-number is enabled.
+.RS
+.RE
+.TP
 .B \-M, \-\-max\-columns \f[I]NUM\f[]
 Don\[aq]t print lines longer than this limit in bytes.
 Longer lines are omitted, and only the number of matches in that line is

--- a/doc/rg.1.md
+++ b/doc/rg.1.md
@@ -222,6 +222,12 @@ Project home page: https://github.com/BurntSushi/ripgrep
 -L, --follow
 : Follow symlinks.
 
+--line-number-width *NUM*
+: Specify a width for the displayed line number. If number of digits
+  in the line number is less than this number, it is left padded with
+  spaces. Note: This setting has no effect if --no-line-number is
+  enabled.
+
 -M, --max-columns *NUM*
 : Don't print lines longer than this limit in bytes. Longer lines are omitted,
   and only the number of matches in that line is printed.

--- a/src/app.rs
+++ b/src/app.rs
@@ -102,6 +102,9 @@ pub fn app() -> App<'static, 'static> {
              .value_name("GLOB"))
         .arg(flag("ignore-case").short("i"))
         .arg(flag("line-number").short("n"))
+        .arg(flag("line-number-width")
+             .value_name("NUM").takes_value(true)
+             .validator(validate_line_number_width))
         .arg(flag("no-line-number").short("N").overrides_with("line-number"))
         .arg(flag("quiet").short("q"))
         .arg(flag("type").short("t")
@@ -318,6 +321,11 @@ lazy_static! {
              "Show line numbers.",
              "Show line numbers (1-based). This is enabled by default when \
               searching in a tty.");
+        doc!(h, "line-number-width",
+             "Left pad line numbers upto NUM width.",
+             "Left pad line numbers upto NUM width. Space is used as \
+              the default padding character. This has no effect if \
+              --no-line-number is enabled.");
         doc!(h, "no-line-number",
              "Suppress line numbers.",
              "Suppress line numbers. This is enabled by default when NOT \
@@ -570,6 +578,15 @@ lazy_static! {
 
         h
     };
+}
+
+fn validate_line_number_width(s: String) -> Result<(), String> {
+    if s.starts_with("0") {
+        Err(String::from("Custom padding characters are currently not supported. \
+        Please enter only a numeric value."))
+    } else {
+        validate_number(s)
+    }
 }
 
 fn validate_number(s: String) -> Result<(), String> {

--- a/src/args.rs
+++ b/src/args.rs
@@ -54,6 +54,7 @@ pub struct Args {
     invert_match: bool,
     line_number: bool,
     line_per_match: bool,
+    line_number_width: Option<usize>,
     max_columns: Option<usize>,
     max_count: Option<u64>,
     max_filesize: Option<u64>,
@@ -144,7 +145,8 @@ impl Args {
             .only_matching(self.only_matching)
             .path_separator(self.path_separator)
             .with_filename(self.with_filename)
-            .max_columns(self.max_columns);
+            .max_columns(self.max_columns)
+            .line_number_width(self.line_number_width);
         if let Some(ref rep) = self.replace {
             p = p.replace(rep.clone());
         }
@@ -336,6 +338,7 @@ impl<'a> ArgMatches<'a> {
             ignore_files: self.ignore_files(),
             invert_match: self.is_present("invert-match"),
             line_number: line_number,
+            line_number_width: try!(self.usize_of("line-number-width")),
             line_per_match: self.is_present("vimgrep"),
             max_columns: try!(self.usize_of("max-columns")),
             max_count: try!(self.usize_of("max-count")).map(|max| max as u64),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -98,7 +98,11 @@ pub struct Printer<W> {
     /// The separator to use for file paths. If empty, this is ignored.
     path_separator: Option<u8>,
     /// Restrict lines to this many columns.
-    max_columns: Option<usize>
+    max_columns: Option<usize>,
+    /// Width of line number displayed. If the number of digits in the
+    /// line number is less than this, it is left padded with
+    /// spaces.
+    line_number_width: Option<usize>
 }
 
 impl<W: WriteColor> Printer<W> {
@@ -120,6 +124,7 @@ impl<W: WriteColor> Printer<W> {
             colors: ColorSpecs::default(),
             path_separator: None,
             max_columns: None,
+            line_number_width: None
         }
     }
 
@@ -205,6 +210,12 @@ impl<W: WriteColor> Printer<W> {
     /// Configure the max. number of columns used for printing matching lines.
     pub fn max_columns(mut self, max_columns: Option<usize>) -> Printer<W> {
         self.max_columns = max_columns;
+        self
+    }
+
+    /// Configure the width of the displayed line number
+    pub fn line_number_width(mut self, line_number_width: Option<usize>) -> Printer<W> {
+        self.line_number_width = line_number_width;
         self
     }
 
@@ -457,7 +468,11 @@ impl<W: WriteColor> Printer<W> {
     }
 
     fn line_number(&mut self, n: u64, sep: u8) {
-        self.write_colored(n.to_string().as_bytes(), |colors| colors.line());
+        let mut line_number = n.to_string();
+        if let Some(width) = self.line_number_width {
+            line_number = format!("{:>width$}", line_number, width = width);
+        }
+        self.write_colored(line_number.as_bytes(), |colors| colors.line());
         self.separator(&[sep]);
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -103,6 +103,22 @@ sherlock!(line_numbers, |wd: WorkDir, mut cmd: Command| {
     assert_eq!(lines, expected);
 });
 
+sherlock!(line_number_width, |wd: WorkDir, mut cmd: Command| {
+    cmd.arg("-n");
+    cmd.arg("--line-number-width").arg("2");
+    let lines: String = wd.stdout(&mut cmd);
+    let expected = " 1:For the Doctor Watsons of this world, as opposed to the Sherlock
+ 3:be, to a very large extent, the result of luck. Sherlock Holmes
+";
+    assert_eq!(lines, expected);
+});
+
+sherlock!(line_number_width_padding_character_error, |wd: WorkDir, mut cmd: Command| {
+    cmd.arg("-n");
+    cmd.arg("--line-number-width").arg("02");
+    wd.assert_non_empty_stderr(&mut cmd);
+});
+
 sherlock!(columns, |wd: WorkDir, mut cmd: Command| {
     cmd.arg("--column");
     let lines: String = wd.stdout(&mut cmd);


### PR DESCRIPTION
As per the discussion on #544, this is my initial attempt at adding support for fixed width line numbers. Please review and let me know if things can be improved upon.

A few thoughts I had as I worked on this:

- Rust's `format!` macro currently has no way of providing a custom padding character as a parameter. You have to provide it directly in the format string itself. (As per [this](https://doc.rust-lang.org/std/fmt/#syntax), only the width can be provided as a parameter.)
- This meant that adding support for format strings as suggested in the issue discussion proved to be difficult. Right now, the argument only accepts a number. It seems that we'll have to write a custom code for left padding or rely on a library to achieve this. I'm open to suggestions on this one.
- Should we handle possible combinations of CLI args? In the long help message for `line-number-width`, I've mentioned that it has no effect if `--no-line-number` is enabled, which is very obvious. Should I handle any other cases specific to this newly introduced argument to ensure nothing breaks?

Thanks in advance!