### PR TITLE
Replace all usages of try! macro with the ? operator

### DIFF
--- a/globset/README.md
+++ b/globset/README.md
@@ -36,7 +36,7 @@ This example shows how to match a single glob against a single file path.
 ```rust
 use globset::Glob;
 
-let glob = try!(Glob::new("*.rs")).compile_matcher();
+let glob = Glob::new("*.rs")?.compile_matcher();
 
 assert!(glob.is_match("foo.rs"));
 assert!(glob.is_match("foo/bar.rs"));
@@ -51,8 +51,8 @@ semantics. In this example, we prevent wildcards from matching path separators.
 ```rust
 use globset::GlobBuilder;
 
-let glob = try!(GlobBuilder::new("*.rs")
-    .literal_separator(true).build()).compile_matcher();
+let glob = GlobBuilder::new("*.rs")
+    .literal_separator(true).build()?.compile_matcher();
 
 assert!(glob.is_match("foo.rs"));
 assert!(!glob.is_match("foo/bar.rs")); // no longer matches
@@ -69,10 +69,10 @@ use globset::{Glob, GlobSetBuilder};
 let mut builder = GlobSetBuilder::new();
 // A GlobBuilder can be used to configure each glob's match semantics
 // independently.
-builder.add(try!(Glob::new("*.rs")));
-builder.add(try!(Glob::new("src/lib.rs")));
-builder.add(try!(Glob::new("src/**/foo.rs")));
-let set = try!(builder.build());
+builder.add(Glob::new("*.rs")?);
+builder.add(Glob::new("src/lib.rs")?);
+builder.add(Glob::new("src/**/foo.rs")?);
+let set = builder.build()?;
 
 assert_eq!(set.matches("src/bar/baz/foo.rs"), vec![0, 2]);
 ```

--- a/globset/src/lib.rs
+++ b/globset/src/lib.rs
@@ -22,7 +22,7 @@ This example shows how to match a single glob against a single file path.
 # fn example() -> Result<(), globset::Error> {
 use globset::Glob;
 
-let glob = try!(Glob::new("*.rs")).compile_matcher();
+let glob = Glob::new("*.rs")?.compile_matcher();
 
 assert!(glob.is_match("foo.rs"));
 assert!(glob.is_match("foo/bar.rs"));
@@ -39,8 +39,8 @@ semantics. In this example, we prevent wildcards from matching path separators.
 # fn example() -> Result<(), globset::Error> {
 use globset::GlobBuilder;
 
-let glob = try!(GlobBuilder::new("*.rs")
-    .literal_separator(true).build()).compile_matcher();
+let glob = GlobBuilder::new("*.rs")
+    .literal_separator(true).build()?.compile_matcher();
 
 assert!(glob.is_match("foo.rs"));
 assert!(!glob.is_match("foo/bar.rs")); // no longer matches
@@ -59,10 +59,10 @@ use globset::{Glob, GlobSetBuilder};
 let mut builder = GlobSetBuilder::new();
 // A GlobBuilder can be used to configure each glob's match semantics
 // independently.
-builder.add(try!(Glob::new("*.rs")));
-builder.add(try!(Glob::new("src/lib.rs")));
-builder.add(try!(Glob::new("src/**/foo.rs")));
-let set = try!(builder.build());
+builder.add(Glob::new("*.rs")?);
+builder.add(Glob::new("src/lib.rs")?);
+builder.add(Glob::new("src/**/foo.rs")?);
+let set = builder.build()?;
 
 assert_eq!(set.matches("src/bar/baz/foo.rs"), vec![0, 2]);
 # Ok(()) } example().unwrap();
@@ -412,8 +412,8 @@ impl GlobSet {
                 GlobSetMatchStrategy::Suffix(suffixes.suffix()),
                 GlobSetMatchStrategy::Prefix(prefixes.prefix()),
                 GlobSetMatchStrategy::RequiredExtension(
-                    try!(required_exts.build())),
-                GlobSetMatchStrategy::Regex(try!(regexes.regex_set())),
+                    required_exts.build()?),
+                GlobSetMatchStrategy::Regex(regexes.regex_set()?),
             ],
         })
     }
@@ -767,7 +767,7 @@ impl MultiStrategyBuilder {
 
     fn regex_set(self) -> Result<RegexSetStrategy, Error> {
         Ok(RegexSetStrategy {
-            matcher: try!(new_regex_set(self.literals)),
+            matcher: new_regex_set(self.literals)?,
             map: self.map,
         })
     }
@@ -792,7 +792,7 @@ impl RequiredExtensionStrategyBuilder {
         for (ext, regexes) in self.0.into_iter() {
             exts.insert(ext.clone(), vec![]);
             for (global_index, regex) in regexes {
-                let compiled = try!(new_regex(&regex));
+                let compiled = new_regex(&regex)?;
                 exts.get_mut(&ext).unwrap().push((global_index, compiled));
             }
         }

--- a/grep/src/nonl.rs
+++ b/grep/src/nonl.rs
@@ -44,25 +44,23 @@ pub fn remove(expr: Expr, byte: u8) -> Result<Expr> {
         }
         Group { e, i, name } => {
             Group {
-                e: Box::new(try!(remove(*e, byte))),
+                e: Box::new(remove(*e, byte)?),
                 i: i,
                 name: name,
             }
         }
         Repeat { e, r, greedy } => {
             Repeat {
-                e: Box::new(try!(remove(*e, byte))),
+                e: Box::new(remove(*e, byte)?),
                 r: r,
                 greedy: greedy,
             }
         }
         Concat(exprs) => {
-            Concat(try!(
-                exprs.into_iter().map(|e| remove(e, byte)).collect()))
+            Concat(exprs.into_iter().map(|e| remove(e, byte)).collect::<Result<Vec<Expr>>>()?)
         }
         Alternate(exprs) => {
-            Alternate(try!(
-                exprs.into_iter().map(|e| remove(e, byte)).collect()))
+            Alternate(exprs.into_iter().map(|e| remove(e, byte)).collect::<Result<Vec<Expr>>>()?)
         }
         e => e,
     })

--- a/grep/src/search.rs
+++ b/grep/src/search.rs
@@ -141,11 +141,11 @@ impl GrepBuilder {
     /// If there was a problem parsing or compiling the regex with the given
     /// options, then an error is returned.
     pub fn build(self) -> Result<Grep> {
-        let expr = try!(self.parse());
+        let expr = self.parse()?;
         let literals = LiteralSets::create(&expr);
-        let re = try!(self.regex(&expr));
+        let re = self.regex(&expr)?;
         let required = match literals.to_regex_builder() {
-            Some(builder) => Some(try!(self.regex_build(builder))),
+            Some(builder) => Some(self.regex_build(builder)?),
             None => {
                 match strip_unicode_word_boundaries(&expr) {
                     None => None,
@@ -186,12 +186,12 @@ impl GrepBuilder {
     /// the line terminator.
     fn parse(&self) -> Result<syntax::Expr> {
         let expr =
-            try!(syntax::ExprBuilder::new()
-                 .allow_bytes(true)
-                 .unicode(true)
-                 .case_insensitive(try!(self.is_case_insensitive()))
-                 .parse(&self.pattern));
-        let expr = try!(nonl::remove(expr, self.opts.line_terminator));
+            syntax::ExprBuilder::new()
+            .allow_bytes(true)
+            .unicode(true)
+            .case_insensitive(self.is_case_insensitive()?)
+            .parse(&self.pattern)?;
+        let expr = nonl::remove(expr, self.opts.line_terminator)?;
         debug!("regex ast:\n{:#?}", expr);
         Ok(expr)
     }

--- a/ignore/src/gitignore.rs
+++ b/ignore/src/gitignore.rs
@@ -322,13 +322,13 @@ impl GitignoreBuilder {
     pub fn build(&self) -> Result<Gitignore, Error> {
         let nignore = self.globs.iter().filter(|g| !g.is_whitelist()).count();
         let nwhite = self.globs.iter().filter(|g| g.is_whitelist()).count();
-        let set = try!(
+        let set =
             self.builder.build().map_err(|err| {
                 Error::Glob {
                     glob: None,
                     err: err.to_string(),
                 }
-            }));
+            })?;
         Ok(Gitignore {
             set: set,
             root: self.root.clone(),
@@ -383,7 +383,7 @@ impl GitignoreBuilder {
         gitignore: &str,
     ) -> Result<&mut GitignoreBuilder, Error> {
         for line in gitignore.lines() {
-            try!(self.add_line(from.clone(), line));
+            self.add_line(from.clone(), line)?;
         }
         Ok(self)
     }
@@ -465,7 +465,7 @@ impl GitignoreBuilder {
         if glob.actual.ends_with("/**") {
             glob.actual = format!("{}/*", glob.actual);
         }
-        let parsed = try!(
+        let parsed =
             GlobBuilder::new(&glob.actual)
                 .literal_separator(literal_separator)
                 .case_insensitive(self.case_insensitive)
@@ -475,7 +475,7 @@ impl GitignoreBuilder {
                         glob: Some(glob.original.clone()),
                         err: err.kind().to_string(),
                     }
-                }));
+                })?;
         self.builder.add(parsed);
         self.globs.push(glob);
         Ok(self)

--- a/ignore/src/overrides.rs
+++ b/ignore/src/overrides.rs
@@ -124,7 +124,7 @@ impl OverrideBuilder {
     ///
     /// Once a matcher is built, no new globs can be added to it.
     pub fn build(&self) -> Result<Override, Error> {
-        Ok(Override(try!(self.builder.build())))
+        Ok(Override(self.builder.build()?))
     }
 
     /// Add a glob to the set of overrides.
@@ -134,7 +134,7 @@ impl OverrideBuilder {
     /// namely, `!` at the beginning of a glob will ignore a file. Without `!`,
     /// all matches of the glob provided are treated as whitelist matches.
     pub fn add(&mut self, glob: &str) -> Result<&mut OverrideBuilder, Error> {
-        try!(self.builder.add_line(None, glob));
+        self.builder.add_line(None, glob)?;
         Ok(self)
     }
 
@@ -144,7 +144,7 @@ impl OverrideBuilder {
     pub fn case_insensitive(
         &mut self, yes: bool
     ) -> Result<&mut OverrideBuilder, Error> {
-        try!(self.builder.case_insensitive(yes));
+        self.builder.case_insensitive(yes)?;
         Ok(self)
     }
 }

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -526,7 +526,7 @@ impl TypesBuilder {
                 }
             };
             for (iglob, glob) in def.globs.iter().enumerate() {
-                build_set.add(try!(
+                build_set.add(
                     GlobBuilder::new(glob)
                         .literal_separator(true)
                         .build()
@@ -535,14 +535,14 @@ impl TypesBuilder {
                                 glob: Some(glob.to_string()),
                                 err: err.kind().to_string(),
                             }
-                        })));
+                        })?);
                 glob_to_selection.push((isel, iglob));
             }
             selections.push(selection.clone().map(move |_| def));
         }
-        let set = try!(build_set.build().map_err(|err| {
+        let set = build_set.build().map_err(|err| {
             Error::Glob { glob: None, err: err.to_string() }
-        }));
+        })?;
         Ok(Types {
             defs: defs,
             selections: selections,
@@ -655,7 +655,7 @@ impl TypesBuilder {
                 for type_name in types {
                     let globs = self.types.get(type_name).unwrap().globs.clone();
                     for glob in globs {
-                        try!(self.add(name, &glob));
+                        self.add(name, &glob)?;
                     }
                 }
                 Ok(())

--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -279,13 +279,13 @@ impl DirEntryRaw {
         depth: usize,
         ent: &fs::DirEntry,
     ) -> Result<DirEntryRaw, Error> {
-        let ty = try!(ent.file_type().map_err(|err| {
+        let ty = ent.file_type().map_err(|err| {
             let err = Error::Io(io::Error::from(err)).with_path(ent.path());
             Error::WithDepth {
                 depth: depth,
                 err: Box::new(err),
             }
-        }));
+        })?;
         Ok(DirEntryRaw::from_entry_os(depth, ent, ty))
     }
 
@@ -322,9 +322,9 @@ impl DirEntryRaw {
 
     #[cfg(not(unix))]
     fn from_link(depth: usize, pb: PathBuf) -> Result<DirEntryRaw, Error> {
-        let md = try!(fs::metadata(&pb).map_err(|err| {
+        let md = fs::metadata(&pb).map_err(|err| {
             Error::Io(err).with_path(&pb)
-        }));
+        })?;
         Ok(DirEntryRaw {
             path: pb,
             ty: md.file_type(),
@@ -337,9 +337,9 @@ impl DirEntryRaw {
     fn from_link(depth: usize, pb: PathBuf) -> Result<DirEntryRaw, Error> {
         use std::os::unix::fs::MetadataExt;
 
-        let md = try!(fs::metadata(&pb).map_err(|err| {
+        let md = fs::metadata(&pb).map_err(|err| {
             Error::Io(err).with_path(&pb)
-        }));
+        })?;
         Ok(DirEntryRaw {
             path: pb,
             ty: md.file_type(),

--- a/src/args.rs
+++ b/src/args.rs
@@ -310,37 +310,37 @@ impl<'a> ArgMatches<'a> {
     fn to_args(&self) -> Result<Args> {
         let paths = self.paths();
         let line_number = self.line_number(&paths);
-        let mmap = try!(self.mmap(&paths));
+        let mmap = self.mmap(&paths)?;
         let with_filename = self.with_filename(&paths);
-        let (before_context, after_context) = try!(self.contexts());
+        let (before_context, after_context) = self.contexts()?;
         let quiet = self.is_present("quiet");
         let args = Args {
             paths: paths,
             after_context: after_context,
             before_context: before_context,
             color_choice: self.color_choice(),
-            colors: try!(self.color_specs()),
+            colors: self.color_specs()?,
             column: self.column(),
             context_separator: self.context_separator(),
             count: self.is_present("count"),
-            encoding: try!(self.encoding()),
+            encoding: self.encoding()?,
             files_with_matches: self.is_present("files-with-matches"),
             files_without_matches: self.is_present("files-without-match"),
             eol: b'\n',
             files: self.is_present("files"),
             follow: self.is_present("follow"),
-            glob_overrides: try!(self.overrides()),
-            grep: try!(self.grep()),
+            glob_overrides: self.overrides()?,
+            grep: self.grep()?,
             heading: self.heading(),
             hidden: self.hidden(),
             ignore_files: self.ignore_files(),
             invert_match: self.is_present("invert-match"),
             line_number: line_number,
             line_per_match: self.is_present("vimgrep"),
-            max_columns: try!(self.usize_of("max-columns")),
-            max_count: try!(self.usize_of("max-count")).map(|max| max as u64),
-            max_filesize: try!(self.max_filesize()),
-            maxdepth: try!(self.usize_of("maxdepth")),
+            max_columns: self.usize_of("max-columns")?,
+            max_count: self.usize_of("max-count")?.map(|max| max as u64),
+            max_filesize: self.max_filesize()?,
+            maxdepth: self.usize_of("maxdepth")?,
             mmap: mmap,
             no_ignore: self.no_ignore(),
             no_ignore_parent: self.no_ignore_parent(),
@@ -348,16 +348,16 @@ impl<'a> ArgMatches<'a> {
             no_messages: self.is_present("no-messages"),
             null: self.is_present("null"),
             only_matching: self.is_present("only-matching"),
-            path_separator: try!(self.path_separator()),
+            path_separator: self.path_separator()?,
             quiet: quiet,
             quiet_matched: QuietMatched::new(quiet),
             replace: self.replace(),
             sort_files: self.is_present("sort-files"),
             stdout_handle: self.stdout_handle(),
             text: self.text(),
-            threads: try!(self.threads()),
+            threads: self.threads()?,
             type_list: self.is_present("type-list"),
-            types: try!(self.types()),
+            types: self.types()?,
             with_filename: with_filename,
         };
         if args.mmap {
@@ -421,7 +421,7 @@ impl<'a> ArgMatches<'a> {
     /// If any part of the pattern isn't valid UTF-8, then an error is
     /// returned.
     fn pattern(&self) -> Result<String> {
-        Ok(try!(self.patterns()).join("|"))
+        Ok(self.patterns()?.join("|"))
     }
 
     /// Get a sequence of all available patterns from the command line.
@@ -442,13 +442,13 @@ impl<'a> ArgMatches<'a> {
             None => {
                 if self.values_of_os("file").is_none() {
                     if let Some(os_pat) = self.value_of_os("PATTERN") {
-                        pats.push(try!(self.os_str_pattern(os_pat)));
+                        pats.push(self.os_str_pattern(os_pat)?);
                     }
                 }
             }
             Some(os_pats) => {
                 for os_pat in os_pats {
-                    pats.push(try!(self.os_str_pattern(os_pat)));
+                    pats.push(self.os_str_pattern(os_pat)?);
                 }
             }
         }
@@ -457,12 +457,12 @@ impl<'a> ArgMatches<'a> {
                 if file == "-" {
                     let stdin = io::stdin();
                     for line in stdin.lock().lines() {
-                        pats.push(self.str_pattern(&try!(line)));
+                        pats.push(self.str_pattern(&line?));
                     }
                 } else {
-                    let f = try!(fs::File::open(file));
+                    let f = fs::File::open(file)?;
                     for line in io::BufReader::new(f).lines() {
-                        pats.push(self.str_pattern(&try!(line)));
+                        pats.push(self.str_pattern(&line?));
                     }
                 }
             }
@@ -478,7 +478,7 @@ impl<'a> ArgMatches<'a> {
     ///
     /// If the pattern is not valid UTF-8, then an error is returned.
     fn os_str_pattern(&self, pat: &OsStr) -> Result<String> {
-        let s = try!(pattern_to_str(pat));
+        let s = pattern_to_str(pat)?;
         Ok(self.str_pattern(s))
     }
 
@@ -578,8 +578,8 @@ impl<'a> ArgMatches<'a> {
     /// `paths` should be a slice of all top-level file paths that ripgrep
     /// will need to search.
     fn mmap(&self, paths: &[PathBuf]) -> Result<bool> {
-        let (before, after) = try!(self.contexts());
-        let enc = try!(self.encoding());
+        let (before, after) = self.contexts()?;
+        let enc = self.encoding()?;
         Ok(if before > 0 || after > 0 || self.is_present("no-mmap") {
             false
         } else if self.is_present("mmap") {
@@ -668,9 +668,9 @@ impl<'a> ArgMatches<'a> {
     /// If there was a problem parsing the values from the user as an integer,
     /// then an error is returned.
     fn contexts(&self) -> Result<(usize, usize)> {
-        let after = try!(self.usize_of("after-context")).unwrap_or(0);
-        let before = try!(self.usize_of("before-context")).unwrap_or(0);
-        let both = try!(self.usize_of("context")).unwrap_or(0);
+        let after = self.usize_of("after-context")?.unwrap_or(0);
+        let before = self.usize_of("before-context")?.unwrap_or(0);
+        let both = self.usize_of("context")?.unwrap_or(0);
         Ok(if both > 0 {
             (both, both)
         } else {
@@ -716,7 +716,7 @@ impl<'a> ArgMatches<'a> {
             "match:style:bold".parse().unwrap(),
         ];
         for spec_str in self.values_of_lossy_vec("colors") {
-            specs.push(try!(spec_str.parse()));
+            specs.push(spec_str.parse()?);
         }
         Ok(ColorSpecs::new(&specs))
     }
@@ -749,7 +749,7 @@ impl<'a> ArgMatches<'a> {
         if self.is_present("sort-files") {
             return Ok(1);
         }
-        let threads = try!(self.usize_of("threads")).unwrap_or(0);
+        let threads = self.usize_of("threads")?.unwrap_or(0);
         Ok(if threads == 0 {
             cmp::min(12, num_cpus::get())
         } else {
@@ -769,15 +769,15 @@ impl<'a> ArgMatches<'a> {
         let casei =
             self.is_present("ignore-case")
             && !self.is_present("case-sensitive");
-        let mut gb = GrepBuilder::new(&try!(self.pattern()))
+        let mut gb = GrepBuilder::new(&self.pattern()?)
             .case_smart(smart)
             .case_insensitive(casei)
             .line_terminator(b'\n');
 
-        if let Some(limit) = try!(self.dfa_size_limit()) {
+        if let Some(limit) = self.dfa_size_limit()? {
             gb = gb.dfa_size_limit(limit);
         }
-        if let Some(limit) = try!(self.regex_size_limit()) {
+        if let Some(limit) = self.regex_size_limit()? {
             gb = gb.size_limit(limit);
         }
         gb.build().map_err(From::from)
@@ -785,17 +785,17 @@ impl<'a> ArgMatches<'a> {
 
     /// Builds the set of glob overrides from the command line flags.
     fn overrides(&self) -> Result<Override> {
-        let mut ovr = OverrideBuilder::new(try!(env::current_dir()));
+        let mut ovr = OverrideBuilder::new(env::current_dir()?);
         for glob in self.values_of_lossy_vec("glob") {
-            try!(ovr.add(&glob));
+            ovr.add(&glob)?;
         }
         // this is smelly. In the long run it might make sense
         // to change overridebuilder to be like globsetbuilder
         // but this would be a breaking change to the ignore crate
         // so it is being shelved for now...
-        try!(ovr.case_insensitive(true));
+        ovr.case_insensitive(true)?;
         for glob in self.values_of_lossy_vec("iglob") {
-            try!(ovr.add(&glob));
+            ovr.add(&glob)?;
         }
         ovr.build().map_err(From::from)
     }
@@ -808,7 +808,7 @@ impl<'a> ArgMatches<'a> {
             btypes.clear(&ty);
         }
         for def in self.values_of_lossy_vec("type-add") {
-            try!(btypes.add_def(&def));
+            btypes.add_def(&def)?;
         }
         for ty in self.values_of_lossy_vec("type") {
             btypes.select(&ty);
@@ -832,12 +832,12 @@ impl<'a> ArgMatches<'a> {
             None => return Ok(None)
         };
         let re = regex::Regex::new("^([0-9]+)([KMG])?$").unwrap();
-        let caps = try!(
+        let caps =
             re.captures(&arg_value).ok_or_else(|| {
                 format!("invalid format for {}", arg_name)
-            }));
+            })?;
 
-        let value = try!(caps[1].parse::<u64>());
+        let value = caps[1].parse::<u64>()?;
         let suffix = caps.get(2).map(|x| x.as_str());
 
         let v_10 = value.checked_mul(1024);
@@ -862,13 +862,13 @@ impl<'a> ArgMatches<'a> {
 
     /// Parse the dfa-size-limit argument option into a byte count.
     fn dfa_size_limit(&self) -> Result<Option<usize>> {
-        let r = try!(self.parse_human_readable_size_arg("dfa-size-limit"));
+        let r = self.parse_human_readable_size_arg("dfa-size-limit")?;
         human_readable_to_usize("dfa-size-limit", r)
     }
 
     /// Parse the regex-size-limit argument option into a byte count.
     fn regex_size_limit(&self) -> Result<Option<usize>> {
-        let r = try!(self.parse_human_readable_size_arg("regex-size-limit"));
+        let r = self.parse_human_readable_size_arg("regex-size-limit")?;
         human_readable_to_usize("regex-size-limit", r)
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -62,7 +62,7 @@ impl<R: io::Read> BomPeeker<R> {
         }
         self.bom = Some(Bom { bytes: [0; 3], len: 0 });
         let mut buf = [0u8; 3];
-        let bom_len = try!(read_full(&mut self.rdr, &mut buf));
+        let bom_len = read_full(&mut self.rdr, &mut buf)?;
         self.bom = Some(Bom { bytes: buf, len: bom_len });
         Ok(self.bom.unwrap())
     }
@@ -71,7 +71,7 @@ impl<R: io::Read> BomPeeker<R> {
 impl<R: io::Read> io::Read for BomPeeker<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if self.nread < 3 {
-            let bom = try!(self.peek_bom());
+            let bom = self.peek_bom()?;
             let bom = bom.as_slice();
             if self.nread < bom.len() {
                 let rest = &bom[self.nread..];
@@ -81,7 +81,7 @@ impl<R: io::Read> io::Read for BomPeeker<R> {
                 return Ok(len);
             }
         }
-        let nread = try!(self.rdr.read(buf));
+        let nread = self.rdr.read(buf)?;
         self.nread += nread;
         Ok(nread)
     }
@@ -196,7 +196,7 @@ impl<R: io::Read, B: AsMut<[u8]>> DecodeReader<R, B> {
         }
         self.pos = 0;
         self.buflen +=
-            try!(self.rdr.read(&mut self.buf.as_mut()[self.buflen..]));
+            self.rdr.read(&mut self.buf.as_mut()[self.buflen..])?;
         Ok(())
     }
 
@@ -219,7 +219,7 @@ impl<R: io::Read, B: AsMut<[u8]>> DecodeReader<R, B> {
             return Ok(0);
         }
         if self.pos >= self.buflen {
-            try!(self.fill());
+            self.fill()?;
         }
         let mut nwrite = 0;
         loop {
@@ -235,7 +235,7 @@ impl<R: io::Read, B: AsMut<[u8]>> DecodeReader<R, B> {
             }
             // Otherwise, we know that our internal buffer has insufficient
             // data to transcode at least one char, so we attempt to refill it.
-            try!(self.fill());
+            self.fill()?;
             // Quit on EOF.
             if self.buflen == 0 {
                 self.pos = 0;
@@ -251,7 +251,7 @@ impl<R: io::Read, B: AsMut<[u8]>> DecodeReader<R, B> {
 
     #[inline(never)] // impacts perf...
     fn detect(&mut self) -> io::Result<()> {
-        let bom = try!(self.rdr.peek_bom());
+        let bom = self.rdr.peek_bom()?;
         self.decoder = bom.decoder();
         Ok(())
     }
@@ -261,7 +261,7 @@ impl<R: io::Read, B: AsMut<[u8]>> io::Read for DecodeReader<R, B> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if self.first {
             self.first = false;
-            try!(self.detect());
+            self.detect()?;
         }
         if self.decoder.is_none() {
             return self.rdr.read(buf);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -726,28 +726,28 @@ impl FromStr for Spec {
         if pieces.len() <= 1 || pieces.len() > 3 {
             return Err(Error::InvalidFormat(s.to_string()));
         }
-        let otype: OutType = try!(pieces[0].parse());
-        match try!(pieces[1].parse()) {
+        let otype: OutType = pieces[0].parse()?;
+        match pieces[1].parse()? {
             SpecType::None => Ok(Spec { ty: otype, value: SpecValue::None }),
             SpecType::Style => {
                 if pieces.len() < 3 {
                     return Err(Error::InvalidFormat(s.to_string()));
                 }
-                let style: Style = try!(pieces[2].parse());
+                let style: Style = pieces[2].parse()?;
                 Ok(Spec { ty: otype, value: SpecValue::Style(style) })
             }
             SpecType::Fg => {
                 if pieces.len() < 3 {
                     return Err(Error::InvalidFormat(s.to_string()));
                 }
-                let color: Color = try!(pieces[2].parse());
+                let color: Color = pieces[2].parse()?;
                 Ok(Spec { ty: otype, value: SpecValue::Fg(color) })
             }
             SpecType::Bg => {
                 if pieces.len() < 3 {
                     return Err(Error::InvalidFormat(s.to_string()));
                 }
-                let color: Color = try!(pieces[2].parse());
+                let color: Color = pieces[2].parse()?;
                 Ok(Spec { ty: otype, value: SpecValue::Bg(color) })
             }
         }

--- a/src/search_stream.rs
+++ b/src/search_stream.rs
@@ -264,7 +264,7 @@ impl<'a, R: io::Read, W: WriteColor> Searcher<'a, R, W> {
         while !self.terminate() {
             let upto = self.inp.lastnl;
             self.print_after_context(upto);
-            if !try!(self.fill()) {
+            if !self.fill()? {
                 break;
             }
             while !self.terminate() && self.inp.pos < self.inp.lastnl {
@@ -301,7 +301,7 @@ impl<'a, R: io::Read, W: WriteColor> Searcher<'a, R, W> {
         }
         if self.after_context_remaining > 0 {
             if self.last_printed == self.inp.lastnl {
-                try!(self.fill());
+                self.fill()?;
             }
             let upto = self.inp.lastnl;
             if upto > 0 {
@@ -348,9 +348,9 @@ impl<'a, R: io::Read, W: WriteColor> Searcher<'a, R, W> {
             self.count_lines(keep);
             self.last_line = 0;
         }
-        let ok = try!(self.inp.fill(&mut self.haystack, keep).map_err(|err| {
+        let ok = self.inp.fill(&mut self.haystack, keep).map_err(|err| {
             Error::from_io(err, &self.path)
-        }));
+        })?;
         Ok(ok)
     }
 
@@ -594,8 +594,8 @@ impl InputBuffer {
                 let new_len = cmp::max(min_len, self.buf.len() * 2);
                 self.buf.resize(new_len, 0);
             }
-            let n = try!(rdr.read(
-                &mut self.buf[self.end..self.end + self.read_size]));
+            let n = rdr.read(
+                &mut self.buf[self.end..self.end + self.read_size])?;
             if !self.text {
                 if is_binary(&self.buf[self.end..self.end + n], self.first) {
                     return Ok(false);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -282,7 +282,7 @@ impl Worker {
         path: &Path,
         file: &File,
     ) -> Result<u64> {
-        if try!(file.metadata()).len() == 0 {
+        if file.metadata()?.len() == 0 {
             // Opening a memory map with an empty file results in an error.
             // However, this may not actually be an empty file! For example,
             // /proc/cpuinfo reports itself as an empty file, but it can
@@ -290,7 +290,7 @@ impl Worker {
             // regular read calls.
             return self.search(printer, path, file);
         }
-        let mmap = unsafe { try!(Mmap::map(file)) };
+        let mmap = unsafe { Mmap::map(file)? };
         let buf = &*mmap;
         if buf.len() >= 3 && Encoding::for_bom(buf).is_some() {
             // If we have a UTF-16 bom in our memory map, then we need to fall

--- a/termcolor/README.md
+++ b/termcolor/README.md
@@ -62,8 +62,8 @@ use std::io::Write;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 let mut stdout = StandardStream::stdout(ColorChoice::Always);
-try!(stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green))));
-try!(writeln!(&mut stdout, "green text!"));
+stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+writeln!(&mut stdout, "green text!")?;
 ```
 
 ### Example: using `BufferWriter`
@@ -80,7 +80,7 @@ use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
 let mut bufwtr = BufferWriter::stderr(ColorChoice::Always);
 let mut buffer = bufwtr.buffer();
-try!(buffer.set_color(ColorSpec::new().set_fg(Some(Color::Green))));
-try!(writeln!(&mut buffer, "green text!"));
-try!(bufwtr.print(&buffer));
+buffer.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+writeln!(&mut buffer, "green text!")?;
+bufwtr.print(&buffer)?;
 ```


### PR DESCRIPTION
So as I was learning and going through the codebase, I came across `try!` a lot. Thinking it was a new macro/syntax I had to learn, I searched the Internet for it only to [learn](https://doc.rust-lang.org/std/macro.try.html) that it was an earlier alternative to the newer `?` operator, which should be preferred nowadays.

As a result of this, I have changed all usages of the `try!` macro to the newer `?` operator in the codebase.

My reasoning is as follows:
- The latest edition (2nd) of the Rust Programming language book teaches newcomers about the `?` as the shortcut for [propagating errors](https://doc.rust-lang.org/book/second-edition/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-).
- I also find that `?` is easier to parse and read than `try!` and is much less of an overhead on my brain. (Note: Subject to personal taste.)

I did not want to create a new issue for this since I assume we only want to do that for actual issues with RipGrep and not changes we want to make to the codebase. So I went ahead and created a PR instead. 

Please feel free to close this PR if you all feel otherwise and are OK with letting `try!` remain as such. Thanks!