### PR TITLE
Adding types for Kafka schema

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -100,6 +100,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("agda", &["*.agda", "*.lagda"]),
     ("asciidoc", &["*.adoc", "*.asc", "*.asciidoc"]),
     ("asm", &["*.asm", "*.s", "*.S"]),
+    ("avro", &["*.avdl", "*.avpr", "*.avsc"]),
     ("awk", &["*.awk"]),
     ("bitbake", &["*.bb", "*.bbappend", "*.bbclass", "*.conf", "*.inc"]),
     ("c", &["*.c", "*.h", "*.H"]),


### PR DESCRIPTION
[Apache Avro](http://avro.apache.org/) uses `.avsc`, `.avpr` & sometimes `.avdl` (json-like) formats to store Kafka schema information. Adding them to rg because I hated adding `--type-add` to all my searches. Thanks :) 
  
  