### PR TITLE
termcolor: Write `Ansi::reset()` using `\x1b[0m` instead of `\x1b[m`

### DIFF
--- a/termcolor/src/lib.rs
+++ b/termcolor/src/lib.rs
@@ -973,7 +973,7 @@ impl<W: io::Write> WriteColor for Ansi<W> {
     }
 
     fn reset(&mut self) -> io::Result<()> {
-        self.write_str("\x1B[m")
+        self.write_str("\x1B[0m")
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1134,7 +1134,7 @@ clean!(regression_428_color_context_path, "foo", ".",
     let expected = format!(
         "{colored_path}:foo\n{colored_path}-bar\n",
         colored_path=format!(
-            "\x1b\x5b\x6d\x1b\x5b\x33\x35\x6d{path}\x1b\x5b\x6d",
+            "\x1b\x5b\x30\x6d\x1b\x5b\x33\x35\x6d{path}\x1b\x5b\x30\x6d",
             path=path("sherlock")));
     assert_eq!(lines, expected);
 });
@@ -1178,9 +1178,9 @@ clean!(regression_599, "^$", "input.txt", |wd: WorkDir, mut cmd: Command| {
     // Technically, the expected output should only be two lines, but:
     // https://github.com/BurntSushi/ripgrep/issues/441
     let expected = "\
-[m1[m:[m[31m[m
-[m2[m:[m[31m[m
-[m4[m:
+[0m1[0m:[0m[31m[0m
+[0m2[0m:[0m[31m[0m
+[0m4[0m:
 ";
     assert_eq!(expected, lines);
 });


### PR DESCRIPTION
AppVeyor CI supports coloring the console through ANSI escape codes, however its support is incomplete (appveyor/ci#1824). One particular issue is that `\x1b[m` is not recognized as the same as `\x1b[0m`. 

This caused colored output using this library extremely ugly on AppVeyor as the color is never reset ([example](https://ci.appveyor.com/project/rust-lang/rust/build/1.0.6004/job/a23aftwu88yh35c4), start from line 675).

While technically an AppVeyor bug, I think changing the code here would improve compatibility anyway. (That issue is also untouched for 2 months so I doubt if AppVeyor is going to fix it soon.)

