### PR TITLE
Add Ubuntu installation guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ $ # (Or using the attribute name, which is also `ripgrep`.)
 If you're an **Ubuntu** user, `ripgrep` can be installed from the `snap` store.
 * Note that if you are using `16.04 LTS` or later, snap is already installed.
 * For older versions you can install snap using
-[this guide](https://docs.snapcraft.io/core/install-ubuntu)
+[this guide](https://docs.snapcraft.io/core/install-ubuntu).
 
 ```
 sudo snap install rg

--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ $ nix-env --install ripgrep
 $ # (Or using the attribute name, which is also `ripgrep`.)
 ```
 
+If you're an **Ubuntu** user and you are using `16.04 LTS` or later, you can install `ripgrep` from the `snap` store:
+
+```
+sudo snap install rg
+```
+
 If you're a **Rust programmer**, `ripgrep` can be installed with `cargo`.
 * Note that the minimum supported version of Rust for ripgrep is **1.17**,
   although ripgrep may work with older versions.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The binary name for `ripgrep` is `rg`.
 
 **[Archives of precompiled binaries for `ripgrep` are available for Windows,
 macOS and Linux.](https://github.com/BurntSushi/ripgrep/releases)** Users of
-platforms not explicitly mentioned below (such as Debian and Ubuntu) are advised
+platforms not explicitly mentioned below (such as Debian) are advised
 to download one of these archives.
 
 Linux binaries are static executables. Windows binaries are available either as
@@ -225,7 +225,10 @@ $ nix-env --install ripgrep
 $ # (Or using the attribute name, which is also `ripgrep`.)
 ```
 
-If you're an **Ubuntu** user and you are using `16.04 LTS` or later, you can install `ripgrep` from the `snap` store:
+If you're an **Ubuntu** user, `ripgrep` can be installed from the `snap` store.
+* Note that if you are using `16.04 LTS` or later, snap is already installed.
+* For older versions you can install snap using
+[this guide](https://docs.snapcraft.io/core/install-ubuntu)
 
 ```
 sudo snap install rg


### PR DESCRIPTION
I added documentation for Ubuntu users who want to install `ripgrep` using the snap tool