### PR TITLE
readme: ripgrep is in Fedora 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ If you're a **Gentoo** user, you can install `ripgrep` from the [official repo](
 $ emerge sys-apps/ripgrep
 ```
 
-If you're a **Fedora 28+** user, you can install `ripgrep` from official repositories.
+If you're a **Fedora 27+** user, you can install `ripgrep` from official repositories.
 
 ```
 $ sudo dnf install ripgrep


### PR DESCRIPTION
References: https://bodhi.fedoraproject.org/updates/FEDORA-2018-ca3c304458

---

P.S. update is still not pushed, but should be fully available within few days