### PR TITLE
Add GN as new filetype

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -135,6 +135,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
         "*.f90", "*.F90", "*.f95", "*.F95",
     ]),
     ("fsharp", &["*.fs", "*.fsx", "*.fsi"]),
+    ("gn", &["*.gn", "*.gni"]),
     ("go", &["*.go"]),
     ("groovy", &["*.groovy", "*.gradle"]),
     ("h", &["*.h", "*.hpp"]),


### PR DESCRIPTION
GN is Googles new build system, originally developed to build chromium. They use the *.gn and *.gni file endings.