### PR TITLE
Add *.hxx to the cpp filetype

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -114,7 +114,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("config", &["*.cfg", "*.conf", "*.config", "*.ini"]),
     ("cpp", &[
         "*.C", "*.cc", "*.cpp", "*.cxx",
-        "*.h", "*.H", "*.hh", "*.hpp", "*.inl",
+        "*.h", "*.H", "*.hh", "*.hpp", "*.hxx", "*.inl",
     ]),
     ("crystal", &["Projectfile", "*.cr"]),
     ("cs", &["*.cs"]),


### PR DESCRIPTION
.hxx is commonly used as a header extension for C++ files, since .cxx was already added, I was free to add the header extension to match the implementation file.