### PR TITLE
Iterate over files caught by Glob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/globset/Cargo.toml
+++ b/globset/Cargo.toml
@@ -28,6 +28,7 @@ walkdir = "2.0"
 
 [dev-dependencies]
 glob = "0.2"
+tempdir = "0.3"
 
 [features]
 simd-accel = ["regex/simd-accel"]

--- a/globset/Cargo.toml
+++ b/globset/Cargo.toml
@@ -24,6 +24,7 @@ fnv = "1.0"
 log = "0.3"
 memchr = "2"
 regex = "0.2.1"
+walkdir = "2.0"
 
 [dev-dependencies]
 glob = "0.2"


### PR DESCRIPTION
Example at the tests section.

Question:
- Is this API acceptable?
- Should `iter_at` consume GlobSet
- Should this feature be behind a feature-gate (because of the added dependency)?