### PR TITLE
[glob] Add tests for single-asterisk patterns

### DIFF
--- a/globset/src/glob.rs
+++ b/globset/src/glob.rs
@@ -1155,6 +1155,7 @@ mod tests {
     matches!(matchrec22, ".*/**", ".abc/abc");
     matches!(matchrec23, "foo/**", "foo");
     matches!(matchrec24, "**/foo/bar", "foo/bar");
+    matches!(matchrec25, "some/*/needle.txt", "some/one/needle.txt");
 
     matches!(matchrange1, "a[0-9]b", "a0b");
     matches!(matchrange2, "a[0-9]b", "a9b");
@@ -1243,6 +1244,9 @@ mod tests {
     nmatches!(matchnot27, "a[^0-9]b", "a0b");
     nmatches!(matchnot28, "a[^0-9]b", "a9b");
     nmatches!(matchnot29, "[^-]", "-");
+    nmatches!(matchnot30, "some/*/needle.txt", "some/needle.txt");
+    nmatches!(matchrec31, "some/*/needle.txt", "some/one/two/needle.txt");
+    nmatches!(matchrec32, "some/*/needle.txt", "some/one/two/three/needle.txt");
 
     macro_rules! extract {
         ($which:ident, $name:ident, $pat:expr, $expect:expr) => {


### PR DESCRIPTION
@Diggsey reported in <https://github.com/rust-lang/cargo/issues/4268#issuecomment-362919612> that the single-asterisk patterns are over-matching into deeper directories.

Looking at the resources I found, looks like that's a right claim, so here I've added the unit tests which show the problem. (The diff breaks the build as it is and should not be landed before a fix is in place.)

I haven't looked into a fix yet, since I'm not 100% sure about the right behavior. If so, would be great to fix it. (Unfortunately, I cannot promise I'll find the time to work on it at the moment.)

What do you think, @BurntSushi?