### PR TITLE
fixes a PATTERN->pattern typo in argument conflicts

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1468,7 +1468,7 @@ Show all supported file types and their corresponding globs.
         .help(SHORT).long_help(LONG)
         // This also technically conflicts with PATTERN, but the first file
         // path will actually be in PATTERN.
-        .conflicts(&["file", "files", "PATTERN", "regexp"]);
+        .conflicts(&["file", "files", "pattern", "regexp"]);
     args.push(arg);
 }
 


### PR DESCRIPTION
Found this while testing kbknapp/clap-rs#868
