### PR TITLE
Ignore (one) trailing line break per --file parameter

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -511,6 +511,9 @@ impl<'a> ArgMatches<'a> {
                     for line in io::BufReader::new(f).lines() {
                         pats.push(self.str_pattern(&line?));
                     }
+                    if Some(&self.str_pattern("")) == pats.last() {
+                        pats.pop();
+                    }
                 }
             }
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1879,6 +1879,22 @@ fn files() {
             || lines == path("dir/file\nfile\n"));
 }
 
+// See: https://github.com/BurntSushi/ripgrep/pull/783
+#[test]
+fn ignore_trailing_line() {
+    let wd = WorkDir::new("ignore_trailing_line");
+    wd.create("foo", "foo");
+    wd.create("bar", "bar");
+    wd.create("patterns.txt", "foo\n\n");
+
+    let mut cmd = wd.command();
+    cmd.arg("--file").arg("patterns.txt")
+        .arg("--glob").arg("!patterns.txt");
+
+    let lines: String = wd.stdout(&mut cmd);
+    assert_eq!(lines, "foo:foo\n".to_string());
+}
+
 // See: https://github.com/BurntSushi/ripgrep/issues/64
 #[test]
 fn regression_64() {


### PR DESCRIPTION
Currently ripgrep interprets a trailing line break at the end of a
pattern file specified via `--file` or similar as a global "match-all"
pattern. Given that many editors are configured to automatically add a
trailing new line at the end of a file on save, this is not necessarily
a good thing.

This patch removes a single new line from the end of each pattern file
contents by simply dropping an empty rule from the pattern vector if it
is the last rule in the vector after loading rules from a file. Multiple
line breaks are not ignored, and no overhead is added by omitting this
check from within the for loop (not that it would really matter since
this is just init time). Additionally, line breaks not at the end of the
file are similarly kept.