### PR TITLE
ignore: add support for VHDL type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -274,6 +274,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("twig", &["*.twig"]),
     ("vala", &["*.vala"]),
     ("vb", &["*.vb"]),
+    ("vhdl", &["*.vhd", "*.vhdl"]),
     ("vim", &["*.vim"]),
     ("vimscript", &["*.vim"]),
     ("wiki", &["*.mediawiki", "*.wiki"]),


### PR DESCRIPTION
VHDL is a very popular language for hardware design for FPGA etc. I think this would be useful for others :-)
