### PR TITLE
[WIP] Add --stats flag and implement basic stat tracking (closes #411)

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -89,6 +89,7 @@ _rg() {
     '(-e -f --file --files --regexp --type-list)1: :_rg_pattern'
     '(--type-list)*:file:_files'
     '(-z --search-zip)'{-z,--search-zip}'[search in compressed files]'
+    "(--stats)--stats[print stats about this search]"
   )
 
   [[ ${_RG_COMPLETE_LIST_ARGS:-} == (1|t*|y*) ]] && {

--- a/src/app.rs
+++ b/src/app.rs
@@ -557,6 +557,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_search_zip(&mut args);
     flag_smart_case(&mut args);
     flag_sort_files(&mut args);
+    flag_stats(&mut args);
     flag_text(&mut args);
     flag_threads(&mut args);
     flag_type(&mut args);
@@ -1444,6 +1445,23 @@ This flag can be disabled with --no-sort-files.
     let arg = RGArg::switch("no-sort-files")
         .hidden()
         .overrides("sort-files");
+    args.push(arg);
+}
+
+fn flag_stats(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Print statistics about this ripgrep search.";
+    const LONG: &str = long!("\
+Print statistics about this ripgrep search. When this flag is present,
+ripgrep will print the following stats at the end of the search: total
+no. of matches, no. of files with matches, no. of files searched, and
+the time taken for the entire search to complete.
+
+Note that this flag has no effect if --files, --files-with-matches or
+--files-without-match is passed.");
+
+    let arg = RGArg::switch("stats")
+        .help(SHORT).long_help(LONG);
+
     args.push(arg);
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -77,7 +77,8 @@ pub struct Args {
     type_list: bool,
     types: Types,
     with_filename: bool,
-    search_zip_files: bool
+    search_zip_files: bool,
+    stats: bool
 }
 
 impl Args {
@@ -216,6 +217,12 @@ impl Args {
     /// Returns true if the given arguments are known to never produce a match.
     pub fn never_match(&self) -> bool {
         self.max_count == Some(0)
+    }
+
+
+    /// Returns whether ripgrep should track stats for this run
+    pub fn stats(&self) -> bool {
+        self.stats
     }
 
     /// Create a new writer for single-threaded searching with color support.
@@ -403,7 +410,8 @@ impl<'a> ArgMatches<'a> {
             type_list: self.is_present("type-list"),
             types: self.types()?,
             with_filename: with_filename,
-            search_zip_files: self.is_present("search-zip")
+            search_zip_files: self.is_present("search-zip"),
+            stats: self.stats()
         };
         if args.mmap {
             debug!("will try to use memory maps");
@@ -793,6 +801,19 @@ impl<'a> ArgMatches<'a> {
                 }
             }
         }
+    }
+
+    /// Returns whether status should be tracked for this run of ripgrep
+
+    /// This is automatically disabled if we're asked to only list the
+    /// files that wil be searched, files with matches or files
+    /// without matches.
+    fn stats(&self) -> bool {
+        if self.is_present("files-with-matches") ||
+           self.is_present("files-without-match") {
+               return false;
+        }
+        self.is_present("stats")
     }
 
     /// Returns the approximate number of threads that ripgrep should use.

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::thread;
+use std::time::{Duration, Instant};
 
 use args::Args;
 use worker::Work;
@@ -85,15 +86,18 @@ fn run(args: Arc<Args>) -> Result<u64> {
 }
 
 fn run_parallel(args: &Arc<Args>) -> Result<u64> {
+    let start_time = Instant::now();
     let bufwtr = Arc::new(args.buffer_writer());
     let quiet_matched = args.quiet_matched();
     let paths_searched = Arc::new(AtomicUsize::new(0));
+    let paths_matched = Arc::new(AtomicUsize::new(0));
     let match_count = Arc::new(AtomicUsize::new(0));
 
     args.walker_parallel().run(|| {
         let args = Arc::clone(args);
         let quiet_matched = quiet_matched.clone();
         let paths_searched = paths_searched.clone();
+        let paths_matched = paths_matched.clone();
         let match_count = match_count.clone();
         let bufwtr = Arc::clone(&bufwtr);
         let mut buf = bufwtr.buffer();
@@ -129,6 +133,9 @@ fn run_parallel(args: &Arc<Args>) -> Result<u64> {
                 if quiet_matched.set_match(count > 0) {
                     return Quit;
                 }
+                if args.stats() && count > 0 {
+                    paths_matched.fetch_add(1, Ordering::SeqCst);
+                }
             }
             // BUG(burntsushi): We should handle this error instead of ignoring
             // it. See: https://github.com/BurntSushi/ripgrep/issues/200
@@ -141,14 +148,22 @@ fn run_parallel(args: &Arc<Args>) -> Result<u64> {
             eprint_nothing_searched();
         }
     }
-    Ok(match_count.load(Ordering::SeqCst) as u64)
+    let match_count = match_count.load(Ordering::SeqCst) as u64;
+    let paths_searched = paths_searched.load(Ordering::SeqCst) as u64;
+    let paths_matched = paths_matched.load(Ordering::SeqCst) as u64;
+    if args.stats() {
+        print_stats(match_count, paths_searched, paths_matched, start_time.elapsed());
+    }
+    Ok(match_count)
 }
 
 fn run_one_thread(args: &Arc<Args>) -> Result<u64> {
+    let start_time = Instant::now();
     let stdout = args.stdout();
     let mut stdout = stdout.lock();
     let mut worker = args.worker();
     let mut paths_searched: u64 = 0;
+    let mut paths_matched: u64 = 0;
     let mut match_count = 0;
     for result in args.walker() {
         let dent = match get_or_log_dir_entry(
@@ -170,17 +185,24 @@ fn run_one_thread(args: &Arc<Args>) -> Result<u64> {
             }
         }
         paths_searched += 1;
-        match_count +=
+        let count =
             if dent.is_stdin() {
                 worker.run(&mut printer, Work::Stdin)
             } else {
                 worker.run(&mut printer, Work::DirEntry(dent))
             };
+        match_count += count;
+        if args.stats() && count > 0 {
+            paths_matched += 1;
+        }
     }
     if !args.paths().is_empty() && paths_searched == 0 {
         if !args.no_messages() {
             eprint_nothing_searched();
         }
+    }
+    if args.stats() {
+        print_stats(match_count, paths_searched, paths_matched, start_time.elapsed());
     }
     Ok(match_count)
 }
@@ -371,6 +393,15 @@ fn eprint_nothing_searched() {
     eprintln!("No files were searched, which means ripgrep probably \
                applied a filter you didn't expect. \
                Try running again with --debug.");
+}
+
+fn print_stats(match_count: u64, paths_searched: u64, paths_matched: u64, time_elapsed: Duration) {
+    let time_elapsed = time_elapsed.as_secs() as f64 + time_elapsed.subsec_nanos() as f64 * 1e-9;
+    println!("\n{} matches \n\
+              {} files contained matches \n\
+              {} files searched \n\
+              {:.3} seconds", match_count, paths_matched,
+             paths_searched, time_elapsed);
 }
 
 // The Rust standard library suppresses the default SIGPIPE behavior, so that

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1770,6 +1770,49 @@ be, to a very large extent, the result of luck. Sherlock Holmes
     assert_eq!(lines, expected);
 });
 
+sherlock!(feature_411_single_threaded_search_stats, |wd: WorkDir, mut cmd: Command| {
+    cmd.arg("--stats");
+
+    let lines: String = wd.stdout(&mut cmd);
+    assert_eq!(lines.contains("2 matches"), true);
+    assert_eq!(lines.contains("1 files contained matches"), true);
+    assert_eq!(lines.contains("1 files searched"), true);
+    assert_eq!(lines.contains("seconds"), true);
+});
+
+#[test]
+fn feature_411_parallel_search_stats() {
+    let wd = WorkDir::new("feature_411");
+    wd.create("sherlock_1", hay::SHERLOCK);
+    wd.create("sherlock_2", hay::SHERLOCK);
+
+    let mut cmd = wd.command();
+    cmd.arg("--stats");
+    cmd.arg("Sherlock");
+
+    let lines: String = wd.stdout(&mut cmd);
+    assert_eq!(lines.contains("4 matches"), true);
+    assert_eq!(lines.contains("2 files contained matches"), true);
+    assert_eq!(lines.contains("2 files searched"), true);
+    assert_eq!(lines.contains("seconds"), true);
+}
+
+sherlock!(feature_411_ignore_stats_1, |wd: WorkDir, mut cmd: Command| {
+    cmd.arg("--files-with-matches");
+    cmd.arg("--stats");
+
+    let lines: String = wd.stdout(&mut cmd);
+    assert_eq!(lines.contains("seconds"), false);
+});
+
+sherlock!(feature_411_ignore_stats_2, |wd: WorkDir, mut cmd: Command| {
+    cmd.arg("--files-without-match");
+    cmd.arg("--stats");
+
+    let lines: String = wd.stdout(&mut cmd);
+    assert_eq!(lines.contains("seconds"), false);
+});
+
 #[test]
 fn feature_740_passthru() {
     let wd = WorkDir::new("feature_740");


### PR DESCRIPTION
Creating this PR for review purposes and as a WIP thread for adding the `--stats` flag to ripgrep.

- Implement tracking for basic stats (no. of matches, files with matches, files searched, and time taken)
- Ensure `--stats` is ignored when `--files`, `--files-with-matches` or `--files-without-match` are passed
- Implement tracking of bytes searched for `--no-mmap` searches using the `counting_reader` trick. This will require changing the worker's `run` method to return an Optional `bytes_searched` attribute along with the existing `match_count`. We also need to ensure this happens only when `--stats` is passed.

Other thoughts:

- Have used the default `Duration` implementation from `std` as did not want to pull in any other dependencies such as [`time`](https://crates.io/crates/time) or [`chrono`](https://crates.io/crates/chrono), and this served the purpose very well.
- Have defaulted the time to always display in seconds since this is what `ag` does as well. `rg` also prints only 3 numbers after the decimal point, as opposed to `ag`'s 6.

  The only reasoning behind this is that Rust only allows us to control the digits printed after the decimal point, not overall. If we run a very long search, we don't want to print something like `2751.648931 seconds`. So have chosen the nicer option of 3 digits after the decimal point.

  I think `ag` prints 6 digits overall, with the number of digits printed after the decimal point depending on the overall width of the string. (This is the behaviour I've observed; have not verified this with the code.) 