### PR TITLE
Allow custom ignore files to be used exclusively

### DIFF
--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -1581,6 +1581,22 @@ mod tests {
         wfile(td.path().join("a/bar"), "");
 
         let mut builder = WalkBuilder::new(td.path());
+        builder.add_custom_ignore_filename(&custom_ignore);
+        assert_paths(td.path(), &builder, &["bar", "a", "a/bar"]);
+    }
+
+    #[test]
+    fn custom_ignore_exclusive_use() {
+        let td = TempDir::new("walk-test-").unwrap();
+        let custom_ignore = ".customignore";
+        mkdirp(td.path().join("a"));
+        wfile(td.path().join(custom_ignore), "foo");
+        wfile(td.path().join("foo"), "");
+        wfile(td.path().join("a/foo"), "");
+        wfile(td.path().join("bar"), "");
+        wfile(td.path().join("a/bar"), "");
+
+        let mut builder = WalkBuilder::new(td.path());
         builder.ignore(false);
         builder.git_ignore(false);
         builder.git_global(false);

--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -1581,6 +1581,10 @@ mod tests {
         wfile(td.path().join("a/bar"), "");
 
         let mut builder = WalkBuilder::new(td.path());
+        builder.ignore(false);
+        builder.git_ignore(false);
+        builder.git_global(false);
+        builder.git_exclude(false);
         builder.add_custom_ignore_filename(&custom_ignore);
         assert_paths(td.path(), &builder, &["bar", "a", "a/bar"]);
     }


### PR DESCRIPTION
This change ensures that `add_custom_ignore_filename` works even if all other ignore rules are disabled, see #800.

I'm not whether it is a good idea to adapt the existing unit test (or if I should have added another unit test).