### PR TITLE
fix issue #359 --machine-readable

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -44,6 +44,7 @@ _rg() {
     '(-i -s -S --case-sensitive --ignore-case --smart-case)'{-i,--ignore-case}'[search case-insensitively]'
     '--ignore-file=[specify additional ignore file]:file:_files'
     '(-v --invert-match)'{-v,--invert-match}'[invert matching]'
+    '(-v --machine-readable)'{-v,--machine-readable}'[machine readable]'
     '(-n -N --line-number --no-line-number)'{-n,--line-number}'[show line numbers]'
     '(-N --no-line-number)--line-number-width=[specify width of displayed line number]:number of columns'
     '(-w -x --line-regexp --word-regexp)'{-x,--line-regexp}'[only show matches surrounded by line boundaries]'

--- a/src/app.rs
+++ b/src/app.rs
@@ -532,6 +532,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_ignore_case(&mut args);
     flag_ignore_file(&mut args);
     flag_invert_match(&mut args);
+    flag_machine_readable(&mut args);
     flag_line_number(&mut args);
     flag_line_number_width(&mut args);
     flag_line_regexp(&mut args);
@@ -1023,6 +1024,16 @@ fn flag_invert_match(args: &mut Vec<RGArg>) {
 Invert matching. Show lines that do not match the given patterns.
 ");
     let arg = RGArg::switch("invert-match").short("v")
+        .help(SHORT).long_help(LONG);
+    args.push(arg);
+}
+
+fn flag_machine_readable(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Machine Readable output.";
+    const LONG: &str = long!("\
+Machine Readable output, for integration with external tools.
+");
+    let arg = RGArg::switch("machine-readable")
         .help(SHORT).long_help(LONG);
     args.push(arg);
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -52,6 +52,7 @@ pub struct Args {
     hidden: bool,
     ignore_files: Vec<PathBuf>,
     invert_match: bool,
+    machine_readable: bool,
     line_number: bool,
     line_per_match: bool,
     line_number_width: Option<usize>,
@@ -185,6 +186,7 @@ impl Args {
             .line_per_match(self.line_per_match)
             .null(self.null)
             .only_matching(self.only_matching)
+            .machine_readable(self.machine_readable)
             .path_separator(self.path_separator)
             .with_filename(self.with_filename)
             .max_columns(self.max_columns)
@@ -378,6 +380,7 @@ impl<'a> ArgMatches<'a> {
             hidden: self.hidden(),
             ignore_files: self.ignore_files(),
             invert_match: self.is_present("invert-match"),
+            machine_readable: self.is_present("machine-readable"),
             line_number: line_number,
             line_number_width: try!(self.usize_of("line-number-width")),
             line_per_match: self.is_present("vimgrep"),


### PR DESCRIPTION
@BurntSushi 

addresses
* https://github.com/BurntSushi/ripgrep/issues/359 (json output option to allow scripting #359) 
* https://github.com/BurntSushi/ripgrep/issues/244 (Output format with parseable match indices? #244)
* https://github.com/BurntSushi/ripgrep/issues/462 (machine interface #462)

not using json but something simple:

outputs in format: `file:line:col:byte_offset:match_size:match:`

all the info is there for another tool to do efficient further processing as discussed in https://github.com/BurntSushi/ripgrep/issues/359 or https://github.com/BurntSushi/ripgrep/issues/795#issuecomment-365453598

## example
```
./target/debug/rg --color=never --only-matching --machine-readable 'machine(\-.*|\w)'
complete/_rg:47:12:2858:62:machine-readable)'{-v,--machine-readable}'[machine readable]':

src/printer.rs:68:5:1847:9:machine_:
src/printer.rs:114:13:3762:9:machine_:
src/printer.rs:175:12:5567:9:machine_:
src/printer.rs:176:14:5634:9:machine_:
src/printer.rs:319:17:1728:9:machine_:

src/args.rs:55:5:1225:9:machine_:
src/args.rs:189:14:6155:9:machine_:
src/args.rs:189:36:6177:9:machine_:
src/args.rs:383:13:4832:9:machine_:
src/args.rs:383:48:4867:20:machine-readable"),:

src/app.rs:535:10:4018:9:machine_:
src/app.rs:1031:9:5399:9:machine_:
src/app.rs:1036:30:5620:19:machine-readable"):

grep/src/data/sherlock.txt:9356:5:5141:9:machiner:
grep/src/data/sherlock.txt:12009:36:2316:9:machiner:
```

## design choices
* byte_offset is needed for O(1) access in a file (eg using seek or using a byte buffer)
* line+column is needed for line oriented tools and human convenience
* match_size is needed to know extent of match
* match is needed for tools to do further filtering on matched pattern to allow skipping reading the corresponding file when possible
* file:line:col (and this exact syntax) is a good order for the 1st 3 things to output because ripgrep already outputs in this format, and lots of tools recognize this to jump to a location (eg sublimetext)

## design questions
* not yet sure how to present context (both within line and across neighboring lines)
A tool can just use the match and compute the context by reading the matched file at corresponding location; but maybe we can also output context as follows:

for context within line: all info is present here since we have column + match size:
src/app.rs:1031:9:5399:9:123:here is the entire line:
in format:

`file:line:col:byte_offset:match_size:line_total_size:line:`
where `line_total_size` is useful in case we want to truncate at a max line length

* for context across lines we could do:

src/app.rs:1031:9:5399:9:123:here is previous line\n:here is the entire line\nhere is the next line:
in format:
`file:line_of_context_start:byte_offset_of_context_start:byte_offset_from_context_start:match_size:line_total_size:multi_lines:`

## use cases enabled by this (via external tooling)
* https://github.com/BurntSushi/ripgrep/issues/360 (multiline search for simple cases #360)
* https://github.com/BurntSushi/ripgrep/issues/346 (Feature idea: "context matches" #346)
* sorting without current performance limitation of --sort-files which disables parallelism
* output alignment (see https://github.com/BurntSushi/ripgrep/issues/795#issuecomment-365453598)
* https://github.com/BurntSushi/ripgrep/issues/357 (filter out duplicate results #357)

## TODO
- [ ] update man pages