### PR TITLE
Implement underline support in termcolor (closes #798)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -190,10 +190,10 @@ The --colors` flag is a bit more complicated. The general format is:
 * `{attribute}` should be one of `fg`, `bg` or `style`, corresponding to
   foreground color, background color, or miscellaneous styling (such as whether
   to bold the output or not).
-* `{value}` is determined by the value of `{attribute}`. If `{attribute}` is
-  `style`, then `{value}` should be one of `nobold`, `bold`, `nointense` or
-  `intense`. If `{attribute}` is `fg` or `bg`, then `{value}` should be a
-  color.
+* `{value}` is determined by the value of `{attribute}`. If
+  `{attribute}` is `style`, then `{value}` should be one of `nobold`,
+  `bold`, `nointense`, `intense`, `nounderline` or `underline`. If
+  `{attribute}` is `fg` or `bg`, then `{value}` should be a color.
 
 A color is specified by either one of eight of English names, a single 256-bit
 number or an RGB triple (with over 16 million possible values, or "true

--- a/complete/_rg
+++ b/complete/_rg
@@ -125,7 +125,7 @@ _rg() {
 
         [[ "${state}" == 'style' ]] &&
         _values -S ':' 'style value' \
-          bold nobold intense nointense && return 0
+          bold nobold intense nointense underline nounderline && return 0
         ;;
 
       typespec)

--- a/src/app.rs
+++ b/src/app.rs
@@ -682,7 +682,8 @@ fn flag_colors(args: &mut Vec<RGArg>) {
 This flag specifies color settings for use in the output. This flag may be
 provided multiple times. Settings are applied iteratively. Colors are limited
 to one of eight choices: red, blue, green, cyan, magenta, yellow, white and
-black. Styles are limited to nobold, bold, nointense or intense.
+black. Styles are limited to nobold, bold, nointense, intense, nounderline
+or underline.
 
 The format of the flag is `{type}:{attribute}:{value}`. `{type}` should be
 one of path, line, column or match. `{attribute}` can be fg, bg or style.

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -555,7 +555,8 @@ impl fmt::Display for Error {
             }
             Error::UnrecognizedStyle(ref name) => {
                 write!(f, "Unrecognized style attribute '{}'. Choose from: \
-                           nobold, bold, nointense, intense.", name)
+                           nobold, bold, nointense, intense, nounderline, \
+                           underline.", name)
             }
             Error::InvalidFormat(ref original) => {
                 write!(
@@ -627,7 +628,8 @@ pub struct ColorSpecs {
 /// Valid colors are `black`, `blue`, `green`, `red`, `cyan`, `magenta`,
 /// `yellow`, `white`.
 ///
-/// Valid style instructions are `nobold`, `bold`, `intense`, `nointense`.
+/// Valid style instructions are `nobold`, `bold`, `intense`, `nointense`,
+/// `underline`, `nounderline`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Spec {
     ty: OutType,
@@ -668,6 +670,8 @@ enum Style {
     NoBold,
     Intense,
     NoIntense,
+    Underline,
+    NoUnderline
 }
 
 impl ColorSpecs {
@@ -727,6 +731,8 @@ impl SpecValue {
                     Style::NoBold => { cspec.set_bold(false); }
                     Style::Intense => { cspec.set_intense(true); }
                     Style::NoIntense => { cspec.set_intense(false); }
+                    Style::Underline => { cspec.set_underline(true); }
+                    Style::NoUnderline => { cspec.set_underline(false); }
                 }
             }
         }
@@ -806,6 +812,8 @@ impl FromStr for Style {
             "nobold" => Ok(Style::NoBold),
             "intense" => Ok(Style::Intense),
             "nointense" => Ok(Style::NoIntense),
+            "underline" => Ok(Style::Underline),
+            "nounderline" => Ok(Style::NoUnderline),
             _ => Err(Error::UnrecognizedStyle(s.to_string())),
         }
     }
@@ -857,6 +865,12 @@ mod tests {
         assert_eq!(spec, Spec {
             ty: OutType::Match,
             value: SpecValue::Style(Style::Intense),
+        });
+
+        let spec: Spec = "match:style:underline".parse().unwrap();
+        assert_eq!(spec, Spec {
+            ty: OutType::Match,
+            value: SpecValue::Style(Style::Underline),
         });
 
         let spec: Spec = "line:none".parse().unwrap();

--- a/termcolor/src/lib.rs
+++ b/termcolor/src/lib.rs
@@ -980,6 +980,9 @@ impl<W: io::Write> WriteColor for Ansi<W> {
         if spec.bold {
             self.write_str("\x1B[1m")?;
         }
+        if spec.underline {
+            self.write_str("\x1B[4m")?;
+        }
         Ok(())
     }
 
@@ -1212,6 +1215,7 @@ pub struct ColorSpec {
     bg_color: Option<Color>,
     bold: bool,
     intense: bool,
+    underline: bool,
 }
 
 impl ColorSpec {
@@ -1251,6 +1255,19 @@ impl ColorSpec {
         self
     }
 
+    /// Get whether this is underline or not.
+    ///
+    /// Note that the underline setting has no effect in a Windows console.
+    pub fn underline(&self) -> bool { self.underline }
+
+    /// Set whether the text is underlined or not.
+    ///
+    /// Note that the underline setting has no effect in a Windows console.
+    pub fn set_underline(&mut self, yes: bool) -> &mut ColorSpec {
+        self.underline = yes;
+        self
+    }
+
     /// Get whether this is intense or not.
     pub fn intense(&self) -> bool { self.intense }
 
@@ -1262,7 +1279,8 @@ impl ColorSpec {
 
     /// Returns true if this color specification has no colors or styles.
     pub fn is_none(&self) -> bool {
-        self.fg_color.is_none() && self.bg_color.is_none() && !self.bold
+        self.fg_color.is_none() && self.bg_color.is_none()
+            && !self.bold && !self.underline
     }
 
     /// Clears this color specification so that it has no color/style settings.
@@ -1270,6 +1288,7 @@ impl ColorSpec {
         self.fg_color = None;
         self.bg_color = None;
         self.bold = false;
+        self.underline = false;
     }
 
     /// Writes this color spec to the given Windows console.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1152,7 +1152,8 @@ clean!(regression_428_unrecognized_style, "Sherlok", ".",
     let output = cmd.output().unwrap();
     let err = String::from_utf8_lossy(&output.stderr);
     let expected = "\
-Unrecognized style attribute ''. Choose from: nobold, bold, nointense, intense.
+Unrecognized style attribute ''. Choose from: nobold, bold, nointense, intense, \
+nounderline, underline.
 ";
     assert_eq!(err, expected);
 });


### PR DESCRIPTION
Closes #798 

This PR implements underline support in `termcolor`. Hopefully I've done it right because it seemed straightforward enough to implement. 😄

I tested this by doing `./target/release/rg 'bufwtr' --colors 'match:style:underline'` on my PC after building `rg`, and I was able to see underlined text.