### PR TITLE
Add termcolor docs explaining what intense does (closes #797)

### DIFF
--- a/termcolor/src/lib.rs
+++ b/termcolor/src/lib.rs
@@ -1252,9 +1252,23 @@ impl ColorSpec {
     }
 
     /// Get whether this is intense or not.
+    ///
+    /// On Unix-like systems, this will output the ANSI escape sequence
+    /// that will print a high-intensity version of the color
+    /// specified.
+    ///
+    /// On Windows systems, this will output the ANSI escape sequence
+    /// that will print a brighter version of the color specified.
     pub fn intense(&self) -> bool { self.intense }
 
     /// Set whether the text is intense or not.
+    ///
+    /// On Unix-like systems, this will output the ANSI escape sequence
+    /// that will print a high-intensity version of the color
+    /// specified.
+    ///
+    /// On Windows systems, this will output the ANSI escape sequence
+    /// that will print a brighter version of the color specified.
     pub fn set_intense(&mut self, yes: bool) -> &mut ColorSpec {
         self.intense = yes;
         self


### PR DESCRIPTION
I went through the code (and searched the WWW) to understand what the `intense` parameter does in `termcolor`. Hopefully I've captured the intent behind them to the best of my understanding.