### PR TITLE
globset: support backslash escaping

### DIFF
--- a/globset/src/lib.rs
+++ b/globset/src/lib.rs
@@ -154,6 +154,8 @@ pub enum ErrorKind {
     /// Occurs when an alternating group is nested inside another alternating
     /// group, e.g., `{{a,b},{c,d}}`.
     NestedAlternates,
+    /// Occurs when an unescaped '\' is found at the end of a glob.
+    DanglingEscape,
     /// An error associated with parsing or compiling a regex.
     Regex(String),
 }
@@ -199,6 +201,9 @@ impl ErrorKind {
             ErrorKind::NestedAlternates => {
                 "nested alternate groups are not allowed"
             }
+            ErrorKind::DanglingEscape => {
+                "dangling '\\'"
+            }
             ErrorKind::Regex(ref err) => err,
         }
     }
@@ -223,6 +228,7 @@ impl fmt::Display for ErrorKind {
             | ErrorKind::UnopenedAlternates
             | ErrorKind::UnclosedAlternates
             | ErrorKind::NestedAlternates
+            | ErrorKind::DanglingEscape
             | ErrorKind::Regex(_) => {
                 write!(f, "{}", self.description())
             }

--- a/ignore/src/gitignore.rs
+++ b/ignore/src/gitignore.rs
@@ -477,6 +477,7 @@ impl GitignoreBuilder {
             GlobBuilder::new(&glob.actual)
                 .literal_separator(literal_separator)
                 .case_insensitive(self.case_insensitive)
+                .backslash_escape(true)
                 .build()
                 .map_err(|err| {
                     Error::Glob {
@@ -635,6 +636,9 @@ mod tests {
     ignored!(ig35, "./.", ".a/b", ".a/b");
     ignored!(ig36, "././", ".a/b", ".a/b");
     ignored!(ig37, "././.", ".a/b", ".a/b");
+    ignored!(ig38, ROOT, "\\[", "[");
+    ignored!(ig39, ROOT, "\\?", "?");
+    ignored!(ig40, ROOT, "\\*", "*");
 
     not_ignored!(ignot1, ROOT, "amonths", "months");
     not_ignored!(ignot2, ROOT, "monthsa", "months");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -800,11 +800,7 @@ clean!(regression_25, "test", ".", |wd: WorkDir, mut cmd: Command| {
 
 // See: https://github.com/BurntSushi/ripgrep/issues/30
 clean!(regression_30, "test", ".", |wd: WorkDir, mut cmd: Command| {
-    if cfg!(windows) {
-        wd.create(".gitignore", "vendor/**\n!vendor\\manifest");
-    } else {
-        wd.create(".gitignore", "vendor/**\n!vendor/manifest");
-    }
+    wd.create(".gitignore", "vendor/**\n!vendor/manifest");
     wd.create_dir("vendor");
     wd.create("vendor/manifest", "test");
 


### PR DESCRIPTION
From `man 7 glob`:

    One can remove the special meaning of '?', '*' and '[' by preceding
    them by a backslash, or, in case this is part of a shell command
    line, enclosing them in quotes.

Conform to glob / fnmatch / git implementations by parsing `\?`, `\*`
and `\[` as literal `?`, `*` and `[`. If a backslash is followed by
anything else, parse it as before.

Closes #526