### PR TITLE
Donation of homebrew-convenience

### DIFF
--- a/ci/update-homebrew-formula.sh
+++ b/ci/update-homebrew-formula.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -eu -o pipefail
+
+[[ $# != 1 ]] && {
+  echo 1>&2 "USAGE: $0 <tag>"
+  exit 2
+}
+
+SRC_DIR="$(cd "${0%/*}/.." && pwd)"
+VERSION="${1:?}"
+TEMPLATE_FILE="${SRC_DIR}/pkg/brew/ripgrep-bin.rb.in"
+HOMEBREW_FILE="${TEMPLATE_FILE%.*}"
+
+OSX_FILE=ripgrep-${VERSION}-x86_64-apple-darwin.tar.gz
+LINUX_FILE=ripgrep-${VERSION}-x86_64-unknown-linux-musl.tar.gz
+URL_PREFIX=https://github.com/BurntSushi/ripgrep/releases/download/${VERSION}
+
+# shellcheck disable=2027,2064
+trap "rm -f $OSX_FILE $LINUX_FILE; exit 1" INT
+
+SLEEP_INTERVAL=5
+ROUND=0
+while ! [[ -f $OSX_FILE && -f $LINUX_FILE ]]; do
+  [[ $ROUND == 0 ]] && {
+    echo 1>&2 "Waiting for '$OSX_FILE' and '$LINUX_FILE' to become available... (Ctrl+C to interrupt)"
+  }
+  ROUND=$((ROUND + 1))
+  
+  for file in "$OSX_FILE" "$LINUX_FILE"; do 
+    [[ -f $file ]] && continue
+    { curl --fail -sLo "$file" "$URL_PREFIX/$file" \
+        && echo 1>&2 "Downloaded '$file'"; } || true
+  done
+  echo 1>&2 -n '.'
+  sleep $SLEEP_INTERVAL
+done
+
+SHA_SUM=$(
+  which sha256sum 2>/dev/null \
+  || which gsha256sum 2>/dev/null \
+  || { echo 1>&2 "sha256 program not found"; false; } \
+)
+
+OSX_SHA256="$($SHA_SUM "$OSX_FILE" | awk '{print $1}')"
+LINUX_SHA256="$($SHA_SUM "$LINUX_FILE" | awk '{print $1}')"
+TEMPLATE_NOTE="---> DO NOT EDIT <--- (this file was generated from $TEMPLATE_FILE"
+export VERSION OSX_SHA256 LINUX_SHA256 TEMPLATE_NOTE
+
+envsubst < "$TEMPLATE_FILE" > "$HOMEBREW_FILE" && {
+  echo 1>&2 'homebrew update finished'
+}

--- a/pkg/brew/ripgrep-bin.rb.in
+++ b/pkg/brew/ripgrep-bin.rb.in
@@ -1,15 +1,15 @@
 class RipgrepBin < Formula
-  # ---> DO NOT EDIT <--- (this file was generated from /Users/byron/dev/ripgrep/pkg/brew/ripgrep-bin.rb.in
-  version '0.8.1'
+  # ${TEMPLATE_NOTE}
+  version '${VERSION}'
   desc "Recursively search directories for a regex pattern."
   homepage "https://github.com/BurntSushi/ripgrep"
 
   if OS.mac?
       url "https://github.com/BurntSushi/ripgrep/releases/download/#{version}/ripgrep-#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "71f8d2907b473e5fc30159b822b0f1de247634ee292d5cc3fa1bb80222e0f613"
+      sha256 "${OSX_SHA256}"
   elsif OS.linux?
       url "https://github.com/BurntSushi/ripgrep/releases/download/#{version}/ripgrep-#{version}-x86_64-unknown-linux-musl.tar.gz"
-      sha256 "08b1aa1440a23a88c94cff41a860340ecf38e9108817aff30ff778c00c63eb76"
+      sha256 "${LINUX_SHA256}"
   end
 
   conflicts_with "ripgrep"


### PR DESCRIPTION
Hi @BurntSushi ,

first of all let me say that I use `rg` every day, it replaced everything else and it's good to know to use the best of the best! Thanks you so much for making it, and even more for maintaining it!

Homebrew for quite some time was a black box to me! I was using it, but had no idea how to bring my own programs in. A random perusal of the `ripgrep` repository finally gave me the hints I needed to implement a tap for [`termbook`][termbook].

After a few releases I realized that I was quite annoyed by the additional maintenance burden - now I had to wait for travis to build the binaries, download the archives, and update hashes.
Judging from you commit-history on `pkg/brew`, it's a manual process for you, too.

So I thought: let's fix this, and make it as easy as a single program invocation, fire and forget.
For `termbook` it's just `make update-homebrew`, and for this repository, and due to a lack of a better place, it is the following:

```bash
./ci/update-homebrew-formula.sh 0.8.1
```

The script is to be executed manually for now, and can certainly serve as basis for even more automation.

Please let me know if you find it useful, or if you need some changes to make it more suitable for `ripgrep`.

*Maybe I can also ask you how it's possible to get a program into homebrew core? Is it as easy as a PR?*

[termbook]: https://github.com/Byron/termbook