### PR TITLE
Add scoop install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ If you're a **Windows Chocolatey** user, then you can install ripgrep from the [
 $ choco install ripgrep
 ```
 
+If you're a **Windows Scoop** user, then you can install ripgrep from the [official bucket](https://github.com/lukesampson/scoop/blob/master/bucket/ripgrep.json):
+
+```
+$ scoop install ripgrep
+```
+
 If you're an **Arch Linux** user, then you can install ripgrep from the official repos:
 
 ```


### PR DESCRIPTION
Scoop, a popular Windows package manager, lists and regularly updates ripgrep. Would be useful to add instructions.