### PR TITLE
update regex to 0.2.9, enables portable binary releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+0.9.0 (TBD)
+===========
+This is a new minor version release of ripgrep that mostly contains bug fixes.
+
+Releases provided on Github for `x86` and `x86_64` will now work on all target
+CPUs, and will also automatically take advantage of features found on modern
+CPUs (such as AVX2) for additional optimizations.
+
+**BREAKING CHANGES**:
+
+* When `--count` and `--only-matching` are provided simultaneously, the
+  behavior of ripgrep is as if the `--count-matches` flag was given. That is,
+  the total number of matches is reported, where there may be multiple matches
+  per line. Previously, the behavior of ripgrep was to report the total number
+  of matching lines. (Note that this behavior diverges from the behavior of
+  GNU grep.)
+
+Feature enhancements:
+
+* [FEATURE #411](https://github.com/BurntSushi/ripgrep/issues/411):
+  Add a `--stats` flag, which emits aggregate statistics after search results.
+* [FEATURE #812](https://github.com/BurntSushi/ripgrep/issues/812):
+  Add `-b/--byte-offset` flag that reports byte offset of each matching line.
+* [FEATURE #814](https://github.com/BurntSushi/ripgrep/issues/814):
+  Add `--count-matches` flag, which is like `--count`, but for each match.
+
+Bug fixes:
+
+* [BUG #135](https://github.com/BurntSushi/ripgrep/issues/135):
+  Release portable binaries that conditionally use SSSE3, AVX2, etc., at
+  runtime.
+* [BUG #526](https://github.com/BurntSushi/ripgrep/issues/526):
+  Support backslash escapes in globs.
+* [BUG #832](https://github.com/BurntSushi/ripgrep/issues/832):
+  Clarify usage instructions for `-f/--file` flag.
+* [BUG #852](https://github.com/BurntSushi/ripgrep/issues/852):
+  Be robust with respect to `ENOMEM` errors returned by `mmap`.
+
+
 0.8.1 (2018-02-20)
 ==================
 This is a patch release of ripgrep that primarily fixes regressions introduced

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ version = "0.1.8"
 dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -121,7 +121,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -207,13 +207,12 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "simd 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -222,6 +221,14 @@ dependencies = [
 name = "regex-syntax"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex-syntax"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "ripgrep"
@@ -240,7 +247,7 @@ dependencies = [
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.5",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -305,6 +312,11 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ucd-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
@@ -388,8 +400,9 @@ dependencies = [
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5be5347bde0c48cfd8c3fdc0766cdfe9d8a755ef84d620d6794c778c91de8b2b"
+"checksum regex 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bde64a9b799f85750f6469fd658cff5fce8d910a7d510858a1f9d15ca9f023bf"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
+"checksum regex-syntax 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d8337992c33b62cf49462a1ce4d0eedbb021f48de017e40ec307cca445df0ca9"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum simd 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd0805c7363ab51a829a1511ad24b6ed0349feaa756c4bc2f977f9f496e6673"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
@@ -397,6 +410,7 @@ dependencies = [
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ log = "0.4"
 memchr = "2"
 memmap = "0.6"
 num_cpus = "1"
-regex = "0.2.4"
+regex = "0.2.9"
 same-file = "1"
 termcolor = { version = "0.3.4", path = "termcolor" }
 
@@ -67,12 +67,13 @@ default-features = false
 features = ["suggestions", "color"]
 
 [features]
-avx-accel = ["bytecount/avx-accel"]
+avx-accel = ["bytecount/avx-accel", "regex/unstable"]
 simd-accel = [
   "bytecount/simd-accel",
-  "regex/simd-accel",
   "encoding_rs/simd-accel",
+  "regex/unstable",
 ]
+unstable = ["regex/unstable"]
 
 [profile.release]
 debug = true

--- a/README.md
+++ b/README.md
@@ -286,6 +286,14 @@ If you're a **Rust programmer**, ripgrep can be installed with `cargo`.
 $ cargo install ripgrep
 ```
 
+If you're using Rust nightly, then use
+
+```
+$ cargo install ripgrep --features unstable
+```
+
+to get SIMD optimizations.
+
 ripgrep isn't currently in any other package repositories.
 [I'd like to change that](https://github.com/BurntSushi/ripgrep/issues/10).
 
@@ -312,7 +320,8 @@ RUSTFLAGS="-C target-cpu=native" cargo build --release --features 'simd-accel av
 ```
 
 If your machine doesn't support AVX instructions, then simply remove
-`avx-accel` from the features list. Similarly for SIMD.
+`avx-accel` from the features list. Similarly for SIMD (which corresponds
+roughly to SSE instructions).
 
 
 ### Running tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,8 +50,7 @@ test_script:
 
 before_deploy:
   # Generate artifacts for release
-  # TODO(burntsushi): How can we enable SSSE3 on Windows?
-  - cargo build --release
+  - cargo build --release --features unstable
   - mkdir staging
   - copy target\release\rg.exe staging
   - ps: copy target\release\build\ripgrep-*\out\_rg.ps1 staging

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -8,12 +8,7 @@ set -ex
 
 # Generate artifacts for release
 mk_artifacts() {
-    if is_ssse3_target; then
-        RUSTFLAGS="-C target-feature=+ssse3" \
-        cargo build --target "$TARGET" --release --features simd-accel
-    else
-        cargo build --target "$TARGET" --release
-    fi
+    cargo build --target "$TARGET" --release --features unstable
 }
 
 mk_tarball() {

--- a/globset/Cargo.toml
+++ b/globset/Cargo.toml
@@ -23,7 +23,7 @@ aho-corasick = "0.6.0"
 fnv = "1.0"
 log = "0.4"
 memchr = "2"
-regex = "0.2.1"
+regex = "0.2.9"
 
 [dev-dependencies]
 glob = "0.2"

--- a/grep/Cargo.toml
+++ b/grep/Cargo.toml
@@ -15,5 +15,5 @@ license = "Unlicense/MIT"
 [dependencies]
 log = "0.4"
 memchr = "2"
-regex = "0.2.1"
+regex = "0.2.9"
 regex-syntax = "0.4.0"

--- a/ignore/Cargo.toml
+++ b/ignore/Cargo.toml
@@ -23,7 +23,7 @@ globset = { version = "0.3.0", path = "../globset" }
 lazy_static = "1"
 log = "0.4"
 memchr = "2"
-regex = "0.2.1"
+regex = "0.2.9"
 same-file = "1"
 thread_local = "0.3.2"
 walkdir = "2"

--- a/src/args.rs
+++ b/src/args.rs
@@ -599,7 +599,7 @@ impl<'a> ArgMatches<'a> {
         // This would normally just be an empty string, which works on its
         // own, but if the patterns are joined in a set of alternations, then
         // you wind up with `foo|`, which is invalid.
-        self.word_pattern("z{0}".to_string())
+        self.word_pattern("(?:z{0})*".to_string())
     }
 
     /// Returns true if and only if file names containing each match should


### PR DESCRIPTION
Pretty much what it says on the tin. This also brings in new AVX2 optimizations added in the regex crate. See: https://github.com/rust-lang/regex/pull/456

We also employ the totally novel idea of updating the CHANGELOG incrementally, instead of doing everything in one swoop during a release.

Note that this does not move to `regex-syntax 0.5.0` yet. That requires a bit more work.