### PR TITLE
Add --no-error-messages to suppress search-time errors

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -61,6 +61,7 @@ _rg() {
     "--no-ignore-parent[don't respect ignore files in parent directories]"
     "--no-ignore-vcs[don't respect version control ignore files]"
     '(-n -N --line-number --no-line-number)'{-N,--no-line-number}'[suppress line numbers]'
+    '--no-error-messages[suppresses errors while searching]'
     '--no-messages[suppress all error messages]'
     "(--mmap --no-mmap)--no-mmap[don't search using memory maps]"
     '(-0 --null)'{-0,--null}'[print NUL byte after file names]'

--- a/src/app.rs
+++ b/src/app.rs
@@ -543,6 +543,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_maxdepth(&mut args);
     flag_mmap(&mut args);
     flag_no_config(&mut args);
+    flag_no_error_messages(&mut args);
     flag_no_ignore(&mut args);
     flag_no_ignore_parent(&mut args);
     flag_no_ignore_vcs(&mut args);
@@ -1294,6 +1295,26 @@ This flag can be disabled with the --messages flag.
     let arg = RGArg::switch("messages")
         .hidden()
         .overrides("no-messages");
+    args.push(arg);
+}
+
+fn flag_no_error_messages(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Suppress errors while searching.";
+    const LONG: &str = long!("\
+Suppresses messages for errors encountered while searching the filesystem,
+but keeps rg's own errors and suggestions enabled, for example, suppressing
+permission denied messages for files the user has no permission to search.
+
+This flag can be disabled with the --error-messages flag.
+");
+    let arg = RGArg::switch("no-error-messages")
+        .help(SHORT).long_help(LONG)
+        .overrides("error-messages");
+    args.push(arg);
+
+    let arg = RGArg::switch("error-messages")
+        .hidden()
+        .overrides("no-error-messages");
     args.push(arg);
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -65,6 +65,7 @@ pub struct Args {
     no_ignore: bool,
     no_ignore_parent: bool,
     no_ignore_vcs: bool,
+    no_error_messages: bool,
     no_messages: bool,
     null: bool,
     only_matching: bool,
@@ -280,6 +281,7 @@ impl Args {
             .invert_match(self.invert_match)
             .max_count(self.max_count)
             .mmap(self.mmap)
+            .no_error_messages(self.no_error_messages)
             .no_messages(self.no_messages)
             .quiet(self.quiet)
             .text(self.text)
@@ -301,6 +303,11 @@ impl Args {
     /// loaded and then exit.
     pub fn type_list(&self) -> bool {
         self.type_list
+    }
+
+    /// Returns true if errors searching files should be suppressed.
+    pub fn no_error_messages(&self) -> bool {
+        self.no_error_messages
     }
 
     /// Returns true if error messages should be suppressed.
@@ -327,7 +334,7 @@ impl Args {
         }
         for path in &self.ignore_files {
             if let Some(err) = wd.add_ignore(path) {
-                if !self.no_messages {
+                if !self.no_messages && !self.no_error_messages {
                     eprintln!("{}", err);
                 }
             }
@@ -404,6 +411,7 @@ impl<'a> ArgMatches<'a> {
             no_ignore: self.no_ignore(),
             no_ignore_parent: self.no_ignore_parent(),
             no_ignore_vcs: self.no_ignore_vcs(),
+			no_error_messages: self.is_present("no-error-messages"),
             no_messages: self.is_present("no-messages"),
             null: self.is_present("null"),
             only_matching: self.is_present("only-matching"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn run_parallel(args: &Arc<Args>) -> Result<u64> {
                 result,
                 args.stdout_handle(),
                 args.files(),
-                args.no_messages(),
+                args.no_messages() || args.no_error_messages(),
             ) {
                 None => return Continue,
                 Some(dent) => dent,
@@ -175,7 +175,7 @@ fn run_one_thread(args: &Arc<Args>) -> Result<u64> {
             result,
             args.stdout_handle(),
             args.files(),
-            args.no_messages(),
+            args.no_messages() || args.no_error_messages(),
         ) {
             None => continue,
             Some(dent) => dent,
@@ -240,7 +240,7 @@ fn run_files_parallel(args: Arc<Args>) -> Result<u64> {
                 result,
                 args.stdout_handle(),
                 args.files(),
-                args.no_messages(),
+                args.no_messages() || args.no_error_messages(),
             ) {
                 tx.send(dent).unwrap();
             }
@@ -259,7 +259,7 @@ fn run_files_one_thread(args: &Arc<Args>) -> Result<u64> {
             result,
             args.stdout_handle(),
             args.files(),
-            args.no_messages(),
+            args.no_messages() || args.no_error_messages(),
         ) {
             None => continue,
             Some(dent) => dent,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -42,6 +42,7 @@ struct Options {
     invert_match: bool,
     line_number: bool,
     max_count: Option<u64>,
+    no_error_messages: bool,
     no_messages: bool,
     quiet: bool,
     text: bool,
@@ -64,6 +65,7 @@ impl Default for Options {
             invert_match: false,
             line_number: false,
             max_count: None,
+            no_error_messages: false,
             no_messages: false,
             quiet: false,
             text: false,
@@ -196,6 +198,14 @@ impl WorkerBuilder {
         self
     }
 
+    /// If enabled, error messages while searching files are suppressed.
+    ///
+    /// This is disabled by default.
+    pub fn no_error_messages(mut self, yes: bool) -> Self {
+        self.opts.no_error_messages = yes;
+        self
+    }
+
     /// If enabled, error messages are suppressed.
     ///
     /// This is disabled by default.
@@ -263,7 +273,7 @@ impl Worker {
                     let file = match File::open(path) {
                         Ok(file) => file,
                         Err(err) => {
-                            if !self.opts.no_messages {
+                            if !self.opts.no_messages && !self.opts.no_error_messages {
                                 eprintln!("{}: {}", path.display(), err);
                             }
                             return 0;
@@ -285,7 +295,7 @@ impl Worker {
                 count
             }
             Err(err) => {
-                if !self.opts.no_messages {
+                if !self.opts.no_messages && !self.opts.no_error_messages {
                     eprintln!("{}", err);
                 }
                 0


### PR DESCRIPTION
In mixed-permission trees (such as `C:\Users\USERNAME\`), the valid
results are vastly outnumbered by the invalid ones for most searches,
due to restrictions on accessing OS-owned paths/files. Unfortunately,
the traditional unix greybeard `2>/dev/null` (and, as I learned
modifying the source code, the `--no-messages` which does just that and
only that) suppresses `rg` errors only too well, including those that
one would _not_ prefer to be hidden/swallowed, such as warnings about no
folders searched, errors in the syntax, etc.

This necessitates an initial run of `rg ....` followed by a hasty ^C as
the file access errors accumulate and then a repeated search redirected
to stderr `rg .... 2>/dev/null` now that the search pattern is verified
correct to filter out those errors.

This patch adds a `--no-error-messages` (which could maybe use a better
name to distinguish it from the existing `--no-messages`, perhaps
`--no-search-errors`?) to achieve just that.

Sidenote: it seems that a `--no-messages` doing nothing more than
globally redirecting all `stderr` output to the ether is of possibly
limited utility. In the interest of preserving backwards compatibility,
this patch was written to add `--no-error-messages` rather than changing
`--no-messages`' behavior to emit rg's own error messages but swallow
I/O errors during the actual search (as this new argument does). Anyone
actually wanting all of `stderr` silenced is welcome to pick up a primer
on unix shells and can learn about just how powerful and customizable
shell scripts can be. /ENDRANT