### PR TITLE
Fix bold, intense color on Windows 10 console.

### DIFF
--- a/termcolor/src/lib.rs
+++ b/termcolor/src/lib.rs
@@ -971,17 +971,17 @@ impl<W: io::Write> WriteColor for Ansi<W> {
 
     fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
         self.reset()?;
-        if let Some(ref c) = spec.fg_color {
-            self.write_color(true, c, spec.intense)?;
-        }
-        if let Some(ref c) = spec.bg_color {
-            self.write_color(false, c, spec.intense)?;
-        }
         if spec.bold {
             self.write_str("\x1B[1m")?;
         }
         if spec.underline {
             self.write_str("\x1B[4m")?;
+        }
+        if let Some(ref c) = spec.fg_color {
+            self.write_color(true, c, spec.intense)?;
+        }
+        if let Some(ref c) = spec.bg_color {
+            self.write_color(false, c, spec.intense)?;
         }
         Ok(())
     }


### PR DESCRIPTION
There is an issue with the Windows 10 console where if you issue the bold
escape sequence after one of the extended foreground colors, it overrides the
color.  This happens in termcolor if you have bold, intense, and color set.
The workaround is to issue the bold sequence before the color.

This is for rust-lang/rust#49322.