### PR TITLE
Add Clone / Debug instance for GitignoreBuilder and GlobsetBuilder

### DIFF
--- a/globset/src/lib.rs
+++ b/globset/src/lib.rs
@@ -441,6 +441,7 @@ impl GlobSet {
 
 /// GlobSetBuilder builds a group of patterns that can be used to
 /// simultaneously match a file path.
+#[derive(Clone, Debug)]
 pub struct GlobSetBuilder {
     pats: Vec<Glob>,
 }

--- a/ignore/src/gitignore.rs
+++ b/ignore/src/gitignore.rs
@@ -301,6 +301,7 @@ impl Gitignore {
 }
 
 /// Builds a matcher for a single set of globs from a .gitignore file.
+#[derive(Clone, Debug)]
 pub struct GitignoreBuilder {
     builder: GlobSetBuilder,
     root: PathBuf,


### PR DESCRIPTION
The clone instance for GitignoreBuilder is useful when building a gitignore line-by-line from user input, checking that they match some file as they are added. GitignoreBuilder and GlobsetBuilder look plain enough to have a clone instance.