### PR TITLE
ignore: impl Clone for DirEntry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.2.8"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -48,7 +48,7 @@ version = "2.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -230,7 +230,7 @@ dependencies = [
 name = "ripgrep"
 version = "0.8.1"
 dependencies = [
- "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecount 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -376,7 +376,7 @@ dependencies = [
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "af80143d6f7608d746df1520709e5d141c96f240b0e62b0aa41bdfb53374d9d4"
+"checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum bytecount 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "882585cd7ec84e902472df34a5e01891202db3bf62614e1f0afe459c1afcf744"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ path = "tests/tests.rs"
 members = ["grep", "globset", "ignore", "termcolor", "wincolor"]
 
 [dependencies]
-atty = "0.2.2"
+atty = "=0.2.6"
 bytecount = "0.3.1"
 encoding_rs = "0.7"
 globset = { version = "0.3.0", path = "globset" }

--- a/ignore/src/lib.rs
+++ b/ignore/src/lib.rs
@@ -132,6 +132,44 @@ pub enum Error {
     InvalidDefinition,
 }
 
+impl Clone for Error {
+    fn clone(&self) -> Error {
+        match *self {
+            Error::Partial(ref errs) => Error::Partial(errs.clone()),
+            Error::WithLineNumber { line, ref err } => {
+                Error::WithLineNumber { line: line, err: err.clone() }
+            }
+            Error::WithPath { ref path, ref err } => {
+                Error::WithPath { path: path.clone(), err: err.clone() }
+            }
+            Error::WithDepth { depth, ref err } => {
+                Error::WithDepth { depth: depth, err: err.clone() }
+            }
+            Error::Loop { ref ancestor, ref child } => {
+                Error::Loop {
+                    ancestor: ancestor.clone(),
+                    child: child.clone()
+                }
+            }
+            Error::Io(ref err) => {
+                match err.raw_os_error() {
+                    Some(e) => Error::Io(io::Error::from_raw_os_error(e)),
+                    None => {
+                        Error::Io(io::Error::new(err.kind(), err.to_string()))
+                    }
+                }
+            }
+            Error::Glob { ref glob, ref err } => {
+                Error::Glob { glob: glob.clone(), err: err.clone() }
+            }
+            Error::UnrecognizedFileType(ref err) => {
+                Error::UnrecognizedFileType(err.clone())
+            }
+            Error::InvalidDefinition => Error::InvalidDefinition,
+        }
+    }
+}
+
 impl Error {
     /// Returns true if this is a partial error.
     ///

--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -24,7 +24,7 @@ use {Error, PartialErrorBuilder};
 ///
 /// The error typically refers to a problem parsing ignore files in a
 /// particular directory.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DirEntry {
     dent: DirEntryInner,
     err: Option<Error>,
@@ -126,7 +126,7 @@ impl DirEntry {
 ///
 /// Specifically, (3) has to essentially re-create the DirEntry implementation
 /// from WalkDir.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 enum DirEntryInner {
     Stdin,
     Walkdir(walkdir::DirEntry),
@@ -235,6 +235,7 @@ impl DirEntryInner {
 
 /// DirEntryRaw is essentially copied from the walkdir crate so that we can
 /// build `DirEntry`s from whole cloth in the parallel iterator.
+#[derive(Clone)]
 struct DirEntryRaw {
     /// The path as reported by the `fs::ReadDir` iterator (even if it's a
     /// symbolic link).


### PR DESCRIPTION
There is a small hiccup here in that a `DirEntry` can embed errors
associated with reading an ignore file, which can be accessed and logged
by consumers if desired. That error type can contain an io::Error, which
isn't cloneable. We therefore implement Clone on our library's error
type in a way that re-creates the I/O error as best as possible.

Fixes #891
