### PR TITLE
Added verilog type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -275,6 +275,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("twig", &["*.twig"]),
     ("vala", &["*.vala"]),
     ("vb", &["*.vb"]),
+    ("verilog", &["*.v", "*.vh", "*.sv", "*.svh"]),
     ("vhdl", &["*.vhd", "*.vhdl"]),
     ("vim", &["*.vim"]),
     ("vimscript", &["*.vim"]),


### PR DESCRIPTION
This adds a verilog type (.v & .vh).
This also includes the typical SystemVerilog extensions (.sv & .svh).
System Verilog is an extension to Verilog, but I think you can combine both in one rg type.