### PR TITLE
ignore: speed up Gitignore::empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Bug fixes:
   Fix problems with `--line-number-width` by removing it.
 * [BUG #832](https://github.com/BurntSushi/ripgrep/issues/832):
   Clarify usage instructions for `-f/--file` flag.
+* [BUG #835](https://github.com/BurntSushi/ripgrep/issues/835):
+  Fix small performance regression while crawling very large directory trees.
 * [BUG #851](https://github.com/BurntSushi/ripgrep/issues/851):
   Fix `-S/--smart-case` detection once and for all.
 * [BUG #852](https://github.com/BurntSushi/ripgrep/issues/852):

--- a/globset/src/lib.rs
+++ b/globset/src/lib.rs
@@ -288,6 +288,14 @@ pub struct GlobSet {
 }
 
 impl GlobSet {
+    /// Create an empty `GlobSet`. An empty set matches nothing.
+    pub fn empty() -> GlobSet {
+        GlobSet {
+            len: 0,
+            strats: vec![],
+        }
+    }
+
     /// Returns true if this set is empty, and therefore matches nothing.
     pub fn is_empty(&self) -> bool {
         self.len == 0

--- a/ignore/src/dir.rs
+++ b/ignore/src/dir.rs
@@ -209,7 +209,9 @@ impl Ignore {
     fn add_child_path(&self, dir: &Path) -> (IgnoreInner, Option<Error>) {
         let mut errs = PartialErrorBuilder::default();
         let custom_ig_matcher =
-            {
+            if self.0.custom_ignore_filenames.is_empty() {
+                Gitignore::empty()
+            } else {
                 let (m, err) =
                     create_gitignore(&dir, &self.0.custom_ignore_filenames);
                 errs.maybe_push(err);

--- a/ignore/src/gitignore.rs
+++ b/ignore/src/gitignore.rs
@@ -83,7 +83,7 @@ pub struct Gitignore {
     globs: Vec<Glob>,
     num_ignores: u64,
     num_whitelists: u64,
-    matches: Arc<ThreadLocal<RefCell<Vec<usize>>>>,
+    matches: Option<Arc<ThreadLocal<RefCell<Vec<usize>>>>>,
 }
 
 impl Gitignore {
@@ -143,7 +143,14 @@ impl Gitignore {
     ///
     /// Its path is empty.
     pub fn empty() -> Gitignore {
-        GitignoreBuilder::new("").build().unwrap()
+        Gitignore {
+            set: GlobSet::empty(),
+            root: PathBuf::from(""),
+            globs: vec![],
+            num_ignores: 0,
+            num_whitelists: 0,
+            matches: None,
+        }
     }
 
     /// Returns the directory containing this gitignore matcher.
@@ -249,7 +256,7 @@ impl Gitignore {
             return Match::None;
         }
         let path = path.as_ref();
-        let _matches = self.matches.get_default();
+        let _matches = self.matches.as_ref().unwrap().get_default();
         let mut matches = _matches.borrow_mut();
         let candidate = Candidate::new(path);
         self.set.matches_candidate_into(&candidate, &mut *matches);
@@ -345,7 +352,7 @@ impl GitignoreBuilder {
             globs: self.globs.clone(),
             num_ignores: nignore as u64,
             num_whitelists: nwhite as u64,
-            matches: Arc::new(ThreadLocal::default()),
+            matches: Some(Arc::new(ThreadLocal::default())),
         })
     }
 


### PR DESCRIPTION
This commit makes Gitignore::empty a bit faster by avoiding allocation
and manually specializing the implementation instead of routing it through
the GitignoreBuilder.

This helps improve uses of ripgrep that traverse *many* directories, and
in particular, when the use of ignores is disabled via command line
switches.

Fixes #835, Closes #836