### PR TITLE
Add support for commonly used files with Puppet

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -215,6 +215,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("pod", &["*.pod"]),
     ("protobuf", &["*.proto"]),
     ("ps", &["*.cdxml", "*.ps1", "*.ps1xml", "*.psd1", "*.psm1"]),
+    ("puppet", &[".erb", "*.pp", "*.rb"]),
     ("purs", &["*.purs"]),
     ("py", &["*.py"]),
     ("qmake", &["*.pro", "*.pri", "*.prf"]),


### PR DESCRIPTION
Puppet is primarily written in it's own format of .pp files, but
custom facts and functions are often written in Ruby. The templating
language is ERB and so this will allow scanning of any of the three
most commonly used formats for Puppet specific things.