### PR TITLE
Add a shorthand file type "hs" for Haskell

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -144,6 +144,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("h", &["*.h", "*.hpp"]),
     ("hbs", &["*.hbs"]),
     ("haskell", &["*.hs", "*.lhs"]),
+    ("hs", &["*.hs", "*.lhs"]),
     ("html", &["*.htm", "*.html", "*.ejs"]),
     ("java", &["*.java"]),
     ("jinja", &["*.j2", "*.jinja", "*.jinja2"]),


### PR DESCRIPTION
"haskell" is a bit long to type and I think most people will intuitively try "-ths", like "-tpy".