### PR TITLE
Update clap for better PowerShell completion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ same-file = "1"
 termcolor = { version = "0.3.4", path = "termcolor" }
 
 [dependencies.clap]
-version = "2.29.4"
+version = "2.31.2"
 default-features = false
 features = ["suggestions", "color"]
 


### PR DESCRIPTION
When generating completions for PowerShell, the latest version of clap will use the short parameter help. 

PowerShell ISE, VSCode w/ the PowerShell extension, and PSReadLine 2.0.0 will all display this help when completing.