### PR TITLE
Add MacPorts installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ $ brew tap burntsushi/ripgrep https://github.com/BurntSushi/ripgrep.git
 $ brew install ripgrep-bin
 ```
 
-If you're a **MacPorts** user, then you can install ripgrep from the [official ports](https://www.macports.org/ports.php?by=name&substr=ripgrep):
+If you're a **MacPorts** user, then you can install ripgrep from the
+[official ports](https://www.macports.org/ports.php?by=name&substr=ripgrep):
 
 ```
 $ sudo port install ripgrep

--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ $ brew tap burntsushi/ripgrep https://github.com/BurntSushi/ripgrep.git
 $ brew install ripgrep-bin
 ```
 
+If you're a **MacPorts** user, then you can install ripgrep from the [official ports](https://www.macports.org/ports.php?by=name&substr=ripgrep):
+
+```
+$ sudo port install ripgrep
+```
+
 If you're a **Windows Chocolatey** user, then you can install ripgrep from the [official repo](https://chocolatey.org/packages/ripgrep):
 
 ```


### PR DESCRIPTION
I just saw the recent addition of BSD installation instructions to the README file. So I thought, what the heck, why not add installation instructions for Macports as well?  :smiley:

This is a tiny change, so I think it should be okay to merge.