### PR TITLE
ignore/types: add support for a few Android platform file types

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -98,6 +98,7 @@ use {Error, Match};
 
 const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("agda", &["*.agda", "*.lagda"]),
+    ("aidl", &["*.aidl"]),
     ("asciidoc", &["*.adoc", "*.asc", "*.asciidoc"]),
     ("asm", &["*.asm", "*.s", "*.S"]),
     ("avro", &["*.avdl", "*.avpr", "*.avsc"]),

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -99,6 +99,7 @@ use {Error, Match};
 const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("agda", &["*.agda", "*.lagda"]),
     ("aidl", &["*.aidl"]),
+    ("amake", &["*.mk", "*.bp"]),
     ("asciidoc", &["*.adoc", "*.asc", "*.asciidoc"]),
     ("asm", &["*.asm", "*.s", "*.S"]),
     ("avro", &["*.avdl", "*.avpr", "*.avsc"]),


### PR DESCRIPTION
Add the following file types to the built-in type list:

- Android AIDL files (*.aidl)
- Android platform makefiles (*.mk, *.bp)

Note: I went with "amake" as the name for the Android makefile pattern because it's quick to write. One could argue that something like "android-make" is easier to comprehend when skimming through the output of --type-list.