### PR TITLE
Use exit code 2 to indicate error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
         Ok(_) => process::exit(0),
         Err(err) => {
             eprintln!("{}", err);
-            process::exit(1);
+            process::exit(2);
         }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2194,7 +2194,7 @@ fn type_list() {
 
 // See: https://github.com/BurntSushi/ripgrep/issues/948
 sherlock!(
-    feature_948_match,
+    exit_code_match_success,
     ".",
     ".",
     |wd: WorkDir, mut cmd: Command| {
@@ -2204,7 +2204,7 @@ sherlock!(
 
 // See: https://github.com/BurntSushi/ripgrep/issues/948
 sherlock!(
-    feature_948_no_match,
+    exit_code_no_match,
     "6d28e48b5224a42b167e{10}",
     ".",
     |wd: WorkDir, mut cmd: Command| {
@@ -2214,7 +2214,7 @@ sherlock!(
 
 // See: https://github.com/BurntSushi/ripgrep/issues/948
 sherlock!(
-    feature_948_error,
+    exit_code_error,
     "*",
     ".",
     |wd: WorkDir, mut cmd: Command| {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2191,3 +2191,33 @@ fn type_list() {
     // This can change over time, so just make sure we print something.
     assert!(!lines.is_empty());
 }
+
+// See: https://github.com/BurntSushi/ripgrep/issues/948
+sherlock!(
+    feature_948_match,
+    ".",
+    ".",
+    |wd: WorkDir, mut cmd: Command| {
+        wd.assert_exit_code(0, &mut cmd);
+    }
+);
+
+// See: https://github.com/BurntSushi/ripgrep/issues/948
+sherlock!(
+    feature_948_no_match,
+    "6d28e48b5224a42b167e{10}",
+    ".",
+    |wd: WorkDir, mut cmd: Command| {
+        wd.assert_exit_code(1, &mut cmd);
+    }
+);
+
+// See: https://github.com/BurntSushi/ripgrep/issues/948
+sherlock!(
+    feature_948_error,
+    "*",
+    ".",
+    |wd: WorkDir, mut cmd: Command| {
+        wd.assert_exit_code(2, &mut cmd);
+    }
+);

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -261,24 +261,26 @@ impl WorkDir {
     pub fn assert_err(&self, cmd: &mut process::Command) {
         let o = cmd.output().unwrap();
         if o.status.success() {
-            panic!("\n\n===== {:?} =====\n\
-                    command succeeded but expected failure!\
-                    \n\ncwd: {}\
-                    \n\nstatus: {}\
-                    \n\nstdout: {}\n\nstderr: {}\
-                    \n\n=====\n",
-                   cmd, self.dir.display(), o.status,
-                   String::from_utf8_lossy(&o.stdout),
-                   String::from_utf8_lossy(&o.stderr));
+            panic!(
+                "\n\n===== {:?} =====\n\
+                 command succeeded but expected failure!\
+                 \n\ncwd: {}\
+                 \n\nstatus: {}\
+                 \n\nstdout: {}\n\nstderr: {}\
+                 \n\n=====\n",
+                cmd,
+                self.dir.display(),
+                o.status,
+                String::from_utf8_lossy(&o.stdout),
+                String::from_utf8_lossy(&o.stderr)
+            );
         }
     }
 
     /// Runs the given command and asserts that its exit code matches expected exit code.
     pub fn assert_exit_code(&self, expected_code: i32, cmd: &mut process::Command) {
-        let code = cmd.status()
-            .expect("no status")
-            .code()
-            .expect("no exit code");
+        let code = cmd.status().unwrap().code().unwrap();
+
         assert_eq!(
             expected_code, code,
             "\n\n===== {:?} =====\n\

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -279,7 +279,15 @@ impl WorkDir {
             .expect("no status")
             .code()
             .expect("no exit code");
-        assert_eq!(expected_code, code);
+        assert_eq!(
+            expected_code, code,
+            "\n\n===== {:?} =====\n\
+             expected exit code did not match\
+             \n\nexpected: {}\
+             \n\nfound: {}\
+             \n\n=====\n",
+            cmd, expected_code, code
+        );
     }
 
     /// Runs the given command and asserts that something was printed to

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -273,6 +273,15 @@ impl WorkDir {
         }
     }
 
+    /// Runs the given command and asserts that its exit code matches expected exit code.
+    pub fn assert_exit_code(&self, expected_code: i32, cmd: &mut process::Command) {
+        let code = cmd.status()
+            .expect("no status")
+            .code()
+            .expect("no exit code");
+        assert_eq!(expected_code, code);
+    }
+
     /// Runs the given command and asserts that something was printed to
     /// stderr.
     pub fn assert_non_empty_stderr(&self, cmd: &mut process::Command) {


### PR DESCRIPTION
Exit code `1` was shared to indicate both "no results" and "error." Use status code `2` to indicate errors, similar to grep's behavior.

Fixes #948

Adds integration tests for exit codes.
Adds test helper `WorkDir::assert_exit_code(&self, expected_code: i32, cmd: &mut process::Command)` to match arbitrary exit codes in tests.


## Testing

```sh
cargo test exit_code
```

## Manual testing

Verify that the exit code is now `2` for error:

```
$ cargo run -- '*' src/main.rs ; echo "Status code: $?"

    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/rg '*' src/main.rs`
regex parse error:
    *
    ^
error: repetition operator missing expression
Status code: 2
```

And remains `0` when matches are found:

```
$ cargo run -- 'main' src/main.rs ; echo "Status code: $?"

    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/rg main src/main.rs`
56:fn main() {
Status code: 0
```

And `1` for no matches:

```
cargo run -- 'this_does_not_match' src/main.rs ; echo "Status code: $?"


    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/rg this_does_not_match src/main.rs`
Status code: 1
```