### PR TITLE
Add --fixed-strings flag (fixes #964)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -909,9 +909,17 @@ fn flag_fixed_strings(args: &mut Vec<RGArg>) {
 Treat the pattern as a literal string instead of a regular expression. When
 this flag is used, special regular expression meta characters such as .(){}*+
 do not need to be escaped.
+
+This flag can be disabled with --no-fixed-strings.
 ");
     let arg = RGArg::switch("fixed-strings").short("F")
-        .help(SHORT).long_help(LONG);
+        .help(SHORT).long_help(LONG)
+        .overrides("no-fixed-strings");
+    args.push(arg);
+
+    let arg = RGArg::switch("no-fixed-strings")
+        .hidden()
+        .overrides("fixed-strings");
     args.push(arg);
 }
 


### PR DESCRIPTION
Simple as this probably? I didn't add a test since i don't see any for other options like this, but let me know if you'd like one.

I also didn't update the completion function. I guess we need to decide whether it's useful to show all of the `--no-*` options; i'm leaning towards not usually. But i should add them as hidden options at least so that the exclusions are accurate. I'll do that eventually...

(Fixes #964)