### PR TITLE
Rename --maxdepth to --max-depth

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -51,7 +51,8 @@ _rg() {
     '(-M --max-columns)'{-M+,--max-columns=}'[specify max length of lines to print]:number of bytes'
     '(-m --max-count)'{-m+,--max-count=}'[specify max number of matches per file]:number of matches'
     '--max-filesize=[specify size above which files should be ignored]:file size'
-    '--maxdepth=[specify max number of directories to descend]:number of directories'
+    '--max-depth=[specify max number of directories to descend]:number of directories'
+    '!--maxdepth=:number of directories'
     '(--mmap --no-mmap)--mmap[search using memory maps when possible]'
     '(-H --with-filename --no-filename)--no-filename[suppress all file names]'
     "(-p --heading --pretty --vimgrep)--no-heading[don't group matches by file name]"

--- a/src/app.rs
+++ b/src/app.rs
@@ -521,8 +521,8 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_line_regexp(&mut args);
     flag_max_columns(&mut args);
     flag_max_count(&mut args);
+    flag_max_depth(&mut args);
     flag_max_filesize(&mut args);
-    flag_maxdepth(&mut args);
     flag_mmap(&mut args);
     flag_no_config(&mut args);
     flag_no_ignore(&mut args);
@@ -1130,6 +1130,23 @@ Limit the number of matching lines per file searched to NUM.
     args.push(arg);
 }
 
+fn flag_max_depth(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Descend at most NUM directories.";
+    const LONG: &str = long!("\
+Limit the depth of directory traversal to NUM levels beyond the paths given. A
+value of zero only searches the explicitly given paths themselves.
+
+For example, 'rg --max-depth 0 dir/' is a no-op because dir/ will not be
+descended into. 'rg --max-depth 1 dir/' will search only the direct children of
+'dir'.
+");
+    let arg = RGArg::flag("max-depth", "NUM")
+        .help(SHORT).long_help(LONG)
+        .alias("maxdepth")
+        .number();
+    args.push(arg);
+}
+
 fn flag_max_filesize(args: &mut Vec<RGArg>) {
     const SHORT: &str = "Ignore files larger than NUM in size.";
     const LONG: &str = long!("\
@@ -1143,22 +1160,6 @@ Examples: --max-filesize 50K or --max-filesize 80M
 ");
     let arg = RGArg::flag("max-filesize", "NUM+SUFFIX?")
         .help(SHORT).long_help(LONG);
-    args.push(arg);
-}
-
-fn flag_maxdepth(args: &mut Vec<RGArg>) {
-    const SHORT: &str = "Descend at most NUM directories.";
-    const LONG: &str = long!("\
-Limit the depth of directory traversal to NUM levels beyond the paths given. A
-value of zero only searches the explicitly given paths themselves.
-
-For example, 'rg --maxdepth 0 dir/' is a no-op because dir/ will not be
-descended into. 'rg --maxdepth 1 dir/' will search only the direct children of
-'dir'.
-");
-    let arg = RGArg::flag("maxdepth", "NUM")
-        .help(SHORT).long_help(LONG)
-        .number();
     args.push(arg);
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -58,8 +58,8 @@ pub struct Args {
     line_per_match: bool,
     max_columns: Option<usize>,
     max_count: Option<u64>,
+    max_depth: Option<usize>,
     max_filesize: Option<u64>,
-    maxdepth: Option<usize>,
     mmap: bool,
     no_ignore: bool,
     no_ignore_messages: bool,
@@ -345,7 +345,7 @@ impl Args {
 
         wd.follow_links(self.follow);
         wd.hidden(!self.hidden);
-        wd.max_depth(self.maxdepth);
+        wd.max_depth(self.max_depth);
         wd.max_filesize(self.max_filesize);
         wd.overrides(self.glob_overrides.clone());
         wd.types(self.types.clone());
@@ -407,8 +407,8 @@ impl<'a> ArgMatches<'a> {
             line_per_match: self.is_present("vimgrep"),
             max_columns: self.usize_of_nonzero("max-columns")?,
             max_count: self.usize_of("max-count")?.map(|n| n as u64),
+            max_depth: self.usize_of("max-depth")?,
             max_filesize: self.max_filesize()?,
-            maxdepth: self.usize_of("maxdepth")?,
             mmap: mmap,
             no_ignore: self.no_ignore(),
             no_ignore_messages: self.is_present("no-ignore-messages"),


### PR DESCRIPTION
The name of the `--maxdepth` option is inconsistent with all of the other `--max-*` options, and aside from being aesthetically displeasing it affects the ordering in the help output and completion results. I assume the wording `maxdepth` comes from `find`, and that makes sense on its own i guess, but... it just feels out of place to me here.

This PR changes the canonical name of the option to `max-depth`, leaving `maxdepth` as a hidden alias for backwards compatibility.

(I realise this is petty; feel free to just close if i'm being *too* ridiculous...)