### PR TITLE
Try to fullfill all the goals of the generic decoder program feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Feature enhancements:
   Add `--count-matches` flag, which is like `--count`, but for each match.
 * [FEATURE #880](https://github.com/BurntSushi/ripgrep/issues/880):
   Add a `--no-column` flag, which disables column numbers in the output.
+* [FEATURE #978](https://github.com/BurntSushi/ripgrep/issues/978):
+  Add a `--preprocessor` option to filter inputs with an arbitrary program.
 
 Bug fixes:
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ increases the times to `2.640s` for ripgrep and `10.277s` for GNU grep.
   specifically specified with the `-E/--encoding` flag.)
 * ripgrep supports searching files compressed in a common format (gzip, xz,
   lzma or bzip2 current) with the `-z/--search-zip` flag.
+* ripgrep supports arbitrary input preprocessing filters which could be PDF
+  text extraction, less supported decompressing, decrypting, and so on.
 
 In other words, use ripgrep if you like speed, filtering by default, fewer
 bugs, and Unicode support.

--- a/complete/_rg
+++ b/complete/_rg
@@ -173,6 +173,7 @@ _rg() {
     + '(zip)' # Compressed-file options
     {-z,--search-zip}'[search in compressed files]'
     $no"--no-search-zip[don't search in compressed files]"
+    {-P,--preprocessor}'[search files needing preprocessing]'
 
     + misc # Other options — no need to separate these at the moment
     '(-b --byte-offset)'{-b,--byte-offset}'[show 0-based byte offset for each matching line]'

--- a/src/app.rs
+++ b/src/app.rs
@@ -540,6 +540,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_regexp(&mut args);
     flag_replace(&mut args);
     flag_search_zip(&mut args);
+    flag_preprocessor(&mut args);
     flag_smart_case(&mut args);
     flag_sort_files(&mut args);
     flag_stats(&mut args);
@@ -1459,6 +1460,33 @@ This flag can be disabled with --no-search-zip.
     let arg = RGArg::switch("no-search-zip")
         .hidden()
         .overrides("search-zip");
+    args.push(arg);
+}
+
+fn flag_preprocessor(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "search outputs of \"COMMAND FILE\" for each FILE";
+    const LONG: &str = long!("\
+For each input FILE, search the standard output of \"COMMAND FILE\" rather
+than the contents of FILE.  This option expects the COMMAND program to be
+available in your PATH.  An empty string COMMAND deactivats this feature.
+
+When searching over sets of files that may require one of several decoders
+as preprocessors, COMMAND should be a wrapper program or script which first
+classifies FILE based on magic numbers/content or based on the FILE name and
+then dispatches to an appropriate preprocessor.  Each COMMAND also has its
+standard input connected to FILE for convenience.
+
+For example, a Unix script for COMMAND might look like:
+case \"$1\" in
+  *.pdf) exec pdftotext \"$1\" - ;;
+  *) case $(file \"$1\") in
+       *Zstandard*) exec pzstd -cdqp8 ;;
+       *) exec cat ;;
+	 esac;
+esac
+");
+    let arg = RGArg::flag("preprocessor", "COMMAND").short("P")
+        .help(SHORT).long_help(LONG);
     args.push(arg);
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -80,6 +80,7 @@ pub struct Args {
     types: Types,
     with_filename: bool,
     search_zip_files: bool,
+    preprocessor: PathBuf,
     stats: bool
 }
 
@@ -288,6 +289,7 @@ impl Args {
             .quiet(self.quiet)
             .text(self.text)
             .search_zip_files(self.search_zip_files)
+            .preprocessor(self.preprocessor.clone())
             .build()
     }
 
@@ -429,6 +431,7 @@ impl<'a> ArgMatches<'a> {
             types: self.types()?,
             with_filename: with_filename,
             search_zip_files: self.is_present("search-zip"),
+            preprocessor: self.preprocessor(),
             stats: self.stats()
         };
         if args.mmap {
@@ -719,6 +722,15 @@ impl<'a> ArgMatches<'a> {
         match self.value_of_lossy("context-separator") {
             None => b"--".to_vec(),
             Some(sep) => unescape(&sep),
+        }
+    }
+
+    /// Returns the preprocessor command
+    fn preprocessor(&self) -> PathBuf {
+        if let Some(path) = self.value_of_os("preprocessor") {
+            Path::new(path).to_path_buf()
+        } else {
+            PathBuf::new()
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ mod args;
 mod config;
 mod decoder;
 mod decompressor;
+mod preprocessor;
 mod logger;
 mod pathutil;
 mod printer;

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -1,0 +1,87 @@
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::process::{self, Stdio};
+
+/// `cmd` is the str argument to -P,--Preprocessor option.
+
+/// PreprocessorReader provides an `io::Read` impl to read kids output.
+#[derive(Debug)]
+pub struct PreprocessorReader {
+    cmd: PathBuf,
+    child: process::Child,
+    done: bool,
+}
+
+impl PreprocessorReader {
+    /// Returns a handle to the stdout of the spawned preprocessor process for
+    /// `path`, which can be directly searched in the worker. When the returned
+    /// value is exhausted, the underlying process is reaped. If the underlying
+    /// process fails, then its stderr is read and converted into a normal
+    /// io::Error.
+    ///
+    /// If there is any error in spawning the preprocessor command, then
+    /// return `None`, after outputting any necessary debug or error messages.
+    pub fn from_cmd_path(c: PathBuf, path: &Path) -> Option<PreprocessorReader> {
+        let cmd = process::Command::new(c.clone())
+            .arg(path)
+            //.stdin(Stdio::open(path)) //Unnecessary since stdin inherited
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn();
+        let child = match cmd {
+            Ok(process) => process,
+            Err(_) => {
+                debug!(
+                    "{}: preprocessor command '{}' not found",
+                    path.display(), c.display());
+                return None;
+            }
+        };
+        Some(PreprocessorReader::new(c, child))
+    }
+
+    fn new(
+        cmd: PathBuf,
+        child: process::Child,
+    ) -> PreprocessorReader {
+        PreprocessorReader {
+            cmd: cmd,
+            child: child,
+            done: false,
+        }
+    }
+
+    fn read_error(&mut self) -> io::Result<io::Error> {
+        let mut errbytes = vec![];
+        self.child.stderr.as_mut().unwrap().read_to_end(&mut errbytes)?;
+        let errstr = String::from_utf8_lossy(&errbytes);
+        let errstr = errstr.trim();
+
+        Ok(if errstr.is_empty() {
+            let msg = format!("preprocessor command failed: '{}'", self.cmd.display());
+            io::Error::new(io::ErrorKind::Other, msg)
+        } else {
+            let msg = format!(
+                "preprocessor command '{}' failed: {}", self.cmd.display(), errstr);
+            io::Error::new(io::ErrorKind::Other, msg)
+        })
+    }
+}
+
+impl io::Read for PreprocessorReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.done {
+            return Ok(0);
+        }
+        let nread = self.child.stdout.as_mut().unwrap().read(buf)?;
+        if nread == 0 {
+            self.done = true;
+            // Reap the child now that we're done reading.
+            // If the command failed, report stderr as an error.
+            if !self.child.wait()?.success() {
+                return Err(self.read_error()?);
+            }
+        }
+        Ok(nread)
+    }
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use encoding_rs::Encoding;
 use grep::Grep;
@@ -10,6 +10,7 @@ use termcolor::WriteColor;
 
 use decoder::DecodeReader;
 use decompressor::{self, DecompressionReader};
+use preprocessor::PreprocessorReader;
 use pathutil::strip_prefix;
 use printer::Printer;
 use search_buffer::BufferSearcher;
@@ -45,6 +46,7 @@ struct Options {
     no_messages: bool,
     quiet: bool,
     text: bool,
+    preprocessor: PathBuf,
     search_zip_files: bool
 }
 
@@ -68,6 +70,7 @@ impl Default for Options {
             quiet: false,
             text: false,
             search_zip_files: false,
+            preprocessor: PathBuf::new(),
         }
     }
 }
@@ -222,6 +225,12 @@ impl WorkerBuilder {
         self.opts.search_zip_files = yes;
         self
     }
+
+    /// If non-empty, search output of preprocessor run on each file
+    pub fn preprocessor(mut self, command: PathBuf) -> Self {
+        self.opts.preprocessor = command;
+        self
+    }
 }
 
 /// Worker is responsible for executing searches on file paths, while choosing
@@ -250,7 +259,14 @@ impl Worker {
             }
             Work::DirEntry(dent) => {
                 let mut path = dent.path();
-                if self.opts.search_zip_files
+                if !self.opts.preprocessor.as_os_str().is_empty() {
+                    match PreprocessorReader::from_cmd_path(self.opts.preprocessor.to_path_buf(), path) {
+                        Some(reader) => self.search(printer, path, reader),
+                        None => {
+                            return 0;
+                        }
+                    }
+                } else if self.opts.search_zip_files
                      && decompressor::is_compressed(path)
                 {
                     match DecompressionReader::from_path(path) {


### PR DESCRIPTION
request: https://github.com/BurntSushi/ripgrep/issues/978

There are a a bunch of choices maybe I should mention in this PR.
I called it "-P,--preprocessor" to suggest its primary function.
I basically just imitated the way decompression was handled with
a new file ``src/preprocessor.rs`` instead of ``src/decompressor.rs``.

Currently, if both ``--search-zip`` and ``--preprocessor PROGRAM`` are
given,  the latter is used.  This seemed reasonable since preprocessing is more
general and probably involves more sophisticated users who can more easily
include whatever compression programs they want (or don't want) using whatever
dispatching algorithm they want.

For me, it compiles and runs fine on rust-1.27.1 both with no ``-P`` at all,
with ``-P program-using-only-stdin`` and ``-P program-using-argv1``.  The only
failing I see right now on Linux is that if you specify a bogus preprocessor
like ``rg -P /junk foo`` it does not error out at the very first file.

Oh, and while the shell script snippet formats fine in the --help output, the
auto-generated man page corrupts it into a 2- or 3-liner with some chars
dropped out.  Not sure what to do about that.  Could also just put that
material in GUIDE.md and drop it from the help.

Also, this is my very first significant stab at Rust work.  So, I may well
have done some things in an undesirable way.