### PR TITLE
ignore: fix has_any_ignore_rules for explicit ignores

### DIFF
--- a/ignore/src/dir.rs
+++ b/ignore/src/dir.rs
@@ -266,9 +266,11 @@ impl Ignore {
     fn has_any_ignore_rules(&self) -> bool {
         let opts = self.0.opts;
         let has_custom_ignore_files = !self.0.custom_ignore_filenames.is_empty();
+        let has_explicit_ignores = !self.0.explicit_ignores.is_empty();
 
         opts.ignore || opts.git_global || opts.git_ignore
                     || opts.git_exclude || has_custom_ignore_files
+                    || has_explicit_ignores
     }
 
     /// Returns a match indicating whether the given file path should be

--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -1674,6 +1674,24 @@ mod tests {
     }
 
     #[test]
+    fn explicit_ignore_exclusive_use() {
+        let td = TempDir::new("walk-test-").unwrap();
+        let igpath = td.path().join(".not-an-ignore");
+        mkdirp(td.path().join("a"));
+        wfile(&igpath, "foo");
+        wfile(td.path().join("foo"), "");
+        wfile(td.path().join("a/foo"), "");
+        wfile(td.path().join("bar"), "");
+        wfile(td.path().join("a/bar"), "");
+
+        let mut builder = WalkBuilder::new(td.path());
+        builder.standard_filters(false);
+        assert!(builder.add_ignore(&igpath).is_none());
+        assert_paths(td.path(), &builder,
+            &[".not-an-ignore", "bar", "a", "a/bar"]);
+    }
+
+    #[test]
     fn gitignore_parent() {
         let td = TempDir::new("walk-test-").unwrap();
         mkdirp(td.path().join("a"));


### PR DESCRIPTION
When building a ignore::WalkBuilder by disabling all standard filters
and adding a custom global ignore file, the ignore file is not used. Example:

    let mut walker = ignore::WalkBuilder::new(dir);
    walker.standard_filters(false);
    walker.add_ignore(myfile);

This makes it impossible to use the ignore crate to walk a directory
with only custom ignore files. Very similar to issue #800 (fixed in
b71a110).