### PR TITLE
complete: add --no-pre, improve --pre/--search-zip exclusivity

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -138,6 +138,10 @@ _rg() {
     '(--vimgrep count only replace)--passthru[show both matching and non-matching lines]'
     '!(--vimgrep count only replace)--passthrough'
 
+    + '(pre)' # Preprocessing options
+    '(-z --search-zip)--pre=[specify preprocessor utility]:preprocessor utility:_command_names -e'
+    $no'--no-pre[disable preprocessor utility]'
+
     + '(pretty-vimgrep)' # Pretty/vimgrep display options
     '(heading)'{-p,--pretty}'[alias for --color=always --heading -n]'
     '(heading passthru)--vimgrep[show results in vim-compatible format]'
@@ -174,9 +178,8 @@ _rg() {
     {-w,--word-regexp}'[only show matches surrounded by word boundaries]'
     {-x,--line-regexp}'[only show matches surrounded by line boundaries]'
 
-    + '(input-decoding)' # Input decoding options
-    '--pre=[specify preprocessor utility]:preprocessor utility:_command_names -e'
-    {-z,--search-zip}'[search in compressed files]'
+    + '(zip)' # Compression options
+    '(--pre)'{-z,--search-zip}'[search in compressed files]'
     $no"--no-search-zip[don't search in compressed files]"
 
     + misc # Other options — no need to separate these at the moment


### PR DESCRIPTION
Complete `--no-pre` — and then break pre/zip options apart since not all of them should be exclusive.

(The CI script doesn't account for completion specs that are marked with a `!`, which is why the tests didn't break when `--no-pre` was added. I could change that, but i think my concern at the time was that those 'negatory' options wouldn't always show up in the usage help. idk, probably not a big deal either way)