### PR TITLE
tests: reduce effect of state on integration tests

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -590,6 +590,7 @@ sherlock!(no_ignore_hidden, "Sherlock", ".", |wd: WorkDir, mut cmd: Command| {
 });
 
 sherlock!(ignore_git, "Sherlock", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create_dir(".git");
     wd.create(".gitignore", "sherlock\n");
     wd.assert_err(&mut cmd);
 });
@@ -852,6 +853,7 @@ sherlock:but Doctor Watson has to have it taken out for him and dusted,
 
 // See: https://github.com/BurntSushi/ripgrep/issues/16
 clean!(regression_16, "xyz", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create_dir(".git");
     wd.create(".gitignore", "ghi/");
     wd.create_dir("ghi");
     wd.create_dir("def/ghi");
@@ -907,6 +909,7 @@ clean!(regression_50, "xyz", ".", |wd: WorkDir, mut cmd: Command| {
 
 // See: https://github.com/BurntSushi/ripgrep/issues/65
 clean!(regression_65, "xyz", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create_dir(".git");
     wd.create(".gitignore", "a/");
     wd.create_dir("a");
     wd.create("a/foo", "xyz");
@@ -916,6 +919,7 @@ clean!(regression_65, "xyz", ".", |wd: WorkDir, mut cmd: Command| {
 
 // See: https://github.com/BurntSushi/ripgrep/issues/67
 clean!(regression_67, "test", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create_dir(".git");
     wd.create(".gitignore", "/*\n!/dir");
     wd.create_dir("dir");
     wd.create_dir("foo");
@@ -928,6 +932,7 @@ clean!(regression_67, "test", ".", |wd: WorkDir, mut cmd: Command| {
 
 // See: https://github.com/BurntSushi/ripgrep/issues/87
 clean!(regression_87, "test", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create_dir(".git");
     wd.create(".gitignore", "foo\n**no-vcs**");
     wd.create("foo", "test");
     wd.assert_err(&mut cmd);
@@ -935,6 +940,7 @@ clean!(regression_87, "test", ".", |wd: WorkDir, mut cmd: Command| {
 
 // See: https://github.com/BurntSushi/ripgrep/issues/90
 clean!(regression_90, "test", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create_dir(".git");
     wd.create(".gitignore", "!.foo");
     wd.create(".foo", "test");
 
@@ -995,6 +1001,7 @@ clean!(regression_127, "Sherlock", ".", |wd: WorkDir, mut cmd: Command| {
     // ripgrep should ignore 'foo/sherlock' giving us results only from
     // 'foo/watson' but on Windows ripgrep will include both 'foo/sherlock' and
     // 'foo/watson' in the search results.
+    wd.create_dir(".git");
     wd.create(".gitignore", "foo/sherlock\n");
     wd.create_dir("foo");
     wd.create("foo/sherlock", hay::SHERLOCK);
@@ -1022,6 +1029,7 @@ clean!(regression_128, "x", ".", |wd: WorkDir, mut cmd: Command| {
 // TODO(burntsushi): Darwin doesn't like this test for some reason.
 #[cfg(not(target_os = "macos"))]
 clean!(regression_131, "test", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create_dir(".git");
     wd.create(".gitignore", "TopÑapa");
     wd.create("TopÑapa", "test");
     wd.assert_err(&mut cmd);
@@ -1309,6 +1317,7 @@ clean!(regression_599, "^$", "input.txt", |wd: WorkDir, mut cmd: Command| {
 
 // See: https://github.com/BurntSushi/ripgrep/issues/807
 clean!(regression_807, "test", ".", |wd: WorkDir, mut cmd: Command| {
+    wd.create_dir(".git");
     wd.create(".gitignore", ".a/b");
     wd.create_dir(".a/b");
     wd.create_dir(".a/c");

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -49,7 +49,11 @@ impl WorkDir {
 
     /// Try to create a new file with the given name and contents in this
     /// directory.
-    pub fn try_create<P: AsRef<Path>>(&self, name: P, contents: &str) -> io::Result<()> {
+    pub fn try_create<P: AsRef<Path>>(
+        &self,
+        name: P,
+        contents: &str,
+    ) -> io::Result<()> {
         let path = self.dir.join(name);
         self.try_create_bytes(path, contents.as_bytes())
     }
@@ -70,7 +74,11 @@ impl WorkDir {
 
     /// Try to create a new file with the given name and contents in this
     /// directory.
-    fn try_create_bytes<P: AsRef<Path>>(&self, path: P, contents: &[u8]) -> io::Result<()> {
+    fn try_create_bytes<P: AsRef<Path>>(
+        &self,
+        path: P,
+        contents: &[u8],
+    ) -> io::Result<()> {
         let mut file = File::create(&path)?;
         file.write_all(contents)?;
         file.flush()
@@ -190,7 +198,11 @@ impl WorkDir {
         match stdout.parse() {
             Ok(t) => t,
             Err(err) => {
-                panic!("could not convert from string: {:?}\n\n{}", err, stdout);
+                panic!(
+                    "could not convert from string: {:?}\n\n{}",
+                    err,
+                    stdout
+                );
             }
         }
     }
@@ -221,7 +233,10 @@ impl WorkDir {
             write!(stdin, "{}", input)
         });
 
-        let output = self.expect_success(cmd, child.wait_with_output().unwrap());
+        let output = self.expect_success(
+            cmd,
+            child.wait_with_output().unwrap(),
+        );
         worker.join().unwrap().unwrap();
         output
     }
@@ -277,8 +292,13 @@ impl WorkDir {
         }
     }
 
-    /// Runs the given command and asserts that its exit code matches expected exit code.
-    pub fn assert_exit_code(&self, expected_code: i32, cmd: &mut process::Command) {
+    /// Runs the given command and asserts that its exit code matches expected
+    /// exit code.
+    pub fn assert_exit_code(
+        &self,
+        expected_code: i32,
+        cmd: &mut process::Command,
+    ) {
         let code = cmd.status().unwrap().code().unwrap();
 
         assert_eq!(


### PR DESCRIPTION
tests: reduce reliance on state in tests

This commit improves the integration test setup by running tests inside
the system's temporary directory instead of within ripgrep's `target`
directory. The motivation here is to attempt to reduce the effect of
unanticipated state on ripgrep's integration tests, such as the presence
of `.gitignore` files in ripgrep's checkout directory hierarchy
(including parent directories).

This doesn't remove all possible state. For example, there's no
guarantee that the system's temporary directory isn't itself within a
git repository. Moreover, there may still be other ignore rules in the
directory tree that might impact test behavior. Fixing this seems
somewhat difficult. Conceptually, it seems like ripgrep should run each
test in its own `chroot`-like environment, but doing this in a
non-annoying and portable way (including Windows) doesn't appear to be
possible.

Another approach to take here might be to teach ripgrep itself that a
particular directory should be treated as root, and therefore, never
look at anything outside that directory. This also seems complex to
implement, but tractable. Let's see how this approach works for now.

Fixes #448, Fixes #996
