### PR TITLE
Update Debian installation instructions by bumping version to 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ then ripgrep can be installed using a binary `.deb` file provided in each
 ripgrep is not in the official Debian or Ubuntu repositories.
 
 ```
-$ curl -LO https://github.com/BurntSushi/ripgrep/releases/download/0.8.1/ripgrep_0.8.1_amd64.deb
-$ sudo dpkg -i ripgrep_0.8.1_amd64.deb
+$ curl -LO https://github.com/BurntSushi/ripgrep/releases/download/0.9.0/ripgrep_0.9.0_amd64.deb
+$ sudo dpkg -i ripgrep_0.9.0_amd64.deb
 ```
 
 (N.B. Various snaps for ripgrep on Ubuntu are also available, but none of them


### PR DESCRIPTION
This commit updates the download link in Debian installation instructions to reflect the latest release.