### PR TITLE
Add *.sbt to scala type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -235,7 +235,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("ruby", &["Gemfile", "*.gemspec", ".irbrc", "Rakefile", "*.rb"]),
     ("rust", &["*.rs"]),
     ("sass", &["*.sass", "*.scss"]),
-    ("scala", &["*.scala"]),
+    ("scala", &["*.scala", "*.sbt"]),
     ("sh", &[
         // Portable/misc. init files
         ".login", ".logout", ".profile", "profile",


### PR DESCRIPTION
Sbt is currently most used Scala build tool which uses *.sbt files, which are basically Scala.