### PR TITLE
ignore/types: add .mako and .mao for Mako templates

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -203,6 +203,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
         "makefile", "Makefile",
         "*.mk", "*.mak"
     ]),
+    ("mako", &["*.mako", "*.mao"]),
     ("markdown", &["*.markdown", "*.md", "*.mdown", "*.mkdn"]),
     ("md", &["*.markdown", "*.md", "*.mdown", "*.mkdn"]),
     ("man", &["*.[0-9lnpx]", "*.[0-9][cEFMmpSx]"]),


### PR DESCRIPTION
I've personally never seen `.mao`, but GitHub includes it in Linguist: 
https://github.com/github/linguist/blob/4f11062304ae28b09a9b90c4536a92a27e142dcb/lib/linguist/languages.yml#L2702-L2709