### PR TITLE
Upgrade minimum reqiured version of Rust to 1.29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,13 @@ matrix:
     # Minimum Rust supported channel. We enable these to make sure ripgrep
     # continues to work on the advertised minimum Rust version.
     - os: linux
-      rust: 1.28.0
+      rust: 1.29.0
       env: TARGET=x86_64-unknown-linux-gnu
     - os: linux
-      rust: 1.28.0
+      rust: 1.29.0
       env: TARGET=x86_64-unknown-linux-musl
     - os: linux
-      rust: 1.28.0
+      rust: 1.29.0
       env: TARGET=arm-unknown-linux-gnueabihf GCC_VERSION=4.8
       addons:
         apt:

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ If you're a **NetBSD** user, then you can install ripgrep from
 
 If you're a **Rust programmer**, ripgrep can be installed with `cargo`.
 
-* Note that the minimum supported version of Rust for ripgrep is **1.28.0**,
+* Note that the minimum supported version of Rust for ripgrep is **1.29.0**,
   although ripgrep may work with older versions.
 * Note that the binary may be bigger than expected because it contains debug
   symbols. This is intentional. To remove debug symbols and therefore reduce
@@ -358,7 +358,7 @@ ripgrep isn't currently in any other package repositories.
 
 ripgrep is written in Rust, so you'll need to grab a
 [Rust installation](https://www.rust-lang.org/) in order to compile it.
-ripgrep compiles with Rust 1.28.0 (stable) or newer. In general, ripgrep tracks
+ripgrep compiles with Rust 1.29.0 (stable) or newer. In general, ripgrep tracks
 the latest stable release of the Rust compiler.
 
 To build ripgrep:


### PR DESCRIPTION
This upgrades the minimum required version of Rust to 1.29 in order to fix #916 (Zombie processes cause `rg --files` to hang in `/proc`).

I have manually confirmed that the bug is fixed when compiling ripgrep with 1.29.

It's probably better to merge this just before the next release in order for the current Rust version to still be in present in the README(?).

See also:
- Rust compiler bug ticket: https://github.com/rust-lang/rust/issues/50619
- Rust compiler PR with the fix: https://github.com/rust-lang/rust/pull/50630

closes #916