### PR TITLE
Add Buildstream type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -107,6 +107,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("awk", &["*.awk"]),
     ("bazel", &["*.bzl", "WORKSPACE", "BUILD"]),
     ("bitbake", &["*.bb", "*.bbappend", "*.bbclass", "*.conf", "*.inc"]),
+    ("buildstream", &["*.bst"]),
     ("bzip2", &["*.bz2"]),
     ("c", &["*.c", "*.h", "*.H", "*.cats"]),
     ("cabal", &["*.cabal"]),


### PR DESCRIPTION
BuildStream is a Free Software tool for building/integrating software stacks.: https://buildstream.gitlab.io/buildstream/

It uses recipes written in YAML, in files with the `.bst` extension.

---

I wonder about the name if the type. I used `buildstream` because that's the name of the project, but the command line is `bst` so that's another possible name.

The latter is also shorter, which is nice when using `rg --type=bst …`.

Do you have a policy on this? Can we add both?