### PR TITLE
Add BUILD.bazel to bazel file type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -105,7 +105,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("asm", &["*.asm", "*.s", "*.S"]),
     ("avro", &["*.avdl", "*.avpr", "*.avsc"]),
     ("awk", &["*.awk"]),
-    ("bazel", &["*.bzl", "WORKSPACE", "BUILD"]),
+    ("bazel", &["*.bzl", "WORKSPACE", "BUILD", "BUILD.bazel"]),
     ("bitbake", &["*.bb", "*.bbappend", "*.bbclass", "*.conf", "*.inc"]),
     ("buildstream", &["*.bst"]),
     ("bzip2", &["*.bz2"]),


### PR DESCRIPTION
This adds `"BUILD.bazel"` to the filename patterns for the `bazel` file type.

Bazel allows `BUILD.bazel` as a filename alternative to `BUILD`, see bazelbuild/bazel#4517 and the [0.4.1 release changelog](https://github.com/bazelbuild/bazel/blob/master/CHANGELOG.md#release-041-2016-11-21).