### PR TITLE
Fix inconsistent handling of gitignore patterns like foo*bar

### DIFF
--- a/ignore/src/gitignore.rs
+++ b/ignore/src/gitignore.rs
@@ -435,7 +435,6 @@ impl GitignoreBuilder {
             is_whitelist: false,
             is_only_dir: false,
         };
-        let mut literal_separator = false;
         let mut is_absolute = false;
         if line.starts_with("\\!") || line.starts_with("\\#") {
             line = &line[1..];
@@ -450,7 +449,6 @@ impl GitignoreBuilder {
                 // then the glob can only match the beginning of a path
                 // (relative to the location of gitignore). We achieve this by
                 // simply banning wildcards from matching /.
-                literal_separator = true;
                 line = &line[1..];
                 is_absolute = true;
             }
@@ -463,16 +461,11 @@ impl GitignoreBuilder {
                 line = &line[..i];
             }
         }
-        // If there is a literal slash, then we note that so that globbing
-        // doesn't let wildcards match slashes.
         glob.actual = line.to_string();
-        if is_absolute || line.chars().any(|c| c == '/') {
-            literal_separator = true;
-        }
-        // If there was a slash, then this is a glob that must match the entire
-        // path name. Otherwise, we should let it match anywhere, so use a **/
-        // prefix.
-        if !literal_separator {
+        // If there is a literal slash, then this is a glob that must match the
+        // entire path name. Otherwise, we should let it match anywhere, so use
+        // a **/ prefix.
+        if !is_absolute && !line.chars().any(|c| c == '/') {
             // ... but only if we don't already have a **/ prefix.
             if !glob.has_doublestar_prefix() {
                 glob.actual = format!("**/{}", glob.actual);
@@ -486,7 +479,7 @@ impl GitignoreBuilder {
         }
         let parsed =
             GlobBuilder::new(&glob.actual)
-                .literal_separator(literal_separator)
+                .literal_separator(true)
                 .case_insensitive(self.case_insensitive)
                 .backslash_escape(true)
                 .build()
@@ -689,6 +682,7 @@ mod tests {
     ignored!(ig39, ROOT, "\\?", "?");
     ignored!(ig40, ROOT, "\\*", "*");
     ignored!(ig41, ROOT, "\\a", "a");
+    ignored!(ig42, ROOT, "s*.rs", "sfoo.rs");
 
     not_ignored!(ignot1, ROOT, "amonths", "months");
     not_ignored!(ignot2, ROOT, "monthsa", "months");
@@ -710,6 +704,7 @@ mod tests {
     not_ignored!(ignot16, ROOT, "*\n!**/", "foo", true);
     not_ignored!(ignot17, ROOT, "src/*.rs", "src/grep/src/main.rs");
     not_ignored!(ignot18, ROOT, "path1/*", "path2/path1/foo");
+    not_ignored!(ignot19, ROOT, "s*.rs", "src/foo.rs");
 
     fn bytes(s: &str) -> Vec<u8> {
         s.to_string().into_bytes()


### PR DESCRIPTION
(This is kind of related to #762, but not exactly. The issue was present before that was merged. I don't think anyone's ever complained, though, because there's no test for it.)

In the `ignore` crate, there's a check for a literal `/` in `gitignore` patterns. If there is one, `literal_separator` is set to `true`, preventing `*` from matching slashes; if there's not, `*` is allowed to match slashes.

Whether the `*` matches slashes doesn't really matter either way for patterns like `*foo` and `foo*`, but it's pretty important for `foo*bar`. In that case (without `literal_separator`), the `gitignore` matcher will return a successful match for both `foobazbar` *and* `foo/baz/bar`.

Git itself does not seem to treat `gitignore` patterns like this (tested 2.17.1 and 2.19.1).

You can run the following in the root of the ripgrep repo to demonstrate this:

```
% \rg --no-ignore-global --files -g 's*.rs' | sort
globset/src/glob.rs
globset/src/lib.rs
globset/src/pathutil.rs
grep-cli/src/decompress.rs
grep-cli/src/escape.rs
... # and so on
% \git ls-files --ignored -x 's*.rs' | sort
grep-printer/src/standard.rs
grep-printer/src/stats.rs
grep-printer/src/summary.rs
grep-regex/src/strip.rs
grep-searcher/examples/search-stdin.rs
grep-searcher/src/sink.rs
grep/examples/simplegrep.rs
src/search.rs
src/subject.rs
```

The `rg` command lists almost all of the Rust source files in the repo, because `s*.rs` without `literal_separator` matches `src/whatever.rs`. The `git` command lists only Rust source files that actually start with an `s`.

With this change, both commands produce the same output.

---

I think `ignore`'s current behaviour is the result of attempting to account for the apparent distinction being made by these two bullet points in the `gitignore` documentation:

>If the pattern does not contain a slash /, Git treats it as a shell glob pattern and checks for a match against the pathname relative to the location of the .gitignore file (relative to the toplevel of the work tree if not from a .gitignore file).
>
>Otherwise, Git treats the pattern as a shell glob: "*" matches anything except "/", "?" matches any one character except "/" and "[]" matches one character in a selected range. See fnmatch(3) and the FNM_PATHNAME flag for a more detailed description.

Someone obviously felt the need to split these two scenarios out here, suggesting there's a difference, but whatever that might be isn't really communicated at all.

The first point kind of suggests, with the 'match against the pathname' bit, that it should be matched against the full relative path, but that's actually the *opposite* of how it behaves, which is evidenced in the `ignore` crate by the way it (correctly) treats patterns without a slash as having `**/` prepended to them.

Both points also use the phrase 'treats ... as a shell glob', and the second one clarifies that, in a shell glob, `*` doesn't match `/`.

So, despite their weird attempt at a distinction, i'm not sure that the existing behaviour is actually supported by the documentation. Or at least the alternative isn't *not* supported...?

Does that make sense, or is this another case where you'd like to see the up-stream documentation made more explicit before changing things? (I should probably send them another e-mail about this either way, but i haven't yet.)