### PR TITLE
Add missing Cython file types

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -128,7 +128,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("cshtml", &["*.cshtml"]),
     ("css", &["*.css", "*.scss"]),
     ("csv", &["*.csv"]),
-    ("cython", &["*.pyx"]),
+    ("cython", &["*.pyx", "*.pxi", "*.pxd"]),
     ("dart", &["*.dart"]),
     ("d", &["*.d"]),
     ("dhall", &["*.dhall"]),


### PR DESCRIPTION
From the [Cython file types](https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html?highlight=pxi#cython-file-types) paragraph on the official docs:

>There are three file types in Cython:
>   - The implementation files, carrying a .py or .pyx suffix.
>   - The definition files, carrying a .pxd suffix.
>   - The include files, carrying a .pxi suffix.

So I added `pxi` and `pxd` to the list. (In fact because `ripgrep` was not searching in all my cython files :smile:)