### PR TITLE
Add postscript to known file types.

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -225,6 +225,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("pdf", &["*.pdf"]),
     ("php", &["*.php", "*.php3", "*.php4", "*.php5", "*.phtml"]),
     ("pod", &["*.pod"]),
+    ("postscript", &[".eps", ".ps"]),
     ("protobuf", &["*.proto"]),
     ("ps", &["*.cdxml", "*.ps1", "*.ps1xml", "*.psd1", "*.psm1"]),
     ("puppet", &["*.erb", "*.pp", "*.rb"]),


### PR DESCRIPTION
Although postscript/encapsulated postscript is usually thought of as a
binary format, it's actually mostly ASCII, so ripgrep will not ignore
these files.

The situation is basically the same as for pdf, which is also already
present in the list of known filetypes.