### PR TITLE
Fix #1121 - avoid triggering windows antimalware when in --files mode

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -782,7 +782,7 @@ impl ArgMatches {
             .max_filesize(self.max_file_size()?)
             .threads(self.threads()?)
             .same_file_system(self.is_present("one-file-system"))
-            .skip_stdout(true)
+            .skip_stdout(!self.is_present("files"))
             .overrides(self.overrides()?)
             .types(self.types()?)
             .hidden(!self.hidden())


### PR DESCRIPTION
This looks basically equivalent to the earlier fix for #600 