### PR TITLE
--files-without-match / --files-with-matches issue when providing only a single path

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1448,6 +1448,8 @@ impl ArgMatches {
         } else {
             self.is_present("with-filename")
             || self.is_present("vimgrep")
+            || self.is_present("files-with-matches")
+            || self.is_present("files-without-match")
             || paths.len() > 1
             || paths.get(0).map_or(false, |p| p.is_dir())
         }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1448,7 +1448,7 @@ impl ArgMatches {
         } else {
             self.is_present("with-filename")
             || self.is_present("vimgrep")
-            || paths.len() > 0
+            || paths.len() > 1
             || paths.get(0).map_or(false, |p| p.is_dir())
         }
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1448,7 +1448,7 @@ impl ArgMatches {
         } else {
             self.is_present("with-filename")
             || self.is_present("vimgrep")
-            || paths.len() > 1
+            || paths.len() > 0
             || paths.get(0).map_or(false, |p| p.is_dir())
         }
     }


### PR DESCRIPTION
This should fix #1106 

When determining if file names should be output despite --with-filename not being set explicitly the length of the paths array should be larger than 0 rather than 1 to activate file name output.