### PR TITLE
Update the crossbeam-channel dep to 0.3.2

### DIFF
--- a/ignore/Cargo.toml
+++ b/ignore/Cargo.toml
@@ -18,7 +18,7 @@ name = "ignore"
 bench = false
 
 [dependencies]
-crossbeam-channel = "0.2.4"
+crossbeam-channel = "0.3.2"
 globset = { version = "0.4.2", path = "../globset" }
 lazy_static = "1.1.0"
 log = "0.4.5"

--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -1446,12 +1446,12 @@ impl Worker {
                 return None;
             }
             match self.rx.try_recv() {
-                Some(Message::Work(work)) => {
+                Ok(Message::Work(work)) => {
                     self.waiting(false);
                     self.quitting(false);
                     return Some(work);
                 }
-                Some(Message::Quit) => {
+                Ok(Message::Quit) => {
                     // We can't just quit because a Message::Quit could be
                     // spurious. For example, it's possible to observe that
                     // all workers are waiting even if there's more work to
@@ -1482,7 +1482,7 @@ impl Worker {
                         // Otherwise, spin.
                     }
                 }
-                None => {
+                Err(_) => {
                     self.waiting(true);
                     self.quitting(false);
                     if self.num_waiting() == self.threads {


### PR DESCRIPTION
Fix issue #1141 
I am still getting some warnings but the ripgrep test suite works
```

warning: unused `std::result::Result` which must be used                                                                                                   
    --> src/walk.rs:1117:13                                                                                                                                
     |                                                                                                                                                     
1117 | /             tx.send(Message::Work(Work {                                                                                                          
1118 | |                 dent: dent,                                                                                                                       
1119 | |                 ignore: self.ig_root.clone(),                                                                                                     
1120 | |                 root_device: root_device,                                                                                                         
1121 | |             }));                                                                                                                                  
     | |________________^                                                                                                                                  
     |                                                                                                                                                     
     = note: #[warn(unused_must_use)] on by default                                                                                                        
     = note: this `Result` may be an `Err` variant, which should be handled                                                                                
                                                                                                                                                           
warning: unused `std::result::Result` which must be used                                                                                                   
    --> src/walk.rs:1430:13                                                                                                                                
     |                                                                                                                                                     
1430 | /             self.tx.send(Message::Work(Work {                                                                                                     
1431 | |                 dent: dent,                                                                                                                       
1432 | |                 ignore: ig.clone(),                                                                                                               
1433 | |                 root_device: root_device,                                                                                                         
1434 | |             }));                                                                                                                                  
     | |________________^                                                                                                                                  
     |                                                                                                                                                     
     = note: this `Result` may be an `Err` variant, which should be handled                                                                                
                                                                                                                                                           
warning: unused `std::result::Result` which must be used                                                                                                   
    --> src/walk.rs:1490:29                                                                                                                                
     |                                                                                                                                                     
1490 |                             self.tx.send(Message::Quit);                                                                                            
     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                            
     |                                                                                                                                                     
     = note: this `Result` may be an `Err` variant, which should be handled                                                                                
                                                                                                                                                           
    Finished dev [unoptimized + debuginfo] target(s) in 22.43s                                                                                             
   create-stamp debian/debhelper-build-stamp

```