### PR TITLE
Move from `trim_right` to `trim_end`

### DIFF
--- a/ignore/src/gitignore.rs
+++ b/ignore/src/gitignore.rs
@@ -423,7 +423,7 @@ impl GitignoreBuilder {
             return Ok(self);
         }
         if !line.ends_with("\\ ") {
-            line = line.trim_right();
+            line = line.trim_end();
         }
         if line.is_empty() {
             return Ok(self);


### PR DESCRIPTION
The `trim_right` method is deprecated in favor of `trim_end` for
`std::string::String` to more naturally support right-to-left
languages. The `trim_end` method was introduced in Rust 1.30.0, and the
current stable version is 1.31.1, so it feels safe to make the change
at this point in time.