### PR TITLE
Easily build static binaries and start developing

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: gitpod.Dockerfile
+tasks:
+- init: cargo build
+  command: cargo test --all

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Please see the [CHANGELOG](CHANGELOG.md) for a release history.
 * [Configuration files](GUIDE.md#configuration-file)
 * [Shell completions](FAQ.md#complete)
 * [Building](#building)
+* [Contribute](#contribute)
 
 
 ### Screenshot of search results
@@ -432,3 +433,14 @@ $ cargo test --all
 ```
 
 from the repository root.
+
+### Contribute
+
+Use a browser based dev environment
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/BurntSushi/ripgrep)
+
+Or clone locally and run
+```
+cargo test --all
+```

--- a/gitpod.Dockerfile
+++ b/gitpod.Dockerfile
@@ -1,0 +1,12 @@
+FROM gitpod/workspace-full:latest
+
+USER root
+RUN apt-get install -yq \
+        musl \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+USER gitpod
+RUN cd /home/gitpod && \
+    .cargo/bin/rustup target add x86_64-unknown-linux-musl
+
+USER root


### PR DESCRIPTION
With this PR everyone browsing GitHub can easily try out ripgrep and start contributing by using Gitpod, a free dev environment service with rich GitHub integration.

The PR contains the config for Gitpod that automatically executes `cargo build` and `cargo test --all` and allows to build static binaries using `cargo build --release --target x86_64-unknown-linux-musl`, without the need for any setup on the user side.

Here is a screenshot:
![image](https://user-images.githubusercontent.com/32448529/50983257-6548da00-14ff-11e9-97fa-58d0549b91bf.png)


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/74880e80-9911-4ca2-8b91-490228153d2b)
