### PR TITLE
*.dtx and *.ins added for -type tex

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -283,7 +283,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ]),
     ("taskpaper", &["*.taskpaper"]),
     ("tcl", &["*.tcl"]),
-    ("tex", &["*.tex", "*.ltx", "*.cls", "*.sty", "*.bib"]),
+    ("tex", &["*.tex", "*.ltx", "*.cls", "*.sty", "*.bib", "*.dtx", "*.ins"]),
     ("textile", &["*.textile"]),
     ("thrift", &["*.thrift"]),
     ("tf", &["*.tf"]),


### PR DESCRIPTION
The --type tex should include documented LaTeX sources (.dtx) and their .ins files