### PR TITLE
Escape documentation braces from a2x

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1471,10 +1471,10 @@ Enable matching across multiple lines.
 
 When multiline mode is enabled, ripgrep will lift the restriction that a match
 cannot include a line terminator. For example, when multiline mode is not
-enabled (the default), then the regex '\\p{any}' will match any Unicode
+enabled (the default), then the regex '\\p\\{any}' will match any Unicode
 codepoint other than '\\n'. Similarly, the regex '\\n' is explicitly forbidden,
 and if you try to use it, ripgrep will return an error. However, when multiline
-mode is enabled, '\\p{any}' will match any Unicode codepoint, including '\\n',
+mode is enabled, '\\p\\{any}' will match any Unicode codepoint, including '\\n',
 and regexes like '\\n' are permitted.
 
 An important caveat is that multiline mode does not change the match semantics


### PR DESCRIPTION
`a2x` is used to convert these documentation strings into a man page. However, the AsciiDoc format reserves the `{identifier}` syntax for [attribute references](http://www.methods.co.nz/asciidoc/userguide.html#_document_attributes), and `a2x` interprets the unescaped substring `{any}` as such an attribute reference. The documentation at that link warns:

> If an attribute is not defined then the line containing the attribute reference is dropped. This property is used extensively in AsciiDoc configuration files to facilitate conditional markup generation.

Indeed, the generated `man` page is missing two lines (here, "lines" means lines of source code), which you can see in a release build like [this one](https://github.com/BurntSushi/ripgrep/releases/download/0.10.0/ripgrep-0.10.0-x86_64-apple-darwin.tar.gz), in the `doc/rg.1` file, resulting in this ill-formed paragraph:

> When multiline mode is enabled, ripgrep will lift the restriction that a match cannot include a line terminator. For example, when multiline mode is not codepoint other than \n. Similarly, the regex \n is explicitly forbidden, and if you try to use it, ripgrep will return an error. However, when multiline and regexes like \n are permitted.

The [FAQ says](http://methods.co.nz/asciidoc/faq.html#_how_can_i_escape_asciidoc_markup) the fix is to simply escape the unintentional markup with a backslash, which is what this PR does. I don't have the ripgrep build set up on my machine, so I have not verified this change. I would ask that a maintainer do so before merging.