### PR TITLE
README.md: Add Repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and grep.
 [![Linux build status](https://travis-ci.org/BurntSushi/ripgrep.svg)](https://travis-ci.org/BurntSushi/ripgrep)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/github/BurntSushi/ripgrep?svg=true)](https://ci.appveyor.com/project/BurntSushi/ripgrep)
 [![Crates.io](https://img.shields.io/crates/v/ripgrep.svg)](https://crates.io/crates/ripgrep)
+[![latest packaged version(s)](https://repology.org/badge/latest-versions/ripgrep.svg)](https://repology.org/project/ripgrep/badges)
 
 Dual-licensed under MIT or the [UNLICENSE](http://unlicense.org).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and grep.
 [![Linux build status](https://travis-ci.org/BurntSushi/ripgrep.svg)](https://travis-ci.org/BurntSushi/ripgrep)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/github/BurntSushi/ripgrep?svg=true)](https://ci.appveyor.com/project/BurntSushi/ripgrep)
 [![Crates.io](https://img.shields.io/crates/v/ripgrep.svg)](https://crates.io/crates/ripgrep)
-[![latest packaged version(s)](https://repology.org/badge/latest-versions/ripgrep.svg)](https://repology.org/project/ripgrep/badges)
+[![Packaging status](https://repology.org/badge/tiny-repos/ripgrep.svg)](https://repology.org/project/ripgrep/badges)
 
 Dual-licensed under MIT or the [UNLICENSE](http://unlicense.org).
 


### PR DESCRIPTION
This adds a badge to the README.md file indicating to users that click on it if their os/distro carries that latest version of ripgrep. The badge looks like this:  
[![Packaging status](https://repology.org/badge/tiny-repos/ripgrep.svg)](https://repology.org/project/ripgrep/badges)

Preview https://github.com/BurntSushi/ripgrep/blob/5cc12cba816e84a7884c755883cad0e3927d7187/README.md