### PR TITLE
Remove extra new-line after Clap output

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1654,12 +1654,12 @@ where I: IntoIterator<Item=T>,
     if err.use_stderr() {
         return Err(err.into());
     }
-    // Explicitly ignore any error returned by writeln!. The most likely error
+    // Explicitly ignore any error returned by write!. The most likely error
     // at this point is a broken pipe error, in which case, we want to ignore
     // it and exit quietly.
     //
     // (This is the point of this helper function. clap's functionality for
     // doing this will panic on a broken pipe error.)
-    let _ = writeln!(io::stdout(), "{}", err);
+    let _ = write!(io::stdout(), "{}", err);
     process::exit(0);
 }


### PR DESCRIPTION
31d3e241306f305c1cb94e1882511da2b48dcd36 added this wrapper around the invocation of Clap which manually writes whatever output it produces. But it uses `writeln!()`, and Clap's output is already new-line-delimited, so `--help` and `--version` now have an extra new-line at the end that inexplicably upsets me. This just makes it go away again