### PR TITLE
Support for files for type `xml`

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -301,7 +301,10 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("vimscript", &["*.vim"]),
     ("wiki", &["*.mediawiki", "*.wiki"]),
     ("webidl", &["*.idl", "*.webidl", "*.widl"]),
-    ("xml", &["*.xml", "*.xml.dist"]),
+    ("xml", &[
+        "*.xml", "*.xml.dist", "*.dtd", "*.xsl", "*.xslt", "*.xsd", "*.xjb",
+        "*.rng", "*.sch",
+    ]),
     ("xz", &["*.xz", "*.txz"]),
     ("yacc", &["*.y"]),
     ("yaml", &["*.yaml", "*.yml"]),


### PR DESCRIPTION
- `*.dtd` for Document Type Definitions
- `*.xsl` and `*.xslt` for XSL Transformation descriptions
- `*.xsd` for XML Schema definitions
- `*.xjb` for JAXB bindings
- `*.rng` for Relax NG files
- `*.sch` for Schematron files