### PR TITLE
ignore/types: add GAP

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -146,6 +146,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
         "*.f90", "*.F90", "*.f95", "*.F95",
     ]),
     ("fsharp", &["*.fs", "*.fsx", "*.fsi"]),
+    ("gap", &["*.g", "*.gap", "*.gi", "*.gd", "*.tst"]),
     ("gn", &["*.gn", "*.gni"]),
     ("go", &["*.go"]),
     ("gzip", &["*.gz", "*.tgz"]),


### PR DESCRIPTION
Add support for file types used by the GAP language, a research system
computational discrete algebra, see <https://www.gap-system.org>