### PR TITLE
Mention `--auto-hybrid-regex` in the README’s advantages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ increases the times to `2.640s` for ripgrep and `10.277s` for GNU grep.
 * ripgrep has optional support for switching its regex engine to use PCRE2.
   Among other things, this makes it possible to use look-around and
   backreferences in your patterns, which are not supported in ripgrep's default
-  regex engine. PCRE2 support is enabled with `-P`.
+  regex engine. PCRE2 support can be enabled with `-P` (use PCRE2 always) or
+  `--auto-hybrid-regex` (use PCRE2 only if needed).
 * ripgrep supports searching files in text encodings other than UTF-8, such
   as UTF-16, latin-1, GBK, EUC-JP, Shift_JIS and more. (Some support for
   automatically detecting UTF-16 is provided. Other text encodings must be


### PR DESCRIPTION
This feature solves a major reason I was skeptical of using ripgrep, so I think it’s good to mention it in the section about why one should use it.

I use backreferences a lot, so I had previously thought that ripgrep would provide no speed advantage over ag, since I would always have `-P` enabled. But when I saw `--auto-hybrid-regex` in the [11.0.0 changelog](https://github.com/BurntSushi/ripgrep/blob/11.0.0/CHANGELOG.md#1100-2019-04-15), I learned that ripgrep can use it to speed up simple queries while still allowing me to write backreferences.