### PR TITLE
readme: mention --pcre2 as long form of -P

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ increases the times to `2.640s` for ripgrep and `10.277s` for GNU grep.
 * ripgrep has optional support for switching its regex engine to use PCRE2.
   Among other things, this makes it possible to use look-around and
   backreferences in your patterns, which are not supported in ripgrep's default
-  regex engine. PCRE2 support can be enabled with `-P` (use PCRE2 always) or
-  `--auto-hybrid-regex` (use PCRE2 only if needed).
+  regex engine. PCRE2 support can be enabled with `-P/--pcre2` (use PCRE2
+  always) or `--auto-hybrid-regex` (use PCRE2 only if needed).
 * ripgrep supports searching files in text encodings other than UTF-8, such
   as UTF-16, latin-1, GBK, EUC-JP, Shift_JIS and more. (Some support for
   automatically detecting UTF-16 is provided. Other text encodings must be


### PR DESCRIPTION
This is for consistency with the short and long flags given in other bullet points. I originally assumed there was no long flag for `-P` because none was given here.