### PR TITLE
Remove outdated statement about rg in package repositories from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,9 +343,6 @@ If you're a **Rust programmer**, ripgrep can be installed with `cargo`.
 $ cargo install ripgrep
 ```
 
-ripgrep isn't currently in any other package repositories.
-[I'd like to change that](https://github.com/BurntSushi/ripgrep/issues/10).
-
 
 ### Building
 


### PR DESCRIPTION
Issue #10 already states that "ripgrep is now in most or all of the major
package repositories"