### PR TITLE
Point regex doc link to the version ripgrep uses

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -110,7 +110,7 @@ colors, you'll notice that `faster` will be highlighted instead of just the
 
 It is beyond the scope of this guide to provide a full tutorial on regular
 expressions, but ripgrep's specific syntax is documented here:
-https://docs.rs/regex/0.2.5/regex/#syntax
+https://docs.rs/regex/*/regex/#syntax
 
 
 ### Recursive search


### PR DESCRIPTION
Cargo.toml says regex 1.0.5, and its doc is different, e.g. adds "symmetric differences" under https://docs.rs/regex/1.0.5/regex/#character-classes