### PR TITLE
Fix stdin being printed when '-' exists as directory in path being searched

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1590,10 +1590,11 @@ impl ArgMatches {
         if self.is_present("no-filename") {
             false
         } else {
+            let should_check_dir = paths != [Path::new("-")];
             self.is_present("with-filename")
             || self.is_present("vimgrep")
             || paths.len() > 1
-            || paths.get(0).map_or(false, |p| p.is_dir())
+            || (should_check_dir && paths.get(0).map_or(false, |p| p.is_dir()))
         }
     }
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -716,3 +716,14 @@ rgtest!(r1259_drop_last_byte_nonl, |dir: Dir, mut cmd: TestCommand| {
     cmd = dir.command();
     eqnice!("fz\n", cmd.arg("-f").arg("patterns-nl").arg("test").stdout());
 });
+
+// See: https://github.com/BurntSushi/ripgrep/issues/1223
+rgtest!(r1223_prevent_dir_check_for_default_path, |dir: Dir, mut cmd: TestCommand| {
+    dir.create_dir("-");
+    dir.create("a.json", "{}");
+    dir.create("a.txt", "some text");
+
+    let mut cmd = dir.command();
+
+    eqnice!("a.json\na.txt\n", cmd.arg("a").pipe(b"a.json\na.txt"));
+});


### PR DESCRIPTION

Fix for this issue. -> https://github.com/BurntSushi/ripgrep/issues/1223
Its my first time raising a PR. Please do tell if I've missed anything.