### PR TITLE
Add --glob-case-insensitive

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -104,6 +104,10 @@ _rg() {
     '*'{-g+,--glob=}'[include/exclude files matching specified glob]:glob'
     '*--iglob=[include/exclude files matching specified case-insensitive glob]:glob'
 
+    + '(glob-case-insensitive)' # File-glob case sensitivity options
+    '--glob-case-insensitive[treat -g/--glob patterns case insensitively]'
+    $no'--no-glob-case-insensitive[treat -g/--glob patterns case sensitively]'
+
     + '(heading)' # Heading options
     '(pretty-vimgrep)--heading[show matches grouped by file name]'
     "(pretty-vimgrep)--no-heading[don't show matches grouped by file name]"

--- a/src/app.rs
+++ b/src/app.rs
@@ -571,6 +571,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_fixed_strings(&mut args);
     flag_follow(&mut args);
     flag_glob(&mut args);
+    flag_glob_case_insensitive(&mut args);
     flag_heading(&mut args);
     flag_hidden(&mut args);
     flag_iglob(&mut args);
@@ -1215,6 +1216,25 @@ it.
         .help(SHORT).long_help(LONG)
         .multiple()
         .allow_leading_hyphen();
+    args.push(arg);
+}
+
+fn flag_glob_case_insensitive(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Process all glob patterns case insensitively.";
+    const LONG: &str = long!("\
+Process glob patterns given with the -g/--glob flag case insensitively. This
+effectively treats --glob as --iglob.
+
+This flag can be disabled with the --no-glob-case-insensitive flag.
+");
+    let arg = RGArg::switch("glob-case-insensitive")
+        .help(SHORT).long_help(LONG)
+        .overrides("no-glob-case-insensitive");
+    args.push(arg);
+
+    let arg = RGArg::switch("no-glob-case-insensitive")
+        .hidden()
+        .overrides("glob-case-insensitive");
     args.push(arg);
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1268,6 +1268,10 @@ impl ArgMatches {
     /// Builds the set of glob overrides from the command line flags.
     fn overrides(&self) -> Result<Override> {
         let mut builder = OverrideBuilder::new(env::current_dir()?);
+        // Make all globs case insensitive with --glob-case-insensitive.
+        if self.is_present("glob-case-insensitive") {
+            builder.case_insensitive(true).unwrap();
+        }
         for glob in self.values_of_lossy_vec("glob") {
             builder.add(&glob)?;
         }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -341,6 +341,14 @@ rgtest!(glob_case_sensitive, |dir: Dir, mut cmd: TestCommand| {
     eqnice!("file2.html:Sherlock\n", cmd.stdout());
 });
 
+rgtest!(glob_always_case_insensitive, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("sherlock", SHERLOCK);
+    dir.create("file.HTML", "Sherlock");
+    cmd.args(&["--glob-case-insensitive", "--glob", "*.html", "Sherlock"]);
+
+    eqnice!("file.HTML:Sherlock\n", cmd.stdout());
+});
+
 rgtest!(byte_offset_only_matching, |dir: Dir, mut cmd: TestCommand| {
     dir.create("sherlock", SHERLOCK);
     cmd.arg("-b").arg("-o").arg("Sherlock");


### PR DESCRIPTION
Hopefully this is what you had in mind. The flag forces `-g`/`--glob` to be treated as `--iglob`.

If usability on case-insensitive file systems is a concern, i suppose the next logical request would be an option to make the built-in type patterns case-insensitive as well. But i didn't touch that obv

Fixes #1293