### PR TITLE
Enable testing on ARM, in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,10 @@ matrix:
           - docbook-xsl
           - xsltproc
           - libxml2-utils
+          - qemu-system-arm
+          - qemu-user
+          - qemu-user-static
+          - binfmt-support
     # Beta channel. We enable these to make sure there are no regressions in
     # Rust beta releases.
     - os: linux
@@ -84,6 +88,10 @@ matrix:
           - docbook-xsl
           - xsltproc
           - libxml2-utils
+          - qemu-system-arm
+          - qemu-user
+          - qemu-user-static
+          - binfmt-support
 install: ci/install.sh
 script: ci/script.sh
 before_deploy: ci/before_deploy.sh

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -10,7 +10,7 @@ set -ex
 mk_artifacts() {
     CARGO="$(builder)"
     if is_arm; then
-        "$CARGO" build --target "$TARGET" --release
+        CC="$(gcc_full_name)" "$CARGO" build --target "$TARGET" --release --features 'pcre2'
     else
         # Technically, MUSL builds will force PCRE2 to get statically compiled,
         # but we also want PCRE2 statically build for macOS binaries.

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -33,11 +33,7 @@ install_osx_dependencies() {
 configure_cargo() {
     local prefix=$(gcc_prefix)
     if [ -n "${prefix}" ]; then
-        local gcc_suffix=
-        if [ -n "$GCC_VERSION" ]; then
-          gcc_suffix="-$GCC_VERSION"
-        fi
-        local gcc="${prefix}gcc${gcc_suffix}"
+        local gcc="$(gcc_full_name)"
 
         # information about the cross compiler
         "${gcc}" -v

--- a/ci/utils.sh
+++ b/ci/utils.sh
@@ -55,6 +55,21 @@ gcc_prefix() {
     esac
 }
 
+gcc_full_name() {
+    local -r prefix="$(gcc_prefix)"
+    local gcc_name="gcc"
+    if [ -n "${prefix}" ]; then
+        local gcc_suffix=
+        if [ -n "${GCC_VERSION}" ]; then
+            gcc_suffix="-${GCC_VERSION}"
+        fi
+
+        gcc_name="${prefix}gcc${gcc_suffix}"
+    fi
+
+    echo "${gcc_name}"
+}
+
 is_musl() {
     case "$TARGET" in
         *-musl) return 0 ;;


### PR DESCRIPTION
A few issues here.
It seems to fail a test in CI because the QEMU version is old and it does not support ARM very well.

There are at least a few ways to fix this(that I can think of):
- There is no QEMU ppa - so, either it is created by someone(I personally don't know how) or have a precompiled QEMU archive be downloaded.
- Switch the ARM build to another CI, like Azure Pipelines and have it there run on a newer version of Linux?
- Disable some tests on ARM(cfg over some tests)?