### PR TITLE
Document shell-specific caveats related to the `--replace` flag

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2171,7 +2171,10 @@ Replace every match with the text given when printing results. Neither this
 flag nor any other ripgrep flag will modify your files.
 
 Capture group indices (e.g., $5) and names (e.g., $foo) are supported in the
-replacement string.
+replacement string. In shells such as Bash and zsh, you should wrap the
+pattern in single quotes instead of double quotes. Otherwise, capture group
+indices will be replaced by expanded shell variables which will most likely
+be empty.
 
 Note that the replacement by default replaces each match, and NOT the entire
 line. To replace the entire line, you should match the entire line.


### PR DESCRIPTION
I ran into this issue today, so I thought it'd be nice to document it for others :smiley:

(I only noticed it because my shell highlights expanded variables thanks to [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting)…)