### PR TITLE
ignore/types: add Robot Framework

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -241,6 +241,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("readme", &["README*", "*README"]),
     ("r", &["*.R", "*.r", "*.Rmd", "*.Rnw"]),
     ("rdoc", &["*.rdoc"]),
+    ("robot", &["*.robot"]),
     ("rst", &["*.rst"]),
     ("ruby", &["Gemfile", "*.gemspec", ".irbrc", "Rakefile", "*.rb"]),
     ("rust", &["*.rs"]),


### PR DESCRIPTION
[Robot Framework](https://robotframework.org/) scripts and resource files have the file extension `.robot`