### PR TITLE
readme: fix broken link to Scoop bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ $ choco install ripgrep
 ```
 
 If you're a **Windows Scoop** user, then you can install ripgrep from the
-[official bucket](https://github.com/lukesampson/scoop/blob/master/bucket/ripgrep.json):
+[official bucket](https://github.com/ScoopInstaller/Main/blob/master/bucket/ripgrep.json):
 
 ```
 $ scoop install ripgrep


### PR DESCRIPTION
It seems that the Scoop buckets were moved to separate repositories: https://github.com/lukesampson/scoop/blob/master/buckets.json