### PR TITLE
Support compiling `ignore` crate to wasm32

### DIFF
--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -379,7 +379,18 @@ impl DirEntryRaw {
         })
     }
 
-    #[cfg(not(unix))]
+    // Placeholder implementation to allow compiling on non-standard platforms (e.g. wasm32).
+    #[cfg(not(any(windows, unix)))]
+    fn from_entry_os(
+        depth: usize,
+        ent: &fs::DirEntry,
+        ty: fs::FileType,
+    ) -> Result<DirEntryRaw, Error> {
+        Err(Error::Io(io::Error::new(
+            io::ErrorKind::Other, "unsupported platform")))
+    }
+
+    #[cfg(windows)]
     fn from_path(
         depth: usize,
         pb: PathBuf,
@@ -415,6 +426,17 @@ impl DirEntryRaw {
             depth: depth,
             ino: md.ino(),
         })
+    }
+
+    // Placeholder implementation to allow compiling on non-standard platforms (e.g. wasm32).
+    #[cfg(not(any(windows, unix)))]
+    fn from_path(
+        depth: usize,
+        pb: PathBuf,
+        link: bool,
+    ) -> Result<DirEntryRaw, Error> {
+        Err(Error::Io(io::Error::new(
+            io::ErrorKind::Other, "unsupported platform")))
     }
 }
 


### PR DESCRIPTION
Currently the crate assumes that exactly one of `cfg(windows)` or
`cfg(unix)` is true, but this is not actually the case, for instance
when compiling for `wasm32`.

Implement the missing functions so that the crate can compile on other
platforms, even though those functions will always return an error.