### PR TITLE
ignore: rework inter-thread messaging

### DIFF
--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -1486,7 +1486,7 @@ impl Worker {
                     }
 
                     // Wait for next `Work` or `Quit` message.
-                    value = self.rx.recv().map_err(|_| TryRecvError::Disconnected);
+                    value = Ok(self.rx.recv().expect("channel disconnected while worker is alive"));
                     self.resume();
                 },
                 Err(TryRecvError::Disconnected) => {


### PR DESCRIPTION
Change the meaning of `Quit` message. Now it means terminate. The final
"dance" is unnecessary, because by the time quitting begins, no thread
will ever spawn a new `Work`.

Replace that heuristic spin-loop, with blocking receive.

Optimize use of atomic operations.