### PR TITLE
minor update to manpage to reflect glob matching behavior change

### DIFF
--- a/doc/rg.1.txt.tpl
+++ b/doc/rg.1.txt.tpl
@@ -143,16 +143,16 @@ would behave identically to the following command
 
 same with using globs
 
-    --glob=!git
+    --glob=!.git
 
 or
 
     --glob
-    !git
+    !.git
 
 would behave identically to the following command
 
-    rg --glob '!git' foo
+    rg --glob '!.git' foo
 
 ripgrep also provides a flag, *--no-config*, that when present will suppress
 any and all support for configuration. This includes any future support

--- a/doc/rg.1.txt.tpl
+++ b/doc/rg.1.txt.tpl
@@ -143,16 +143,16 @@ would behave identically to the following command
 
 same with using globs
 
-    --glob=!git/*
+    --glob=!git
 
 or
 
     --glob
-    !git/*
+    !git
 
 would behave identically to the following command
 
-    rg --glob '!git/*' foo
+    rg --glob '!git' foo
 
 ripgrep also provides a flag, *--no-config*, that when present will suppress
 any and all support for configuration. This includes any future support


### PR DESCRIPTION
This is a minor update to ripgrep's manpage to reflect the changes in #762. The manpage's use of `!git/*` in glob patten matching examples, which is presumably intended to exclude all `git` directories from ripgrep's search, is incorrect. This might be a source of confusion for people configuring ripgrep who may not be familiar with `.gitignore` semantics.