### PR TITLE
Split sbt out of scala file type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -247,7 +247,8 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("ruby", &["Gemfile", "*.gemspec", ".irbrc", "Rakefile", "*.rb"]),
     ("rust", &["*.rs"]),
     ("sass", &["*.sass", "*.scss"]),
-    ("scala", &["*.scala", "*.sbt"]),
+    ("sbt", &["*.sbt"]),
+    ("scala", &["*.scala"]),
     ("sh", &[
         // Portable/misc. init files
         ".login", ".logout", ".profile", "profile",


### PR DESCRIPTION
sbt is a build tool for Scala. It is often useful to search only in sbt
files and not Scala files (e.g. looking for dependencies)