### PR TITLE
Ensure intended builds run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - master
   schedule:
-    cron: '00 01 * * *'
+    - cron: '00 01 * * *'
 jobs:
   test:
     name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
         sudo apt-get install musl-tools
     - name: Build everything
       run: cargo build --verbose --target ${{ matrix.target }} --all --features pcre2
+    - name: Install zsh
+      if: matrix.build == 'stable'
+      run: sudo apt-get install zsh
     - name: Test zsh auto-completions
       if: matrix.build == 'stable'
       run: ./ci/test_complete.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Install musl-gcc
       if: contains(matrix.target, 'musl')
       run: |
-        apt-get install musl-tools
+        sudo apt-get install musl-tools
     - name: Build everything
       run: cargo build --verbose --target ${{ matrix.target }} --all --features pcre2
     - name: Test zsh auto-completions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,19 @@ jobs:
         # include directive, but it result in a "matrix must define at least
         # one vector" error in the CI system.
         build:
-        - pinned-glibc
+        # - pinned-glibc
         - pinned-musl
         - stable
-        - beta
+        # - beta
         # We test musl with nightly because every once in a while, this will
         # catch an upstream regression.
-        - nightly-glibc
-        - nightly-musl
-        - macos
-        - win-msvc-32
-        - win-msvc-64
-        - win-gnu-32
-        - win-gnu-64
+        # - nightly-glibc
+        # - nightly-musl
+        # - macos
+        # - win-msvc-32
+        # - win-msvc-64
+        # - win-gnu-32
+        # - win-gnu-64
         include:
         # - build: pinned-glibc
           # os: ubuntu-18.04


### PR DESCRIPTION
Since this workflow specifies `runs-on: ${{matrix.os}}`, the `os` parameter needs to be defined for every build run.

Even though `include` is defined just for `pinned-musl` and `stable`, the other `build`s will still run—`include` is just saying "when these parameters match existing jobs, include some additional ones".

I've also added `sudo` to your `apt-get` command here—when running steps directly on the VM (as opposed to Docker), you're not running as root, and so password-less sudo can be used where needed.