### PR TITLE
Add --no-context-separator option

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -277,6 +277,7 @@ _rg() {
     ))'
     '*--colors=[specify color and style settings]: :->colorspec'
     '--context-separator=[specify string used to separate non-continuous context lines in output]:separator'
+    "--no-context-separator[Don't print context separators]"
     '--debug[show debug messages]'
     '--dfa-size-limit=[specify upper size limit of generated DFA]:DFA size (bytes)'
     "(1 stats)--files[show each file that would be searched (but don't search)]"

--- a/src/app.rs
+++ b/src/app.rs
@@ -579,6 +579,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_ignore_file(&mut args);
     flag_ignore_file_case_insensitive(&mut args);
     flag_invert_match(&mut args);
+    flag_no_context_separator(&mut args);
     flag_json(&mut args);
     flag_line_buffered(&mut args);
     flag_line_number(&mut args);
@@ -1364,6 +1365,16 @@ fn flag_invert_match(args: &mut Vec<RGArg>) {
 Invert matching. Show lines that do not match the given patterns.
 ");
     let arg = RGArg::switch("invert-match").short("v")
+        .help(SHORT).long_help(LONG);
+    args.push(arg);
+}
+
+fn flag_no_context_separator(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Don't print context separators.";
+    const LONG: &str = long!("\
+Don't print context separators. Print matched lines and requested contexts only.
+");
+    let arg = RGArg::switch("no-context-separator")
         .help(SHORT).long_help(LONG);
     args.push(arg);
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -784,7 +784,7 @@ impl ArgMatches {
             .byte_offset(self.is_present("byte-offset"))
             .trim_ascii(self.is_present("trim"))
             .separator_search(None)
-            .separator_context(Some(self.context_separator()))
+            .separator_context(self.context_separator())
             .separator_field_match(b":".to_vec())
             .separator_field_context(b"-".to_vec())
             .separator_path(self.path_separator()?)
@@ -1020,10 +1020,13 @@ impl ArgMatches {
     /// Returns the unescaped context separator in UTF-8 bytes.
     ///
     /// If one was not provided, the default `--` is returned.
-    fn context_separator(&self) -> Vec<u8> {
-        match self.value_of_os("context-separator") {
-            None => b"--".to_vec(),
-            Some(sep) => cli::unescape_os(&sep),
+    /// If --no-context-separator is passed, None is returned.
+    fn context_separator(&self) -> Option<Vec<u8>> {
+        let sep = !self.is_present("no-context-separator");
+        match (sep, self.value_of_os("context-separator")) {
+            (false, _) => None,
+            (true, None) => Some(b"--".to_vec()),
+            (true, Some(sep)) => Some(cli::unescape_os(&sep)),
         }
     }
 
@@ -1092,7 +1095,7 @@ impl ArgMatches {
         Ok(if self.heading() {
             Some(b"".to_vec())
         } else if ctx_before > 0 || ctx_after > 0 {
-            Some(self.context_separator().clone())
+            self.context_separator()
         } else {
             None
         })

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -727,3 +727,15 @@ rgtest!(f1207_ignore_encoding, |dir: Dir, mut cmd: TestCommand| {
     cmd.arg("--encoding").arg("none").arg("-a").arg("\\x00").arg("foo");
     eqnice!("\u{FFFD}\u{FFFD}\x00b\n", cmd.stdout());
 });
+
+rgtest!(no_context_sep, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("foo", "foo\nctx\nbar\nctx\nfoo\nctx");
+    cmd.arg("-I").arg("-A1").arg("--no-context-separator").arg("--context-separator").arg("AAA").arg("foo");
+    eqnice!("foo\nctx\nfoo\nctx\n", cmd.stdout());
+});
+
+rgtest!(no_no_context_sep, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("foo", "foo\nctx\nbar\nctx\nfoo\nctx");
+    cmd.arg("-I").arg("-A1").arg("--context-separator").arg("AAA").arg("foo");
+    eqnice!("foo\nctx\nAAA\nfoo\nctx\n", cmd.stdout());
+});


### PR DESCRIPTION
 `--context-separator=""` still adds a new line separator, and changing
 that would be a breaking change.

 This new option has clear intent, and preserves backward compatibility.