### PR TITLE
ignore/types: Add slim, slime, and skim template filetypes

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -271,6 +271,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
         // Extensions
         "*.bash", "*.csh", "*.ksh", "*.sh", "*.tcsh", "*.zsh",
     ]),
+    ("slim", &["*.skim", "*.slim", "*.slime"]),
     ("smarty", &["*.tpl"]),
     ("sml", &["*.sml", "*.sig"]),
     ("soy", &["*.soy"]),


### PR DESCRIPTION
[Slim](http://slim-lang.com/) is a popular templating language for ruby, and [Slime](https://github.com/slime-lang/slime) is its elixir counterpart. [Skim](https://github.com/appjudo/skim) is "rails javascript" variant of it.