### PR TITLE
Put ignore's parallel walk support behind a feature gate

### DIFF
--- a/ignore/Cargo.toml
+++ b/ignore/Cargo.toml
@@ -18,13 +18,13 @@ name = "ignore"
 bench = false
 
 [dependencies]
-crossbeam-channel = "0.3.6"
+crossbeam-channel = { version = "0.3.6", optional = true }
 globset = { version = "0.4.3", path = "../globset" }
 lazy_static = "1.1"
 log = "0.4.5"
 memchr = "2.1"
 regex = "1.1"
-same-file = "1.0.4"
+same-file = { version = "1.0.4" }
 thread_local = "0.3.6"
 walkdir = "2.2.7"
 
@@ -32,4 +32,10 @@ walkdir = "2.2.7"
 version = "0.1.2"
 
 [features]
+default = ["parallel"]
+parallel = ["crossbeam-channel"]
 simd-accel = ["globset/simd-accel"]
+
+[[example]]
+name = "walk"
+required-features = ["parallel"]

--- a/ignore/src/dir.rs
+++ b/ignore/src/dir.rs
@@ -129,6 +129,7 @@ struct IgnoreInner {
 
 impl Ignore {
     /// Return the directory path of this matcher.
+    #[cfg(feature = "parallel")]
     pub fn path(&self) -> &Path {
         &self.0.dir
     }
@@ -139,6 +140,7 @@ impl Ignore {
     }
 
     /// Returns true if this matcher was added via the `add_parents` method.
+    #[cfg(feature = "parallel")]
     pub fn is_absolute_parent(&self) -> bool {
         self.0.is_absolute_parent
     }

--- a/ignore/src/lib.rs
+++ b/ignore/src/lib.rs
@@ -46,6 +46,7 @@ See the documentation for `WalkBuilder` for many other options.
 
 #![deny(missing_docs)]
 
+#[cfg(feature = "parallel")]
 extern crate crossbeam_channel as channel;
 extern crate globset;
 #[macro_use]
@@ -65,7 +66,10 @@ use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 
-pub use walk::{DirEntry, Walk, WalkBuilder, WalkParallel, WalkState};
+pub use walk::{DirEntry, Walk, WalkBuilder, WalkState};
+
+#[cfg(feature = "parallel")]
+pub use walk::WalkParallel;
 
 mod dir;
 pub mod gitignore;
@@ -218,6 +222,7 @@ impl Error {
     }
 
     /// Turn an error into a tagged error with the given depth.
+    #[cfg(feature = "parallel")]
     fn with_depth(self, depth: usize) -> Error {
         Error::WithDepth {
             depth: depth,


### PR DESCRIPTION
We would like to use the ignore crate in [mozjs_sys](https://github.com/servo/mozjs) to tell cargo to rebuild
SpiderMonkey on filesystem changes in its own sources, but we don't
want to bring crossbeam-channel and whatnot in the build for such a trivial
operation.