### PR TITLE
Walkbuilder add ignore root

### DIFF
--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -1920,6 +1920,22 @@ mod tests {
     }
 
     #[test]
+    fn explicit_ignore_absolute_path() {
+        let td = tmpdir();
+        let igpath = td.path().join(".not-an-ignore");
+        mkdirp(td.path().join("a"));
+        wfile(&igpath, "/a");
+        wfile(td.path().join("foo"), "");
+        wfile(td.path().join("a/foo"), "");
+        wfile(td.path().join("bar"), "");
+        wfile(td.path().join("a/bar"), "");
+
+        let mut builder = WalkBuilder::new(td.path());
+        assert!(builder.add_ignore(&igpath).is_none());
+        assert_paths(td.path(), &builder, &["foo", "bar"]);
+    }
+
+    #[test]
     fn gitignore_parent() {
         let td = tmpdir();
         mkdirp(td.path().join(".git"));


### PR DESCRIPTION
See #1394 for full description.

> When building an instance of Walk using ignore::WalkBuilder, the patterns in files added by .add_ignore() are matched against the current working directory of the process, instead of the root of the tree being Walked.

This PR changes the behaviour or `WalkBuilder.add_ignore()`. **This is a breaking change.** Absolute file paths are now resolved based on the directory the `WalkBuilder` was initialised with.

Example directory structure:
```log
// /home
//   /subdir
//     - ignorefile
//     - README.md
```
Contents of `/home/subdir/ignorefile`:
```log
/README.md
```

The below code will now always ignore `/home/subdir/README.md` rather than `./README.md` of wherever the executing process is.

```rust
// psuedococde
let mut builder = WalkBuilder::new("/home/subdir");
builder.add_ignore("/home/subdir/ignorefile);
```