### PR TITLE
args: Do not attempt to build glob options when not specified.

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1267,6 +1267,13 @@ impl ArgMatches {
 
     /// Builds the set of glob overrides from the command line flags.
     fn overrides(&self) -> Result<Override> {
+        if !(self.is_present("glob-case-insensitive")
+             || self.is_present("glob")
+             || self.is_present("iglob"))
+        {
+            return Ok(Override::empty());
+        }
+
         let mut builder = OverrideBuilder::new(env::current_dir()?);
         // Make all globs case insensitive with --glob-case-insensitive.
         if self.is_present("glob-case-insensitive") {
@@ -1479,6 +1486,10 @@ impl ArgMatches {
     /// flag. If no --pre-globs are available, then this always returns an
     /// empty set of globs.
     fn preprocessor_globs(&self) -> Result<Override> {
+        if !self.is_present("pre-glob") {
+            return Ok(Override::empty());
+        }
+
         let mut builder = OverrideBuilder::new(env::current_dir()?);
         for glob in self.values_of_lossy_vec("pre-glob") {
             builder.add(&glob)?;


### PR DESCRIPTION
Closes #1291 

This is a first shot at addressing #1291, though I think some additional input is needed.

After reviewing and manually testing, I found that the source of the errors being raised was due to unconditionally building an `OverrideBuilder` from the globbing options. As this relies on the current working directory, it understandably fails when the cwd does not exist.

The immediate error can be suppressed by checking that the globbing options are actually required before attempting to handle them. This will still raise the same error when any of these options are present without an existing cwd, though perhaps a clearer error message could also be emitted as part of this change in that case.

On the testing front, I wasn't able to suitably recreate the original issue in a regression test. In my experiments, I tried to set the `current_dir` of the `TestCommand` to something non-existent before running, but this seemed to result in a panic before actually entering any ripgrep code when we go to execute the command.

Manual testing showed that we were able to execute non-globbing ripgrep commands without failure from a non-existent cwd with this change applied.