### PR TITLE
Add --include-zero option

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -281,6 +281,7 @@ _rg() {
     '--dfa-size-limit=[specify upper size limit of generated DFA]:DFA size (bytes)'
     "(1 stats)--files[show each file that would be searched (but don't search)]"
     '*--ignore-file=[specify additional ignore file]:ignore file:_files'
+    '--include-zero[include files with zero matches in summary]'
     '(-v --invert-match)'{-v,--invert-match}'[invert matching]'
     '(-M --max-columns)'{-M+,--max-columns=}'[specify max length of lines to print]:number of bytes'
     '(-m --max-count)'{-m+,--max-count=}'[specify max number of matches per file]:number of matches'

--- a/grep-printer/src/summary.rs
+++ b/grep-printer/src/summary.rs
@@ -25,7 +25,7 @@ struct Config {
     stats: bool,
     path: bool,
     max_matches: Option<u64>,
-    exclude_zero: bool,
+    include_zero: bool,
     separator_field: Arc<Vec<u8>>,
     separator_path: Option<u8>,
     path_terminator: Option<u8>,
@@ -39,7 +39,7 @@ impl Default for Config {
             stats: false,
             path: true,
             max_matches: None,
-            exclude_zero: true,
+            include_zero: false,
             separator_field: Arc::new(b":".to_vec()),
             separator_path: None,
             path_terminator: None,
@@ -261,13 +261,13 @@ impl SummaryBuilder {
         self
     }
 
-    /// Exclude count-related summary results with no matches.
+    /// Include count-related summary results with no matches.
     ///
     /// When enabled and the mode is either `Count` or `CountMatches`, then
-    /// results are not printed if no matches were found. Otherwise, every
-    /// search prints a result with a possibly `0` number of matches.
-    pub fn exclude_zero(&mut self, yes: bool) -> &mut SummaryBuilder {
-        self.config.exclude_zero = yes;
+    /// results are printed even if no matches were found. Otherwise, every
+    /// search only prints a result if there were matches.
+    pub fn include_zero(&mut self, yes: bool) -> &mut SummaryBuilder {
+        self.config.include_zero = yes;
         self
     }
 
@@ -666,7 +666,7 @@ impl<'p, 's, M: Matcher, W: WriteColor> Sink for SummarySink<'p, 's, M, W> {
         }
 
         let show_count =
-            !self.summary.config.exclude_zero
+            self.summary.config.include_zero
             || self.match_count > 0;
         match self.summary.config.kind {
             SummaryKind::Count => {
@@ -820,7 +820,7 @@ and exhibited clearly, with a label attached.
         ).unwrap();
         let mut printer = SummaryBuilder::new()
             .kind(SummaryKind::Count)
-            .exclude_zero(false)
+            .include_zero(true)
             .build_no_color(vec![]);
         SearcherBuilder::new()
             .build()
@@ -842,7 +842,7 @@ and exhibited clearly, with a label attached.
         ).unwrap();
         let mut printer = SummaryBuilder::new()
             .kind(SummaryKind::Count)
-            .exclude_zero(true)
+            .include_zero(false)
             .build_no_color(vec![]);
         SearcherBuilder::new()
             .build()

--- a/src/app.rs
+++ b/src/app.rs
@@ -578,6 +578,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_ignore_case(&mut args);
     flag_ignore_file(&mut args);
     flag_ignore_file_case_insensitive(&mut args);
+    flag_include_zero(&mut args);
     flag_invert_match(&mut args);
     flag_json(&mut args);
     flag_line_buffered(&mut args);
@@ -1355,6 +1356,17 @@ This flag can be disabled with the --no-ignore-file-case-insensitive flag.
     let arg = RGArg::switch("no-ignore-file-case-insensitive")
         .hidden()
         .overrides("ignore-file-case-insensitive");
+    args.push(arg);
+}
+
+fn flag_include_zero(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Include files with zero matches in summary";
+    const LONG: &str = long!("\
+When used with --count or --count-matches, print the number of matches for
+each file even if there were zero matches. This is disabled by default but can
+be enabled to make ripgrep behave more like grep.
+");
+    let arg = RGArg::switch("include-zero").help(SHORT).long_help(LONG);
     args.push(arg);
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -812,6 +812,7 @@ impl ArgMatches {
             .stats(self.stats())
             .path(self.with_filename(paths))
             .max_matches(self.max_count()?)
+            .include_zero(self.is_present("include-zero"))
             .separator_field(b":".to_vec())
             .separator_path(self.path_separator()?)
             .path_terminator(self.path_terminator());

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -392,6 +392,18 @@ rgtest!(count_matches_via_only, |dir: Dir, mut cmd: TestCommand| {
     eqnice!(expected, cmd.stdout());
 });
 
+rgtest!(include_zero, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("sherlock", SHERLOCK);
+    cmd.arg("--count").arg("--include-zero").arg("string_that_doesnt_appear");
+    cmd.assert_err();
+
+    let output = cmd.cmd().output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let expected = "sherlock:0\n";
+
+    eqnice!(expected, stdout);
+});
+
 rgtest!(files_with_matches, |dir: Dir, mut cmd: TestCommand| {
     dir.create("sherlock", SHERLOCK);
     cmd.arg("--files-with-matches").arg("Sherlock");


### PR DESCRIPTION
This PR addresses the suggestion in https://github.com/BurntSushi/ripgrep/issues/1370.

If `--count` or `--count-matches` is enabled, ripgrep currently only reports the number of matches if it's non-zero. [This is desired behavior](https://github.com/BurntSushi/ripgrep/issues/1317#issuecomment-507711847) because otherwise it can generate a lot of noise but sometimes users may want to print zeroes anyway. There's actually already a setting for outputting a zero if there were no matches but there's no way of turning it on from the command line interface. This PR adds the `--include-zero` option to fix that.