### PR TITLE
[RFC] ripgrep: expose custom ignore files via --ignore-file-name

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -281,6 +281,7 @@ _rg() {
     '--dfa-size-limit=[specify upper size limit of generated DFA]:DFA size (bytes)'
     "(1 stats)--files[show each file that would be searched (but don't search)]"
     '*--ignore-file=[specify additional ignore file]:ignore file:_files'
+    '*--ignore-file-name=[specify custom ignore file]:ignore file name:_files'
     '(-v --invert-match)'{-v,--invert-match}'[invert matching]'
     '(-M --max-columns)'{-M+,--max-columns=}'[specify max length of lines to print]:number of bytes'
     '(-m --max-count)'{-m+,--max-count=}'[specify max number of matches per file]:number of matches'

--- a/src/app.rs
+++ b/src/app.rs
@@ -577,6 +577,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_iglob(&mut args);
     flag_ignore_case(&mut args);
     flag_ignore_file(&mut args);
+    flag_ignore_file_name(&mut args);
     flag_ignore_file_case_insensitive(&mut args);
     flag_invert_match(&mut args);
     flag_json(&mut args);
@@ -1332,6 +1333,24 @@ If you are looking for a way to include or exclude files and directories
 directly on the command line, then used -g instead.
 ");
     let arg = RGArg::flag("ignore-file", "PATH")
+        .help(SHORT).long_help(LONG)
+        .multiple()
+        .allow_leading_hyphen();
+    args.push(arg);
+}
+
+fn flag_ignore_file_name(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Specify custom ignore file name";
+    const LONG: &str = long!("\
+Specifies the name of a custom .gitignore file. All files of this name will
+be interpretted as .ignore files, regardless of whether or not it is invoked
+in a proper git repository.
+
+As a custom ignore file, these rules take precedent over other ignore files
+(i.e. .ignore or .gitignore), and should the flag be given multiple times,
+the order they are specified will indicate precedence.
+");
+    let arg = RGArg::flag("ignore-file-name", "NAME")
         .help(SHORT).long_help(LONG)
         .multiple()
         .allow_leading_hyphen();

--- a/src/args.rs
+++ b/src/args.rs
@@ -882,9 +882,16 @@ impl ArgMatches {
             .git_ignore(!self.no_ignore_vcs())
             .git_exclude(!self.no_ignore_vcs())
             .ignore_case_insensitive(self.ignore_file_case_insensitive());
+
         if !self.no_ignore() {
             builder.add_custom_ignore_filename(".rgignore");
         }
+        if let Some(names) = self.values_of_os("ignore-file-name") {
+            for n in names {
+                builder.add_custom_ignore_filename(n);
+            }
+        }
+
         let sortby = self.sort_by()?;
         sortby.check()?;
         sortby.configure_walk_builder(&mut builder);


### PR DESCRIPTION
The ignore crate has the concept of "custom ignore" files. These files
take precedence over all others and can be used to declare arbitrary
file names as files which should be parsed for ignore patterns.

This commit adds the `--ignore-file-name` switch to `ripgrep`, exposing this
functionality to the user. For instance, if a user wanted to put their
ignores in many files called `.my_ignore` they could:

    rg --ignore-file-name .my_ignore

This can also be used as a hack to honor `.gitignore` files outside .git
repositories (#1414), which can be useful if a git repo has been copied
somewhere without the .git directory (i.e. downloaded as a zip from
GitHub) or for SCM systems like Perforce which allow `.gitignore` files
but are not valid git repositories. Note, however, that this tactic
gives `.gitignore` precedence over `.ignore` and `.rgignore`, so consider
using multiple flags:

    rg --ignore-file-name .ignore --ignore-file-name .gitignore

-------

Aside: this is discussed in #1414 .

@BurntSushi : I have another branch on my fork, [ignore_outside](https://github.com/akarle/ripgrep/commit/efbed3298e9a5c2383c91e084012e0cbbda9e2ff), that implements the other possible way we discussed of solving this (via a `--force-gitignore` flag, which I called `--ignore-outside-git`, but am happy to change to whatever we find appropriate).

I also came up with a **third** solution that would work for our use-case: creating a `--alt-git-root-file` switch which specifies a token that is determined to indicate the root of a git repo. This is the most intrusive implementation though (getting into the guts of the `ignore` crate), and I found my knowledge of asynchronous rust didn't cut it :)

I'm proposing we merge the `--ignore-file-name` switch, even though it is the most hacky solution to #1414 , because it is the least change to the code, and could have other benefits / be considered a feature. However, I'm happy to go with either the `--ignore-outside-git` or `--alt-git-repo-files` solutions if you deem them more appropriate for the project.

Rust is not my strongest language, so I appreciate any and all pointers / tips / corrections!

Thanks for your time and help!
Alex