### PR TITLE
ripgrep: add --no-ignore-exclude flag

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -128,6 +128,10 @@ _rg() {
     '--ignore-file-case-insensitive[process ignore files case insensitively]'
     $no'--no-ignore-file-case-insensitive[process ignore files case sensitively]'
 
+    + '(ignore-exclude)' # Local exclude (ignore)-file options
+    "--no-ignore-exclude[don't respect local exclude (ignore) files]"
+    $no'--ignore-exclude[respect local exclude (ignore) files]'
+
     + '(ignore-global)' # Global ignore-file options
     "--no-ignore-global[don't respect global ignore files]"
     $no'--ignore-global[respect global ignore files]'

--- a/doc/rg.1.txt.tpl
+++ b/doc/rg.1.txt.tpl
@@ -28,8 +28,8 @@ Synopsis
 DESCRIPTION
 -----------
 ripgrep (rg) recursively searches your current directory for a regex pattern.
-By default, ripgrep will respect your .gitignore and automatically skip hidden
-files/directories and binary files.
+By default, ripgrep will respect your .gitignore (and .git/info/exclude)
+and automatically skip hidden files/directories and binary files.
 
 ripgrep's default regex engine uses finite automata and guarantees linear
 time searching. Because of this, features like backreferences and arbitrary

--- a/src/app.rs
+++ b/src/app.rs
@@ -594,6 +594,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_no_config(&mut args);
     flag_no_ignore(&mut args);
     flag_no_ignore_dot(&mut args);
+    flag_no_ignore_exclude(&mut args);
     flag_no_ignore_global(&mut args);
     flag_no_ignore_messages(&mut args);
     flag_no_ignore_parent(&mut args);
@@ -1741,6 +1742,26 @@ This flag can be disabled with the --ignore-dot flag.
         .overrides("no-ignore-dot");
     args.push(arg);
 }
+
+fn flag_no_ignore_exclude(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Don't respect local exclusion files.";
+    const LONG: &str = long!("\
+Don't respect ignore files that are manually configured for the repository
+such as git's `.git/info/exclude`).
+
+This flag can be disabled with the --ignore-exclude flag.
+");
+    let arg = RGArg::switch("no-ignore-exclude")
+        .help(SHORT).long_help(LONG)
+        .overrides("ignore-exclude");
+    args.push(arg);
+
+    let arg = RGArg::switch("ignore-exclude")
+        .hidden()
+        .overrides("no-ignore-exclude");
+    args.push(arg);
+}
+
 
 fn flag_no_ignore_global(args: &mut Vec<RGArg>) {
     const SHORT: &str = "Don't respect global ignore files.";

--- a/src/args.rs
+++ b/src/args.rs
@@ -880,7 +880,7 @@ impl ArgMatches {
             .ignore(!self.no_ignore_dot())
             .git_global(!self.no_ignore_vcs() && !self.no_ignore_global())
             .git_ignore(!self.no_ignore_vcs())
-            .git_exclude(!self.no_ignore_vcs())
+            .git_exclude(!self.no_ignore_vcs() && !self.no_ignore_exclude())
             .ignore_case_insensitive(self.ignore_file_case_insensitive());
         if !self.no_ignore() {
             builder.add_custom_ignore_filename(".rgignore");
@@ -1224,6 +1224,11 @@ impl ArgMatches {
     /// Returns true if .ignore files should be ignored.
     fn no_ignore_dot(&self) -> bool {
         self.is_present("no-ignore-dot") || self.no_ignore()
+    }
+
+    /// Returns true if local exclude (ignore) files should be ignored.
+    fn no_ignore_exclude(&self) -> bool {
+        self.is_present("no-ignore-exclude") || self.no_ignore()
     }
 
     /// Returns true if global ignore files should be ignored.


### PR DESCRIPTION
This is PR arises from a fundamental misunderstanding on my part of how exclude files are handled by ripgrep and ag (silversearcher) (#1417).

1. ripgrep ignores .gitignore and goes further to ignore configured global ignores (toggleable) and local .git/info/exclude (not toggleable).
2. ag ignores .gitignore and ostensibly .git/info/exclude. I say ostensibly because I came to the incorrect conclusion in #1417  that it actually ignores excludes but a cursory reading of source suggests otherwise.

Local excludes are setup because these are files you don't want to see when working in a VCS. So it does make sense to retain default behaviour to ignore them. It is imperative the user however knows this which is explained in the guide but not manpage (this is added as part of this patch).

However when the VCS is shared among others -- local excludes are not. Being able to turn it off allows to get a more consistent view when shared.

The functionality of this patch has been verified manually. It should work because it is essentially a copy of --no-ignore-global behaviour.

I haven't added tests - I didn't see any for --[no-]ignore-global otherwise I would've followed that.

Manual verification:

```
# we don't want doc/rg.1.txt.tpl to match
a:ripgrep $ cat .git/info/exclude
doc/*


# ag respects exclude and doesnt match doc/rg.1.txt.tp
a:ripgrep $ ag -l info.exclude
CHANGELOG.md
ignore/src/dir.rs
ignore/src/walk.rs
GUIDE.md
src/app.rs

# rg respects exclude and doesnt match doc/rg.1.txt.tp
a:ripgrep $ target/release/rg -l info.exclude
CHANGELOG.md
GUIDE.md
src/app.rs
ignore/src/dir.rs
ignore/src/walk.rs

a:ripgrep $ cd doc

# ag does not respect exclude (inconsistent behaviour)
a:doc $ ag -l info.exclude
rg.1.txt.tpl

# rg continues to respect exclude
a:doc $ ../target/release/rg -l info.exclude

# rg now also respects --no-ignore-exclude
a:doc $ ../target/release/rg --no-ignore-exclude -l info.exclude
rg.1.txt.tpl
```