### PR TITLE
Add ".xhtml" to xml file type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Bug fixes:
 * [BUG #1335](https://github.com/BurntSushi/ripgrep/issues/1335):
   Fixes a performance bug when searching plain text files with very long lines.
 
+Various:
+
+* Add `.xhtml` to xml file type
 
 11.0.2 (2019-08-01)
 ===================

--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -306,7 +306,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("webidl", &["*.idl", "*.webidl", "*.widl"]),
     ("xml", &[
         "*.xml", "*.xml.dist", "*.dtd", "*.xsl", "*.xslt", "*.xsd", "*.xjb",
-        "*.rng", "*.sch",
+        "*.rng", "*.sch", "*.xhtml",
     ]),
     ("xz", &["*.xz", "*.txz"]),
     ("yacc", &["*.y"]),


### PR DESCRIPTION
Wasn't sure if this belonged rather in html or xml, but at least according to https://html.spec.whatwg.org/multipage/iana.html#application/xhtml+xml it makes sense to place it in xml.