### PR TITLE
Documented CentOS 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ If you're an **openSUSE Tumbleweed** user, you can install ripgrep from the
 $ sudo zypper install ripgrep
 ```
 
-If you're a **RHEL/CentOS 7** user, you can install ripgrep from
+If you're a **RHEL/CentOS 7/8** user, you can install ripgrep from
 [copr](https://copr.fedorainfracloud.org/coprs/carlwgeorge/ripgrep/):
 
 ```


### PR DESCRIPTION
ripgrep install instructions are valid even for the 7  version. The tool works without problems on these too.