### PR TITLE
readme: remove outdated SIMD info

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,8 @@ prefer MSVC over GNU, but you'll need to have the [Microsoft VC++ 2015
 redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145)
 installed.
 
-If you're a **macOS Homebrew** or a **Linuxbrew** user,
-then you can install ripgrep either
-from homebrew-core, (compiled with rust stable, no SIMD):
+If you're a **macOS Homebrew** or a **Linuxbrew** user, then you can install
+ripgrep from homebrew-core:
 
 ```
 $ brew install ripgrep


### PR DESCRIPTION
Looks like the [upstream brew Formula][0] now has SIMD support, so
remove the extraneous info now that the custom tap [is no longer needed][1].

[0]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/ripgrep.rb
[1]: https://github.com/BurntSushi/ripgrep/commit/f3083e4574ad20881de66fdeb66d671f1cbdfda4