### PR TITLE
feat(ignore): Allow parallel-walker to borrow data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ name = "ignore"
 version = "0.4.10"
 dependencies = [
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.4",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ignore/Cargo.toml
+++ b/ignore/Cargo.toml
@@ -19,6 +19,7 @@ bench = false
 
 [dependencies]
 crossbeam-channel = "0.3.6"
+crossbeam-utils = "0.6.3"
 globset = { version = "0.4.3", path = "../globset" }
 lazy_static = "1.1"
 log = "0.4.5"

--- a/ignore/src/walk.rs
+++ b/ignore/src/walk.rs
@@ -1068,6 +1068,8 @@ impl WalkState {
     }
 }
 
+type FnVisitor<'s> = Box<dyn FnMut(Result<DirEntry, Error>) -> WalkState + Send + 's>;
+
 /// WalkParallel is a parallel recursive directory iterator over files paths
 /// in one or more directories.
 ///
@@ -1091,11 +1093,10 @@ impl WalkParallel {
     /// Execute the parallel recursive directory iterator. `mkf` is called
     /// for each thread used for iteration. The function produced by `mkf`
     /// is then in turn called for each visited file path.
-    pub fn run<F>(self, mut mkf: F)
+    pub fn run<'s, F>(mut self, mut mkf: F)
     where
-        F: FnMut() -> Box<dyn FnMut(Result<DirEntry, Error>) -> WalkState + Send + 'static>,
+        F: FnMut() -> FnVisitor<'s>,
     {
-        let mut f = mkf();
         let threads = self.threads();
         // TODO: Figure out how to use a bounded channel here. With an
         // unbounded channel, the workers can run away and fill up memory
@@ -1106,21 +1107,35 @@ impl WalkParallel {
         // this. The best case scenario would be finding a way to use rayon
         // to do this.
         let (tx, rx) = channel::unbounded();
-        let mut any_work = false;
-        // Send the initial set of root paths to the pool of workers.
-        // Note that we only send directories. For files, we send to them the
-        // callback directly.
-        for path in self.paths {
-            let (dent, root_device) = if path == Path::new("-") {
-                (DirEntry::new_stdin(), None)
-            } else {
-                let root_device = if !self.same_file_system {
-                    None
+        {
+            let mut f = mkf();
+            let mut any_work = false;
+            let mut paths = Vec::new().into_iter();
+            std::mem::swap(&mut paths, &mut self.paths);
+            // Send the initial set of root paths to the pool of workers.
+            // Note that we only send directories. For files, we send to them the
+            // callback directly.
+            for path in paths {
+                let (dent, root_device) = if path == Path::new("-") {
+                    (DirEntry::new_stdin(), None)
                 } else {
-                    match device_num(&path) {
-                        Ok(root_device) => Some(root_device),
+                    let root_device = if !self.same_file_system {
+                        None
+                    } else {
+                        match device_num(&path) {
+                            Ok(root_device) => Some(root_device),
+                            Err(err) => {
+                                let err = Error::Io(err).with_path(path);
+                                if f(Err(err)).is_quit() {
+                                    return;
+                                }
+                                continue;
+                            }
+                        }
+                    };
+                    match DirEntryRaw::from_path(0, path, false) {
+                        Ok(dent) => (DirEntry::new_raw(dent, None), root_device),
                         Err(err) => {
-                            let err = Error::Io(err).with_path(path);
                             if f(Err(err)).is_quit() {
                                 return;
                             }
@@ -1128,56 +1143,50 @@ impl WalkParallel {
                         }
                     }
                 };
-                match DirEntryRaw::from_path(0, path, false) {
-                    Ok(dent) => (DirEntry::new_raw(dent, None), root_device),
-                    Err(err) => {
-                        if f(Err(err)).is_quit() {
-                            return;
-                        }
-                        continue;
-                    }
-                }
-            };
-            tx.send(Message::Work(Work {
-                dent: dent,
-                ignore: self.ig_root.clone(),
-                root_device: root_device,
-            }))
-            .unwrap();
-            any_work = true;
-        }
-        // ... but there's no need to start workers if we don't need them.
-        if !any_work {
-            return;
+                tx.send(Message::Work(Work {
+                    dent: dent,
+                    ignore: self.ig_root.clone(),
+                    root_device: root_device,
+                }))
+                .unwrap();
+                any_work = true;
+            }
+            // ... but there's no need to start workers if we don't need them.
+            if !any_work {
+                return;
+            }
         }
         // Create the workers and then wait for them to finish.
         let num_waiting = Arc::new(AtomicUsize::new(0));
         let num_quitting = Arc::new(AtomicUsize::new(0));
         let quit_now = Arc::new(AtomicBool::new(false));
-        let mut handles = vec![];
-        for _ in 0..threads {
-            let worker = Worker {
-                f: mkf(),
-                tx: tx.clone(),
-                rx: rx.clone(),
-                quit_now: quit_now.clone(),
-                is_waiting: false,
-                is_quitting: false,
-                num_waiting: num_waiting.clone(),
-                num_quitting: num_quitting.clone(),
-                threads: threads,
-                max_depth: self.max_depth,
-                max_filesize: self.max_filesize,
-                follow_links: self.follow_links,
-                skip: self.skip.clone(),
-            };
-            handles.push(thread::spawn(|| worker.run()));
-        }
-        drop(tx);
-        drop(rx);
-        for handle in handles {
-            handle.join().unwrap();
-        }
+        crossbeam_utils::thread::scope(|s| {
+            let mut handles = vec![];
+            for _ in 0..threads {
+                let worker = Worker {
+                    f: mkf(),
+                    tx: tx.clone(),
+                    rx: rx.clone(),
+                    quit_now: quit_now.clone(),
+                    is_waiting: false,
+                    is_quitting: false,
+                    num_waiting: num_waiting.clone(),
+                    num_quitting: num_quitting.clone(),
+                    threads: threads,
+                    max_depth: self.max_depth,
+                    max_filesize: self.max_filesize,
+                    follow_links: self.follow_links,
+                    skip: self.skip.clone(),
+                };
+                handles.push(s.spawn(|_| worker.run()));
+            }
+            drop(tx);
+            drop(rx);
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        })
+        .unwrap(); // Pass along panics from threads
     }
 
     fn threads(&self) -> usize {
@@ -1267,9 +1276,9 @@ impl Work {
 /// ignore matchers, producing new work and invoking the caller's callback.
 ///
 /// Note that a worker is *both* a producer and a consumer.
-struct Worker {
+struct Worker<'s> {
     /// The caller's callback.
-    f: Box<dyn FnMut(Result<DirEntry, Error>) -> WalkState + Send + 'static>,
+    f: FnVisitor<'s>,
     /// The push side of our mpmc queue.
     tx: channel::Sender<Message>,
     /// The receive side of our mpmc queue.
@@ -1303,7 +1312,7 @@ struct Worker {
     skip: Option<Arc<Handle>>,
 }
 
-impl Worker {
+impl<'s> Worker<'s> {
     /// Runs this worker until there is no more work left to do.
     ///
     /// The worker will call the caller's callback for all entries that aren't

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,16 +55,15 @@ fn main() {
 fn try_main(args: Args) -> Result<()> {
     use args::Command::*;
 
-    let matched =
-        match args.command()? {
-            Search => search(&args),
-            SearchParallel => search_parallel(&args),
-            SearchNever => Ok(false),
-            Files => files(&args),
-            FilesParallel => files_parallel(&args),
-            Types => types(&args),
-            PCRE2Version => pcre2_version(&args),
-        }?;
+    let matched = match args.command()? {
+        Search => search(&args),
+        SearchParallel => search_parallel(&args),
+        SearchNever => Ok(false),
+        Files => files(&args),
+        FilesParallel => files_parallel(&args),
+        Types => types(&args),
+        PCRE2Version => pcre2_version(&args),
+    }?;
     if matched && (args.quiet() || !messages::errored()) {
         process::exit(0)
     } else if messages::errored() {
@@ -126,24 +125,21 @@ fn search_parallel(args: &Args) -> Result<bool> {
 
     let quit_after_match = args.quit_after_match()?;
     let started_at = Instant::now();
-    let subject_builder = Arc::new(args.subject_builder());
-    let bufwtr = Arc::new(args.buffer_writer()?);
-    let stats = Arc::new(args.stats()?.map(Mutex::new));
-    let matched = Arc::new(AtomicBool::new(false));
+    let subject_builder = args.subject_builder();
+    let bufwtr = args.buffer_writer()?;
+    let stats = args.stats()?.map(Mutex::new);
+    let matched = AtomicBool::new(false);
     let mut searcher_err = None;
     args.walker_parallel()?.run(|| {
-        let args = args.clone();
-        let bufwtr = Arc::clone(&bufwtr);
-        let stats = Arc::clone(&stats);
-        let matched = Arc::clone(&matched);
-        let subject_builder = Arc::clone(&subject_builder);
+        let bufwtr = &bufwtr;
+        let stats = &stats;
+        let matched = &matched;
+        let subject_builder = &subject_builder;
         let mut searcher = match args.search_worker(bufwtr.buffer()) {
             Ok(searcher) => searcher,
             Err(err) => {
                 searcher_err = Some(err);
-                return Box::new(move |_| {
-                    WalkState::Quit
-                });
+                return Box::new(move |_| WalkState::Quit);
             }
         };
 
@@ -185,7 +181,7 @@ fn search_parallel(args: &Args) -> Result<bool> {
     if let Some(err) = searcher_err.take() {
         return Err(err);
     }
-    if let Some(ref locked_stats) = *stats {
+    if let Some(ref locked_stats) = stats {
         let elapsed = Instant::now().duration_since(started_at);
         let stats = locked_stats.lock().unwrap();
         let mut searcher = args.search_worker(args.stdout())?;
@@ -235,9 +231,9 @@ fn files_parallel(args: &Args) -> Result<bool> {
     use std::thread;
 
     let quit_after_match = args.quit_after_match()?;
-    let subject_builder = Arc::new(args.subject_builder());
+    let subject_builder = args.subject_builder();
     let mut path_printer = args.path_printer(args.stdout())?;
-    let matched = Arc::new(AtomicBool::new(false));
+    let matched = AtomicBool::new(false);
     let (tx, rx) = mpsc::channel::<Subject>();
 
     let print_thread = thread::spawn(move || -> io::Result<()> {
@@ -247,8 +243,8 @@ fn files_parallel(args: &Args) -> Result<bool> {
         Ok(())
     });
     args.walker_parallel()?.run(|| {
-        let subject_builder = Arc::clone(&subject_builder);
-        let matched = Arc::clone(&matched);
+        let subject_builder = &subject_builder;
+        let matched = &matched;
         let tx = tx.clone();
 
         Box::new(move |result| {


### PR DESCRIPTION
This makes it so the caller can more easily refactor from
single-threaded to multi-threaded walking. If they want to support both,
this makes it easier to do so with a single initialization code-path.

In a separate commit, ripgrep is updated to use this. I assume the performance difference is negligible
but it cleans up the code and provides a test case for ignores changes. I kept it as a separate commit so we can more easily validate that compatibility was not broken.

Closes #1410