### PR TITLE
Improve help text for `--sort` and `--sortr` flags

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2281,16 +2281,15 @@ fn flag_sort(args: &mut Vec<RGArg>) {
 This flag enables sorting of results in ascending order. The possible values
 for this flag are:
 
-    path        Sort by file path.
-    modified    Sort by the last modified time on a file.
-    accessed    Sort by the last accessed time on a file.
-    created     Sort by the creation time on a file.
-    none        Do not sort results.
+    none        (Default) Do not sort results. Fastest. Can be multi-threaded.
+    path        Sort by file path. Always single-threaded.
+    modified    Sort by the last modified time on a file. Always single-threaded.
+    accessed    Sort by the last accessed time on a file. Always single-threaded.
+    created     Sort by the creation time on a file. Always single-threaded.
 
-If the sorting criteria isn't available on your system (for example, creation
-time is not available on ext4 file systems), then ripgrep will attempt to
-detect this and print an error without searching any results. Otherwise, the
-sort order is unspecified.
+If the chosen (manually or by-default) sorting criteria isn't available on your
+system (for example, creation time is not available on ext4 file systems), then
+ripgrep will attempt to detect this, print an error and exit without searching.
 
 To sort results in reverse or descending order, use the --sortr flag. Also,
 this flag overrides --sortr.
@@ -2314,16 +2313,15 @@ fn flag_sortr(args: &mut Vec<RGArg>) {
 This flag enables sorting of results in descending order. The possible values
 for this flag are:
 
-    path        Sort by file path.
-    modified    Sort by the last modified time on a file.
-    accessed    Sort by the last accessed time on a file.
-    created     Sort by the creation time on a file.
-    none        Do not sort results.
+    none        (Default) Do not sort results. Fastest. Can be multi-threaded.
+    path        Sort by file path. Always single-threaded.
+    modified    Sort by the last modified time on a file. Always single-threaded.
+    accessed    Sort by the last accessed time on a file. Always single-threaded.
+    created     Sort by the creation time on a file. Always single-threaded.
 
-If the sorting criteria isn't available on your system (for example, creation
-time is not available on ext4 file systems), then ripgrep will attempt to
-detect this and print an error without searching any results. Otherwise, the
-sort order is unspecified.
+If the chosen (manually or by-default) sorting criteria isn't available on your
+system (for example, creation time is not available on ext4 file systems), then
+ripgrep will attempt to detect this, print an error and exit without searching.
 
 To sort results in ascending order, use the --sort flag. Also, this flag
 overrides --sort.


### PR DESCRIPTION
I improved the help documentation in the following manner and for the 
following reasons:
1. It's only logical to put the default sub-option on the first possible 
line, as well as to separately mention that it is indeed the default 
sub-option.
2. Additional options for the flags should describe the main points of 
their purpose without requiring user to read the whole help entry. In my 
opinion, the information sub-options' influence on multi-threading and 
speed are important enough to warrant their inclusion in each 
sub-option's description line text.