### PR TITLE
Implement FromStr for Glob

### DIFF
--- a/globset/src/glob.rs
+++ b/globset/src/glob.rs
@@ -103,6 +103,14 @@ impl fmt::Display for Glob {
     }
 }
 
+impl str::FromStr for Glob {
+    type Err = Error;
+
+    fn from_str(glob: &str) -> Result<Self, Self::Err> {
+        Self::new(glob)
+    }
+}
+
 /// A matcher for a single pattern.
 #[derive(Clone, Debug)]
 pub struct GlobMatcher {


### PR DESCRIPTION
The `globset::Glob` type [`new`] function creates a new value with an `&str` parameter which returns an `Result<Glob, Error>` object. This is exactly what [`std::str::FromStr::from_str`][`std::str::FromStr`] defines. Libraries like [`clap`] use [`std::str::FromStr`] to create objects from provided commandline arguments. This change makes this library usable without a newtype wrapper.

[`std::str::FromStr`]: 	https://doc.rust-lang.org/std/str/trait.FromStr.html
[`clap`]:		https://docs.rs/clap/2.33.0/clap/macro.value_t.html
[`new`]:		https://docs.rs/globset/0.4.4/globset/struct.Glob.html#method.new