### PR TITLE
globset: Add GlobMatcher::glob

### DIFF
--- a/globset/src/glob.rs
+++ b/globset/src/glob.rs
@@ -122,6 +122,11 @@ impl GlobMatcher {
     pub fn is_match_candidate(&self, path: &Candidate) -> bool {
         self.re.is_match(&path.path)
     }
+
+    /// Returns the `Glob` used to compile this matcher.
+    pub fn glob(&self) -> &Glob {
+        &self.pat
+    }
 }
 
 /// A strategic matcher for a single pattern.


### PR DESCRIPTION
The `GlobMatcher` type holds onto the `Glob` object that was used to create it. This PR exposes a reference to it through a getter.

My main use is that I have a project that uses globset by wrapping the `GlobMatcher` type in a type that I can implement Serde's `Serialize` and `Deserialize` on. In order to get access to the original pattern, I [currently need to redundantly keep my own copy of the `Glob` struct](https://github.com/rojo-rbx/rojo/blob/c82bc8a3583a65279d7aa28cde4b53977cd78fc4/src/glob.rs) to get access to its string pattern.

This API would enable me to only need to keep around `GlobMatcher`.