### PR TITLE
ignore/types: fix postscript globs

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -231,7 +231,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("pdf", &["*.pdf"]),
     ("php", &["*.php", "*.php3", "*.php4", "*.php5", "*.phtml"]),
     ("pod", &["*.pod"]),
-    ("postscript", &[".eps", ".ps"]),
+    ("postscript", &["*.eps", "*.ps"]),
     ("protobuf", &["*.proto"]),
     ("ps", &["*.cdxml", "*.ps1", "*.ps1xml", "*.psd1", "*.psm1"]),
     ("puppet", &["*.erb", "*.pp", "*.rb"]),


### PR DESCRIPTION
I noticed the postscript globs were missing asterisks, so they were treated as literal filenames.