### PR TITLE
Add *.org_archive to org file type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -226,7 +226,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("objc", &["*.h", "*.m"]),
     ("objcpp", &["*.h", "*.mm"]),
     ("ocaml", &["*.ml", "*.mli", "*.mll", "*.mly"]),
-    ("org", &["*.org"]),
+    ("org", &["*.org", "*.org_archive"]),
     ("pascal", &["*.pas", "*.dpr", "*.lpr", "*.pp", "*.inc"]),
     ("perl", &["*.perl", "*.pl", "*.PL", "*.plh", "*.plx", "*.pm", "*.t"]),
     ("pdf", &["*.pdf"]),


### PR DESCRIPTION
`.org_archive` is the default extension for Org archive files, created when
entries from an Org-mode file are archived (see
<https://orgmode.org/org.html#Moving-subtrees>). These files are still in Org
mode format, so it's worth searching them at the same time as non-archive Org
mode files.