### PR TITLE
Add typoscript file type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -297,6 +297,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("txt", &["*.txt"]),
     ("toml", &["*.toml", "Cargo.lock"]),
     ("twig", &["*.twig"]),
+    ("typoscript", &["*.typoscript", "*.ts"]),
     ("vala", &["*.vala"]),
     ("vb", &["*.vb"]),
     ("verilog", &["*.v", "*.vh", "*.sv", "*.svh"]),


### PR DESCRIPTION
Add the file types for TypoScript - the configuration language of the
TYPO3 CMS.