### PR TITLE
globset: Implement serde::{Serialize, Deserialize} for Glob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,8 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -24,10 +24,13 @@ bstr = { version = "0.2.0", default-features = false, features = ["std"] }
 fnv = "1.0.6"
 log = "0.4.5"
 regex = "1.1.5"
+serde = { version = "1.0.104", optional = true }
 
 [dev-dependencies]
 glob = "0.3.0"
 lazy_static = "1"
+serde_json = "1.0.45"
 
 [features]
 simd-accel = []
+serde1 = ["serde"]

--- a/crates/globset/README.md
+++ b/crates/globset/README.md
@@ -29,6 +29,10 @@ and this to your crate root:
 extern crate globset;
 ```
 
+### Features
+
+* `serde1`: Enables implementing Serde traits on the `Glob` type.
+
 ### Example: one glob
 
 This example shows how to match a single glob against a single file path.

--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -110,6 +110,9 @@ extern crate fnv;
 extern crate log;
 extern crate regex;
 
+#[cfg(feature = "serde1")]
+extern crate serde;
+
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error as StdError;
@@ -128,6 +131,9 @@ use pathutil::{file_name, file_name_ext, normalize_path};
 
 mod glob;
 mod pathutil;
+
+#[cfg(feature = "serde1")]
+mod serde_impl;
 
 /// Represents an error that can occur when parsing a glob pattern.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/globset/src/serde_impl.rs
+++ b/crates/globset/src/serde_impl.rs
@@ -1,0 +1,38 @@
+use serde::de::Error;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use Glob;
+
+impl Serialize for Glob {
+    fn serialize<S: Serializer>(
+        &self,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.glob())
+    }
+}
+
+impl<'de> Deserialize<'de> for Glob {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, D::Error> {
+        let glob = <&str as Deserialize>::deserialize(deserializer)?;
+        Glob::new(glob).map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use Glob;
+
+    #[test]
+    fn glob_json_works() {
+        let test_glob = Glob::new("src/**/*.rs").unwrap();
+
+        let ser = serde_json::to_string(&test_glob).unwrap();
+        assert_eq!(ser, "\"src/**/*.rs\"");
+
+        let de: Glob = serde_json::from_str(&ser).unwrap();
+        assert_eq!(test_glob, de);
+    }
+}


### PR DESCRIPTION
Closes #1455.

This PR adds an optional dependency to serde, which implies a matching feature named `serde`. When enabled, `Serialize` and `Deserialize` are implemented for `Glob`, using its string form.

Implementing serde traits for `GlobSet` might also be a good idea, but looked like it might be a much more invasive change.

I used serde_json for the included test. There might be other edge cases that should be tested.