### PR TITLE
ignore/types: add K type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -85,6 +85,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("jsonl", &["*.jsonl"]),
     ("julia", &["*.jl"]),
     ("jupyter", &["*.ipynb", "*.jpynb"]),
+    ("k", &["*.k"]),
     ("kotlin", &["*.kt", "*.kts"]),
     ("less", &["*.less"]),
     ("license", &[


### PR DESCRIPTION
Adds support for files used by the [K executable semantic framework](http://www.kframework.org/index.php/Main_Page); code [here](https://github.com/kframework/k).