### PR TITLE
add engine option to easily switch between regexp engines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
 
     - name: Install packages (Ubuntu)
       if: matrix.os == 'ubuntu-18.04'
@@ -185,8 +183,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ increases the times to `2.640s` for ripgrep and `10.277s` for GNU grep.
   Among other things, this makes it possible to use look-around and
   backreferences in your patterns, which are not supported in ripgrep's default
   regex engine. PCRE2 support can be enabled with `-P/--pcre2` (use PCRE2
-  always) or `--auto-hybrid-regex` (use PCRE2 only if needed).
+  always) or `--auto-hybrid-regex` (use PCRE2 only if needed). An alternative
+  syntax is provided via the `--engine (default|pcre2|auto-hybrid)` option.
 * ripgrep supports searching files in text encodings other than UTF-8, such
   as UTF-16, latin-1, GBK, EUC-JP, Shift_JIS and more. (Some support for
   automatically detecting UTF-16 is provided. Other text encodings must be

--- a/complete/_rg
+++ b/complete/_rg
@@ -78,6 +78,13 @@ _rg() {
     {-E+,--encoding=}'[specify text encoding of files to search]: :_rg_encodings'
     $no'--no-encoding[use default text encoding]'
 
+    + '(engine)' # Engine choice options
+    '--engine=[select which regexp engine to use (overriden by pcre2 and hybrid options)]:when:((
+      default\:"use default engine"
+      pcre2\:"identical to --pcre2"
+      auto-hybrid\:"identical to --auto-hybrid-regex"
+    ))'
+
     + file # File-input options
     '(1)*'{-f+,--file=}'[specify file containing patterns to search for]: :_files'
 

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -508,6 +508,13 @@ impl RGArg {
         self
     }
 
+    /// Sets the default value of this argument when not specified at
+    /// runtime.
+    fn default_value(mut self, value: &'static str) -> RGArg {
+        self.claparg = self.claparg.default_value(value);
+        self
+    }
+
     /// Sets the default value of this argument if and only if the argument
     /// given is present.
     fn default_value_if(
@@ -566,6 +573,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_debug(&mut args);
     flag_dfa_size_limit(&mut args);
     flag_encoding(&mut args);
+    flag_engine(&mut args);
     flag_file(&mut args);
     flag_files(&mut args);
     flag_files_with_matches(&mut args);
@@ -1182,6 +1190,36 @@ This flag can be disabled with --no-encoding.
     args.push(arg);
 
     let arg = RGArg::switch("no-encoding").hidden().overrides("encoding");
+    args.push(arg);
+}
+
+fn flag_engine(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Specify which regexp engine to use: default|pcre2|auto-hybrid.";
+    const LONG: &str = long!(
+        "\
+Specify which regular expression engine to use. When you choose a
+regex engine, it applies that choice for every regex provided to ripgrep (e.g.,
+via multiple -e/--regexp or -f/--file flags).
+
+Accepted values are `default|pcre2|auto-hybrid`.
+
+The default value is default, which is the fastest and should be good for most
+use-cases. PCRE2 engine is generally useful when you want to use features such
+as look-around backreferences. auto-hybrid will dynamically choose between
+supported regex engines depending on the features used in a pattern.
+
+Please have a look at the custom flags '--pcre2' and '--auto-hybrid-regexp'
+which explain their respective meaning in more depth. Those flags override
+any value provided to the `engine` option.
+
+Using '--pcre2' or '--auto-hybrid-regexp' overrides the value of this flag.
+"
+    );
+    let arg = RGArg::flag("engine", "ENGINE")
+        .help(SHORT)
+        .long_help(LONG)
+        .possible_values(&["default", "pcre2", "auto-hybrid"])
+        .default_value("default");
     args.push(arg);
 }
 

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -1194,7 +1194,8 @@ This flag can be disabled with --no-encoding.
 }
 
 fn flag_engine(args: &mut Vec<RGArg>) {
-    const SHORT: &str = "Specify which regexp engine to use: default|pcre2|auto-hybrid.";
+    const SHORT: &str =
+        "Specify which regexp engine to use: default|pcre2|auto-hybrid.";
     const LONG: &str = long!(
         "\
 Specify which regular expression engine to use. When you choose a

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -1209,11 +1209,10 @@ use-cases. PCRE2 engine is generally useful when you want to use features such
 as look-around backreferences. auto-hybrid will dynamically choose between
 supported regex engines depending on the features used in a pattern.
 
-Please have a look at the custom flags '--pcre2' and '--auto-hybrid-regexp'
-which explain their respective meaning in more depth. Those flags override
-any value provided to the `engine` option.
+Please have a look at the custom flags '--pcre2' and '--auto-hybrid-regex'
+which explain their respective meaning in more depth.
 
-Using '--pcre2' or '--auto-hybrid-regexp' overrides the value of this flag.
+Using '--pcre2' or '--auto-hybrid-regex' overrides the value of this flag.
 "
     );
     let arg = RGArg::flag("engine", "ENGINE")

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -582,10 +582,12 @@ impl ArgMatches {
         } else if self.is_present("auto-hybrid-regex") {
             self.matcher_engine("auto-hybrid", patterns)
         } else {
-            let engine = self.value_of_lossy("engine")
-                             .ok_or(clap::Error::with_description("Please \
-                                     provide a valid value to the engine \
-                                     option.", clap::ErrorKind::InvalidValue))?;
+            let engine = self.value_of_lossy("engine").ok_or(
+                clap::Error::with_description(
+                    "Please provide a valid value to the engine option.",
+                    clap::ErrorKind::InvalidValue,
+                ),
+            )?;
             self.matcher_engine(engine.as_str(), patterns)
         }
     }
@@ -598,7 +600,7 @@ impl ArgMatches {
     fn matcher_engine(
         &self,
         engine: &str,
-        patterns: &[String]
+        patterns: &[String],
     ) -> Result<PatternMatcher> {
         match engine {
             "default" => {
@@ -609,23 +611,24 @@ impl ArgMatches {
                     }
                 };
                 Ok(PatternMatcher::RustRegex(matcher))
-            },
+            }
 
             #[cfg(feature = "pcre2")]
             "pcre2" => {
                 let matcher = self.matcher_pcre2(patterns)?;
                 Ok(PatternMatcher::PCRE2(matcher))
-            },
+            }
 
             #[cfg(not(feature = "pcre2"))]
-            "pcre2" => {
-                Err(From::from("PCRE2 is not available in \
-                                this build of ripgrep"))
-            },
+            "pcre2" => Err(From::from(
+                "PCRE2 is not available in this build of ripgrep",
+            )),
 
             "auto-hybrid" => {
                 let rust_err = match self.matcher_rust(patterns) {
-                    Ok(matcher) => return Ok(PatternMatcher::RustRegex(matcher)),
+                    Ok(matcher) => {
+                        return Ok(PatternMatcher::RustRegex(matcher))
+                    }
                     Err(err) => err,
                 };
                 log::debug!(
@@ -648,14 +651,15 @@ impl ArgMatches {
                     "~".repeat(79),
                     pcre_err,
                 )))
-            },
+            }
 
-            _ => Err(From::from(format!("Engine '{}' not found. Refer to the \
-                                         help to know supported values.",
-                                        engine)))
+            _ => Err(From::from(format!(
+                "Engine '{}' not found. Refer to the help to know supported \
+                 values.",
+                engine
+            ))),
         }
     }
-
 
     /// Build a matcher using Rust's regex engine.
     ///


### PR DESCRIPTION
This is the commits corresponding to https://github.com/BurntSushi/ripgrep/issues/1488 

I tried to not change any default behavior of the options.

If I've done things correctly, the only thing that should change is when using the "auto-hybrid-regex" option without pcre2 feature enabled, an additional error message stating that pcre2 is not enabled should appear.

Thanks !