### PR TITLE
add engine option to easily switch between regexp engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ increases the times to `2.640s` for ripgrep and `10.277s` for GNU grep.
   Among other things, this makes it possible to use look-around and
   backreferences in your patterns, which are not supported in ripgrep's default
   regex engine. PCRE2 support can be enabled with `-P/--pcre2` (use PCRE2
-  always) or `--auto-hybrid-regex` (use PCRE2 only if needed).
+  always) or `--auto-hybrid-regex` (use PCRE2 only if needed). An alternative
+  syntax is provided via the `--engine (default|pcre2|auto-hybrid)` option.
 * ripgrep supports searching files in text encodings other than UTF-8, such
   as UTF-16, latin-1, GBK, EUC-JP, Shift_JIS and more. (Some support for
   automatically detecting UTF-16 is provided. Other text encodings must be

--- a/complete/_rg
+++ b/complete/_rg
@@ -78,6 +78,13 @@ _rg() {
     {-E+,--encoding=}'[specify text encoding of files to search]: :_rg_encodings'
     $no'--no-encoding[use default text encoding]'
 
+    + '(engine)' # Engine choice options
+    '--engine=[select which regexp engine to use (overriden by pcre2 and hybrid options)]:when:((
+      default\:"use default engine"
+      pcre2\:"identical to --pcre2"
+      auto-hybrid\:"identical to --auto-hybrid-regex"
+    ))'
+
     + file # File-input options
     '(1)*'{-f+,--file=}'[specify file containing patterns to search for]: :_files'
 

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -508,6 +508,13 @@ impl RGArg {
         self
     }
 
+    /// Sets the default value of this argument when not specified at
+    /// runtime.
+    fn default_value(mut self, value: &'static str) -> RGArg {
+        self.claparg = self.claparg.default_value(value);
+        self
+    }
+
     /// Sets the default value of this argument if and only if the argument
     /// given is present.
     fn default_value_if(
@@ -566,6 +573,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_debug(&mut args);
     flag_dfa_size_limit(&mut args);
     flag_encoding(&mut args);
+    flag_engine(&mut args);
     flag_file(&mut args);
     flag_files(&mut args);
     flag_files_with_matches(&mut args);
@@ -741,14 +749,16 @@ This flag can be disabled with --no-auto-hybrid-regex.
         .long_help(LONG)
         .overrides("no-auto-hybrid-regex")
         .overrides("pcre2")
-        .overrides("no-pcre2");
+        .overrides("no-pcre2")
+        .overrides("engine");
     args.push(arg);
 
     let arg = RGArg::switch("no-auto-hybrid-regex")
         .hidden()
         .overrides("auto-hybrid-regex")
         .overrides("pcre2")
-        .overrides("no-pcre2");
+        .overrides("no-pcre2")
+        .overrides("engine");
     args.push(arg);
 }
 
@@ -1182,6 +1192,41 @@ This flag can be disabled with --no-encoding.
     args.push(arg);
 
     let arg = RGArg::switch("no-encoding").hidden().overrides("encoding");
+    args.push(arg);
+}
+
+fn flag_engine(args: &mut Vec<RGArg>) {
+    const SHORT: &str =
+        "Specify which regexp engine to use: default|pcre2|auto-hybrid.";
+    const LONG: &str = long!(
+        "\
+Specify which regular expression engine to use. When you choose a
+regex engine, it applies that choice for every regex provided to ripgrep (e.g.,
+via multiple -e/--regexp or -f/--file flags).
+
+Accepted values are 'default', 'pcre2', or 'auto-hybrid'.
+
+The default value is default, which is the fastest and should be good for most
+use-cases. PCRE2 engine is generally useful when you want to use features such
+as look-around or backreferences. auto-hybrid will dynamically choose between
+supported regex engines depending on the features used in a pattern.
+
+Please have a look at the custom flags '--pcre2' and '--auto-hybrid-regex'
+which explain their respective meaning in more depth.
+
+Using '--pcre2' or '--auto-hybrid-regex' afterwards overrides the value of this
+flag.
+"
+    );
+    let arg = RGArg::flag("engine", "ENGINE")
+        .help(SHORT)
+        .long_help(LONG)
+        .possible_values(&["default", "pcre2", "auto-hybrid"])
+        .default_value("default")
+        .overrides("pcre2")
+        .overrides("no-pcre2")
+        .overrides("auto-hybrid-regex")
+        .overrides("no-auto-hybrid-regex");
     args.push(arg);
 }
 
@@ -2303,14 +2348,16 @@ This flag can be disabled with --no-pcre2.
         .long_help(LONG)
         .overrides("no-pcre2")
         .overrides("auto-hybrid-regex")
-        .overrides("no-auto-hybrid-regex");
+        .overrides("no-auto-hybrid-regex")
+        .overrides("engine");
     args.push(arg);
 
     let arg = RGArg::switch("no-pcre2")
         .hidden()
         .overrides("pcre2")
         .overrides("auto-hybrid-regex")
-        .overrides("no-auto-hybrid-regex");
+        .overrides("no-auto-hybrid-regex")
+        .overrides("engine");
     args.push(arg);
 }
 

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -582,7 +582,8 @@ impl ArgMatches {
         } else if self.is_present("auto-hybrid-regex") {
             self.matcher_engine("auto-hybrid", patterns)
         } else {
-            self.matcher_engine("default", patterns)
+            let engine = self.value_of_lossy("engine").unwrap();
+            self.matcher_engine(engine.as_str(), patterns)
         }
     }
 

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -576,58 +576,77 @@ impl ArgMatches {
     ///
     /// If there was a problem building the matcher (e.g., a syntax error),
     /// then this returns an error.
-    #[cfg(feature = "pcre2")]
     fn matcher(&self, patterns: &[String]) -> Result<PatternMatcher> {
         if self.is_present("pcre2") {
-            let matcher = self.matcher_pcre2(patterns)?;
-            Ok(PatternMatcher::PCRE2(matcher))
+            self.matcher_engine("pcre2", patterns)
         } else if self.is_present("auto-hybrid-regex") {
-            let rust_err = match self.matcher_rust(patterns) {
-                Ok(matcher) => return Ok(PatternMatcher::RustRegex(matcher)),
-                Err(err) => err,
-            };
-            log::debug!(
-                "error building Rust regex in hybrid mode:\n{}",
-                rust_err,
-            );
-            let pcre_err = match self.matcher_pcre2(patterns) {
-                Ok(matcher) => return Ok(PatternMatcher::PCRE2(matcher)),
-                Err(err) => err,
-            };
-            Err(From::from(format!(
-                "regex could not be compiled with either the default regex \
-                 engine or with PCRE2.\n\n\
-                 default regex engine error:\n{}\n{}\n{}\n\n\
-                 PCRE2 regex engine error:\n{}",
-                "~".repeat(79),
-                rust_err,
-                "~".repeat(79),
-                pcre_err,
-            )))
+            self.matcher_engine("auto-hybrid", patterns)
         } else {
-            let matcher = match self.matcher_rust(patterns) {
-                Ok(matcher) => matcher,
-                Err(err) => {
-                    return Err(From::from(suggest_pcre2(err.to_string())));
-                }
-            };
-            Ok(PatternMatcher::RustRegex(matcher))
+            self.matcher_engine("default", patterns)
         }
     }
 
-    /// Return the matcher that should be used for searching.
+    /// Return the matcher that should be used for searching using engine
+    /// as the engine for the patterns.
     ///
     /// If there was a problem building the matcher (e.g., a syntax error),
     /// then this returns an error.
-    #[cfg(not(feature = "pcre2"))]
-    fn matcher(&self, patterns: &[String]) -> Result<PatternMatcher> {
-        if self.is_present("pcre2") {
-            return Err(From::from(
-                "PCRE2 is not available in this build of ripgrep",
-            ));
+    fn matcher_engine(
+        &self,
+        engine: &str,
+        patterns: &[String],
+    ) -> Result<PatternMatcher> {
+        match engine {
+            "default" => {
+                let matcher = match self.matcher_rust(patterns) {
+                    Ok(matcher) => matcher,
+                    Err(err) => {
+                        return Err(From::from(suggest(err.to_string())));
+                    }
+                };
+                Ok(PatternMatcher::RustRegex(matcher))
+            }
+
+            #[cfg(feature = "pcre2")]
+            "pcre2" => {
+                let matcher = self.matcher_pcre2(patterns)?;
+                Ok(PatternMatcher::PCRE2(matcher))
+            }
+
+            #[cfg(not(feature = "pcre2"))]
+            "pcre2" => Err(From::from("PCRE2 is not available in this build of ripgrep")),
+
+            "auto-hybrid" => {
+                let rust_err = match self.matcher_rust(patterns) {
+                    Ok(matcher) => return Ok(PatternMatcher::RustRegex(matcher)),
+                    Err(err) => err,
+                };
+                log::debug!(
+                    "error building Rust regex in hybrid mode:\n{}",
+                    rust_err,
+                );
+
+                let pcre_err = match self.matcher_engine("pcre2", patterns) {
+                    Ok(matcher) => return Ok(matcher),
+                    Err(err) => err,
+                };
+
+                Err(From::from(format!(
+                    "regex could not be compiled with either the default regex \
+                     engine or with PCRE2.\n\n\
+                     default regex engine error:\n{}\n{}\n{}\n\n\
+                     PCRE2 regex engine error:\n{}",
+                    "~".repeat(79),
+                    rust_err,
+                    "~".repeat(79),
+                    pcre_err,
+                )))
+            }
+
+            _ => Err(From::from(
+               format!("Engine '{}' not found. Refer to the help to know supported values.", engine)
+            )),
         }
-        let matcher = self.matcher_rust(patterns)?;
-        Ok(PatternMatcher::RustRegex(matcher))
     }
 
     /// Build a matcher using Rust's regex engine.
@@ -1677,12 +1696,25 @@ impl ArgMatches {
 }
 
 /// Inspect an error resulting from building a Rust regex matcher, and if it's
+/// believed to correspond to a syntax error that another engine could handle,
+/// then add a message to suggest the use of the engine flag.
+fn suggest(msg: String) -> String {
+    let pcre_suggestion = suggest_pcre2(&msg);
+    if pcre_suggestion != msg {
+        return pcre_suggestion;
+    }
+
+    //add other engines suggestions here, return msg if nothing is found
+    msg
+}
+
+/// Inspect an error resulting from building a Rust regex matcher, and if it's
 /// believed to correspond to a syntax error that PCRE2 could handle, then
 /// add a message to suggest the use of -P/--pcre2.
 #[cfg(feature = "pcre2")]
-fn suggest_pcre2(msg: String) -> String {
+fn suggest_pcre2(msg: &String) -> String {
     if !msg.contains("backreferences") && !msg.contains("look-around") {
-        msg
+        msg.to_string()
     } else {
         format!(
             "{}
@@ -1692,6 +1724,17 @@ and look-around.",
             msg
         )
     }
+}
+
+/// Inspect an error resulting from building a Rust regex matcher, and if it's
+/// believed to correspond to a syntax error that PCRE2 could handle, then
+/// add a message to suggest the use of -P/--pcre2.
+///
+/// Since here rg is not compiled with pcre2, we can't offer any suggestion
+/// so we return the message untouched.
+#[cfg(not(feature = "pcre2"))]
+fn suggest_pcre2(msg: &String) -> String {
+    msg.to_string()
 }
 
 fn suggest_multiline(msg: String) -> String {


### PR DESCRIPTION
This is the commits corresponding to #1488

I tried to not change any default behavior of the options.

If I've done things correctly, the only thing that should change is when using the "auto-hybrid-regex" option without pcre2 feature enabled, an additional error message stating that pcre2 is not enabled should appear.

This is a follow up on : https://github.com/BurntSushi/ripgrep/pull/1499

Thanks !