### PR TITLE
ignore: handling of broken symlinks

### DIFF
--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -2109,6 +2109,24 @@ mod tests {
         assert_paths(td.path(), &builder.follow_links(true), &["a", "a/b"]);
     }
 
+    #[cfg(unix)] // because symlinks on windows are weird
+    #[test]
+    fn broken_symlinks() {
+        let td = tmpdir();
+        mkdirp(td.path().join("dir"));
+        symlink(td.path().join("dir"), td.path().join("normal_link"));
+        symlink(td.path().join("non-existing"), td.path().join("broken_link"));
+
+        let mut builder = WalkBuilder::new(td.path());
+        assert_paths(td.path(), &builder, &["dir", "normal_link", "broken_link"]);
+
+        assert_paths(
+            td.path(),
+            &builder.follow_links(true),
+            &["dir", "normal_link", "broken_link"],
+        );
+    }
+
     // It's a little tricky to test the 'same_file_system' option since
     // we need an environment with more than one file system. We adopt a
     // heuristic where /sys is typically a distinct volume on Linux and roll


### PR DESCRIPTION
This is maybe more of a question than a bug report.

Currently, the `ignore` crate has the following behavior:

* If `.follow_links(false)`: both broken and normal symlinks are reported as directory entries. This is as expected.
* If `.follow_links(true)`: normal symlinks are reported as directory entries (and traversed, if they point to a directory), broken symlinks are not reported (an `ignore::Error::WithPath` is returned from the iterator).

Question: in the `follow_links(true)` case, do we expect to see broken symlinks as normal directory entries?

I would argue yes, they should be reported. Broken symlinks are file-like directory entries which should show up when "walking a directory" with `ignore`. This is backed by `find`s behavior, which does report broken symlinks, even when `-follow` is present.


This is a PR which adds a (currently failing) unit test, which can be used as a basis to fix this, if desired. I tried to implement a fix myself, but didn't get very far:
``` diff
diff --git a/crates/ignore/src/walk.rs b/crates/ignore/src/walk.rs
index 6fd7087..c7bf039 100644
--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -958,6 +958,13 @@ impl Iterator for Walk {
             };
             match ev {
                 Err(err) => {
+                    if err.io_error().map_or(false, |io_error| {
+                        io_error.kind() == io::ErrorKind::NotFound
+                    }) {
+                        // TODO: make sure this is actually caused by a broken symlink
+                        // TODO: how to create a `DirEntry` from `io_error`? We only have
+                        // io_error.path().
+                    }
                     return Some(Err(Error::from_walkdir(err)));
                 }
                 Ok(WalkEvent::Exit) => {
```