### PR TITLE
update globset and ignore's cargo manifest urls

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -6,8 +6,8 @@ description = """
 Utilities for search oriented command line applications.
 """
 documentation = "https://docs.rs/grep-cli"
-homepage = "https://github.com/BurntSushi/ripgrep"
-repository = "https://github.com/BurntSushi/ripgrep"
+homepage = "https://github.com/BurntSushi/ripgrep/tree/master/crates/cli"
+repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/cli"
 readme = "README.md"
 keywords = ["regex", "grep", "cli", "utility", "util"]
 license = "Unlicense/MIT"

--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -8,8 +8,8 @@ process of matching one or more glob patterns against a single candidate path
 simultaneously, and returning all of the globs that matched.
 """
 documentation = "https://docs.rs/globset"
-homepage = "https://github.com/BurntSushi/ripgrep/tree/master/globset"
-repository = "https://github.com/BurntSushi/ripgrep/tree/master/globset"
+homepage = "https://github.com/BurntSushi/ripgrep/tree/master/crates/globset"
+repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/globset"
 readme = "README.md"
 keywords = ["regex", "glob", "multiple", "set", "pattern"]
 license = "Unlicense/MIT"

--- a/crates/grep/Cargo.toml
+++ b/crates/grep/Cargo.toml
@@ -6,8 +6,8 @@ description = """
 Fast line oriented regex searching as a library.
 """
 documentation = "http://burntsushi.net/rustdoc/grep/"
-homepage = "https://github.com/BurntSushi/ripgrep"
-repository = "https://github.com/BurntSushi/ripgrep"
+homepage = "https://github.com/BurntSushi/ripgrep/tree/master/crates/grep"
+repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/grep"
 readme = "README.md"
 keywords = ["regex", "grep", "egrep", "search", "pattern"]
 license = "Unlicense/MIT"

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -7,8 +7,8 @@ A fast library for efficiently matching ignore files such as `.gitignore`
 against file paths.
 """
 documentation = "https://docs.rs/ignore"
-homepage = "https://github.com/BurntSushi/ripgrep/tree/master/ignore"
-repository = "https://github.com/BurntSushi/ripgrep/tree/master/ignore"
+homepage = "https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore"
+repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore"
 readme = "README.md"
 keywords = ["glob", "ignore", "gitignore", "pattern", "file"]
 license = "Unlicense/MIT"

--- a/crates/matcher/Cargo.toml
+++ b/crates/matcher/Cargo.toml
@@ -6,8 +6,8 @@ description = """
 A trait for regular expressions, with a focus on line oriented search.
 """
 documentation = "https://docs.rs/grep-matcher"
-homepage = "https://github.com/BurntSushi/ripgrep"
-repository = "https://github.com/BurntSushi/ripgrep"
+homepage = "https://github.com/BurntSushi/ripgrep/tree/master/crates/matcher"
+repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/matcher"
 readme = "README.md"
 keywords = ["regex", "pattern", "trait"]
 license = "Unlicense/MIT"

--- a/crates/pcre2/Cargo.toml
+++ b/crates/pcre2/Cargo.toml
@@ -6,8 +6,8 @@ description = """
 Use PCRE2 with the 'grep' crate.
 """
 documentation = "https://docs.rs/grep-pcre2"
-homepage = "https://github.com/BurntSushi/ripgrep"
-repository = "https://github.com/BurntSushi/ripgrep"
+homepage = "https://github.com/BurntSushi/ripgrep/tree/master/crates/pcre2"
+repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/pcre2"
 readme = "README.md"
 keywords = ["regex", "grep", "pcre", "backreference", "look"]
 license = "Unlicense/MIT"

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -7,8 +7,8 @@ An implementation of the grep crate's Sink trait that provides standard
 printing of search results, similar to grep itself.
 """
 documentation = "https://docs.rs/grep-printer"
-homepage = "https://github.com/BurntSushi/ripgrep"
-repository = "https://github.com/BurntSushi/ripgrep"
+homepage = "https://github.com/BurntSushi/ripgrep/tree/master/crates/printer"
+repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/printer"
 readme = "README.md"
 keywords = ["grep", "pattern", "print", "printer", "sink"]
 license = "Unlicense/MIT"

--- a/crates/regex/Cargo.toml
+++ b/crates/regex/Cargo.toml
@@ -6,8 +6,8 @@ description = """
 Use Rust's regex library with the 'grep' crate.
 """
 documentation = "https://docs.rs/grep-regex"
-homepage = "https://github.com/BurntSushi/ripgrep"
-repository = "https://github.com/BurntSushi/ripgrep"
+homepage = "https://github.com/BurntSushi/ripgrep/tree/master/crates/regex"
+repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/regex"
 readme = "README.md"
 keywords = ["regex", "grep", "search", "pattern", "line"]
 license = "Unlicense/MIT"

--- a/crates/searcher/Cargo.toml
+++ b/crates/searcher/Cargo.toml
@@ -6,8 +6,8 @@ description = """
 Fast line oriented regex searching as a library.
 """
 documentation = "https://docs.rs/grep-searcher"
-homepage = "https://github.com/BurntSushi/ripgrep"
-repository = "https://github.com/BurntSushi/ripgrep"
+homepage = "https://github.com/BurntSushi/ripgrep/tree/master/crates/searcher"
+repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/searcher"
 readme = "README.md"
 keywords = ["regex", "grep", "egrep", "search", "pattern"]
 license = "Unlicense/MIT"


### PR DESCRIPTION
The homepage and repo urls for `ignore` and `globset` manifest keys weren't updated when the project structure changed, leading links from https://docs.rs and https://crates.io to 404s.

Sorry about the PR on the new globset repo, I happened to find it first before this crates directory.