### PR TITLE
ignore/types: add ebuild type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -52,6 +52,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("dhall", &["*.dhall"]),
     ("diff", &["*.patch", "*.diff"]),
     ("docker", &["*Dockerfile*"]),
+    ("ebuild", &["*.ebuild"]),
     ("edn", &["*.edn"]),
     ("elisp", &["*.el"]),
     ("elixir", &["*.ex", "*.eex", "*.exs"]),


### PR DESCRIPTION
Add support for Gentoo's portage package manager spec files:
https://wiki.gentoo.org/wiki/Portage

Closes #1534

(N.B. Refiling #1534 since something seems borked about CI there. It keeps failing on being able to checkout the repo. Not sure if it's something to do with the forked repo, so trying it here.)