### PR TITLE
doc: use asciidoctor instead of a2x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
       TARGET_DIR: ./target
       # Emit backtraces on panics.
       RUST_BACKTRACE: 1
-      # Apparently needed to use a2x on macOS.
-      XML_CATALOG_FILES: /usr/local/etc/xml/catalog
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,6 @@ jobs:
       RUST_BACKTRACE: 1
       # Build static releases with PCRE2.
       PCRE2_SYS_STATIC: 1
-      # Apparently needed to use a2x on macOS.
-      XML_CATALOG_FILES: /usr/local/etc/xml/catalog
     strategy:
       matrix:
         build: [linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc]

--- a/FAQ.md
+++ b/FAQ.md
@@ -60,9 +60,10 @@ patch release out with a fix. However, no promises are made.
 Does ripgrep have a man page?
 </h3>
 
-Yes! Whenever ripgrep is compiled on a system with `asciidoc` present, then a
-man page is generated from ripgrep's argv parser. After compiling ripgrep, you
-can find the man page like so from the root of the repository:
+Yes! Whenever ripgrep is compiled on a system with `asciidoctor` or `asciidoc`
+present, then a man page is generated from ripgrep's argv parser. After
+compiling ripgrep, you can find the man page like so from the root of the
+repository:
 
 ```
 $ find ./target -name rg.1 -print0 | xargs -0 ls -t | head -n1

--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -4,7 +4,7 @@ via the [Cross](https://github.com/rust-embedded/cross) tool.
 The Cross tool actually provides its own Docker images, and all Docker images
 in this directory are derived from one of them. We provide our own in order
 to customize the environment. For example, we need to install some things like
-`asciidoc` in order to generate man pages. We also install compression tools
+`asciidoctor` in order to generate man pages. We also install compression tools
 like `xz` so that tests for the `-z/--search-zip` flag are run.
 
 If you make a change to a Docker image, then you can re-build it. `cd` into the

--- a/ci/macos-install-packages
+++ b/ci/macos-install-packages
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-brew install asciidoc docbook-xsl
+brew install asciidoctor

--- a/ci/ubuntu-install-packages
+++ b/ci/ubuntu-install-packages
@@ -2,5 +2,5 @@
 
 sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
-  libxslt1-dev asciidoc docbook-xsl xsltproc libxml2-utils \
+  asciidoctor \
   zsh xz-utils liblz4-tool musl-tools


### PR DESCRIPTION
Ref: Homebrew/linuxbrew-core#19885

AsciiDoc development is continued under asciidoctor. See https://github.com/asciidoc/asciidoc.

I tried to run CI several times, but on nightly build, Rust fails to find the asciidoctor binary even `/usr/bin/asciidoctor` exists.

Attaching `rg.1.asciidoc` from current build, and `rg.1.asciidoctor` from new build.
- [rg.1.asciidoc.txt](https://github.com/BurntSushi/ripgrep/files/4439537/rg.1.asciidoc.txt)
- [rg.1.asciidoctor.txt](https://github.com/BurntSushi/ripgrep/files/4439540/rg.1.asciidoctor.txt)