### PR TITLE
pkg: fix brew tap version to 12.0.1 to match sha

### DIFF
--- a/pkg/brew/ripgrep-bin.rb
+++ b/pkg/brew/ripgrep-bin.rb
@@ -1,5 +1,5 @@
 class RipgrepBin < Formula
-  version '12.0.0'
+  version '12.0.1'
   desc "Recursively search directories for a regex pattern."
   homepage "https://github.com/BurntSushi/ripgrep"
 


### PR DESCRIPTION
Hello!

This will fix this currently happening error :
```
> brew install ripgrep-bin

==> Installing ripgrep-bin from burntsushi/ripgrep
==> Downloading https://github.com/BurntSushi/ripgrep/releases/download/12.0.0/ripgrep-12.0.0-x86_64-apple-darwin.tar.gz
Already downloaded: /Library/Caches/Homebrew/downloads/71ad3a51a074950abeaa875fb35ac00adca54d0852b0e0f4ed627056994fbecc--ripgrep-12.0.0-x86_64-apple-darwin.tar.gz
Error: An exception occurred within a child process:
  ChecksumMismatchError: SHA256 mismatch
Expected: 59e78931a7577e76f40c937cae2782f2bbdcb40f056df5dd84247a671373525d
  Actual: ebbc518ac019fc78b6429ec2e64b823c59b15a6f942436f43b9afc23c9aad9ea
 Archive: /Library/Caches/Homebrew/downloads/71ad3a51a074950abeaa875fb35ac00adca54d0852b0e0f4ed627056994fbecc--ripgrep-12.0.0-x86_64-apple-darwin.tar.gz
To retry an incomplete download, remove the file above.
```