### PR TITLE
ci: puts jemalloc allocator behind a cargo feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,12 @@ jobs:
       if: matrix.target != ''
       run: ${{ env.CARGO }} test --verbose --all ${{ env.TARGET_FLAGS }}
 
+    - name: Run tests with jemalloc (Musl)
+      # We only use the jemalloc allocator when building with musl.
+      # The system allocator is good enough for other platforms.
+      if: matrix.os == 'nightly-musl'
+      run: ${{ env.CARGO }} test --verbose --all --features jemalloc ${{ env.TARGET_FLAGS }}
+
     - name: Test for existence of build artifacts (Windows)
       if: matrix.os == 'windows-2019'
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,13 @@ jobs:
         echo "::set-env name=RELEASE_VERSION::$release_version"
         echo "release version: $RELEASE_VERSION"
 
-    - name: Build release binary
+    - name: Build release binary (linux)
+      if: matrix.build == 'linux'
+      # Use jemalloc allocator for much better performance over the musl default allocator
+      run: ${{ env.CARGO }} build --verbose --release --features "pcre2 jemalloc" ${{ env.TARGET_FLAGS }}
+
+    - name: Build release binary (non-linux)
+      if: matrix.build != 'linux'
       run: ${{ env.CARGO }} build --verbose --release --features pcre2 ${{ env.TARGET_FLAGS }}
 
     - name: Strip release binary (linux and macos)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,9 @@ version = "2.33.0"
 default-features = false
 features = ["suggestions"]
 
-[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.jemallocator]
+[dependencies.jemallocator]
 version = "0.3.0"
+optional = true
 
 [build-dependencies]
 lazy_static = "1.1.0"
@@ -80,6 +81,11 @@ walkdir = "2"
 [features]
 simd-accel = ["grep/simd-accel"]
 pcre2 = ["grep/pcre2"]
+# The jemalloc allocator is used for improved
+# performance on x86 musl builds.
+# Cargo does not yet support platform-specific features
+# https://github.com/rust-lang/cargo/issues/1197
+jemalloc = ["jemallocator"]
 
 [profile.release]
 debug = 1

--- a/README.md
+++ b/README.md
@@ -411,6 +411,15 @@ build a static executable with MUSL and with PCRE2, then you will need to have
 `musl-gcc` installed, which might be in a separate package from the actual
 MUSL library, depending on your Linux distribution.
 
+When building with the MUSL target on Linux, it is recommended to use the
+jemalloc allocator for performance:
+
+```
+$ rustup target add x86_64-unknown-linux-musl
+$ cargo build --release --target x86_64-unknown-linux-musl --features jemalloc
+```
+
+
 
 ### Running tests
 

--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -31,7 +31,7 @@ mod subject;
 // have the fastest version of everything. Its goal is to be small and amenable
 // to static compilation.) Even though ripgrep isn't particularly allocation
 // heavy, musl's allocator appears to slow down ripgrep quite a bit. Therefore,
-// when building with musl, we use jemalloc.
+// we expose a feature for using jemalloc when building with musl.
 //
 // We don't unconditionally use jemalloc because it can be nice to use the
 // system's default allocator by default. Moreover, jemalloc seems to increase
@@ -39,7 +39,11 @@ mod subject;
 //
 // Moreover, we only do this on 64-bit systems since jemalloc doesn't support
 // i686.
-#[cfg(all(target_env = "musl", target_pointer_width = "64"))]
+#[cfg(all(
+    target_env = "musl",
+    target_pointer_width = "64",
+    feature = "jemalloc"
+))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
I have to say, thank you for making such incredibly nice, well-designed tools. I went through `ripgrep` and `xsv` a lot when I was first wrapping my head around Rust.

I saw an issue that I thought I could handle, so in an effort to be helpful, here it is.

This puts the jemalloc allocator behind a cargo feature as suggested here:
https://github.com/BurntSushi/ripgrep/issues/1542

The GitHub action for building releases appears to work:
https://github.com/jonstites/ripgrep/actions/runs/97156617

I did my best to make sensible choices, but I could be off the mark. Some thoughts:
- It might be confusing that there is a feature called "jemalloc" that doesn't actually use jemalloc unless on x86 musl. Cargo does not yet fully support platform-specific features. The feature could be called "jemalloc-musl-x86" or it could actually try to use "jemalloc" for any target. But jemallocator doesn't fully support all that many targets...
- This changes the default allocator for x86_64-unknown-linux-musl. This might lead to a big performance hit for someone. The feature could instead be for disabling jemalloc.
- I didn't touch the build-deb file, partly because I don't fully understand how .deb packaging works and partly because as best I can tell, jemalloc is disabled: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/85f65b218cf86dbded7b66705617d3a5eb0b6a25/src/ripgrep/debian/patches/disable-jemallocator.diff

PS I am not someone who would take it personally if you requested big changes or decided that this issue isn't important enough for the added complexity. It's your project and your call on the code!