### PR TITLE
Update a misleading doc that may have originated from a bad copy/paste

### DIFF
--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -346,7 +346,7 @@ impl Args {
         Ok(self.matches().walker_builder(self.paths())?.build())
     }
 
-    /// Return a walker that never uses additional threads.
+    /// Return a parallel walker that may use additional threads.
     pub fn walker_parallel(&self) -> Result<WalkParallel> {
         Ok(self.matches().walker_builder(self.paths())?.build_parallel())
     }


### PR DESCRIPTION
It seems like `fn walker_parallel` in `core/args.rs` has a documentation copy/pasted from the `fn walker` above it.  Updated the documentation to be (IMO) more accurate.

It's my first contribution -- apologies if I'm not following some convention.