### PR TITLE
Add nightly flag to SIMD cargo build command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ If you have a Rust nightly compiler and a recent Intel CPU, then you can enable
 additional optional SIMD acceleration like so:
 
 ```
-RUSTFLAGS="-C target-cpu=native" cargo build --release --features 'simd-accel'
+RUSTFLAGS="-C target-cpu=native" cargo +nightly build --release --features 'simd-accel'
 ```
 
 The `simd-accel` feature enables SIMD support in certain ripgrep dependencies


### PR DESCRIPTION
A tiny doc update that adds the `+nightly` flag to the example command to build ripgrep with simd extensions. Thought it might be nice in case folks have the stable rustc set to default and forget to add the flag.