### PR TITLE
Removed AVX feature notice

### DIFF
--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -115,11 +115,6 @@ fn compile_cpu_features() -> Vec<&'static str> {
     } else {
         features.push("-SIMD");
     }
-    if cfg!(feature = "avx-accel") {
-        features.push("+AVX");
-    } else {
-        features.push("-AVX");
-    }
     features
 }
 
@@ -134,11 +129,6 @@ fn runtime_cpu_features() -> Vec<&'static str> {
         features.push("+SIMD");
     } else {
         features.push("-SIMD");
-    }
-    if is_x86_feature_detected!("avx2") {
-        features.push("+AVX");
-    } else {
-        features.push("-AVX");
     }
     features
 }


### PR DESCRIPTION
Currently, ripgrep will note in `--version`<sup>[1]</sup> output which features are enabled at compile time and runtime, including the AVX feature. Given AVX feature appears to be deprecated now, it seemed safe to remove this notice to reduce confusion.

- Alternative 1: instead of removing this notice entirely, simply append "[DEPRECATED]" to the AVX feature string.
- Alternative 2: conditionally display AVX in the features only if it is enabled at compile time

-----

<sup>[1]</sup>: Example `--version` output:
```
ripgrep on  depavx via 🦀 v1.44.0
16:38 ☄ rg --version
ripgrep 12.1.1 (rev a16bfcb3d6)
+SIMD -AVX (compiled)
+SIMD +AVX (runtime)
```