### PR TITLE
ignore/types: add racket

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -162,6 +162,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("qmake", &["*.pro", "*.pri", "*.prf"]),
     ("qml", &["*.qml"]),
     ("r", &["*.R", "*.r", "*.Rmd", "*.Rnw"]),
+    ("racket", &["*.rkt"]),
     ("rdoc", &["*.rdoc"]),
     ("readme", &["README*", "*README"]),
     ("robot", &["*.robot"]),


### PR DESCRIPTION
Adding filetype for racket-lang (https://racket-lang.org/).

PS: Thanks for this awesome software!