### PR TITLE
ignore/types: add vcl

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -224,6 +224,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("typoscript", &["*.typoscript", "*.ts"]),
     ("vala", &["*.vala"]),
     ("vb", &["*.vb"]),
+    ("vcl", &["*.vcl"]),
     ("verilog", &["*.v", "*.vh", "*.sv", "*.svh"]),
     ("vhdl", &["*.vhd", "*.vhdl"]),
     ("vim", &["*.vim"]),


### PR DESCRIPTION
VCL is the Varnish Configuration Language used by Varnish and Fastly.

https://varnish-cache.org/docs/trunk/users-guide/vcl.html