### PR TITLE
cli: adding -. as short option for --hidden

### DIFF
--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -1434,6 +1434,7 @@ This flag can be disabled with --no-hidden.
 "
     );
     let arg = RGArg::switch("hidden")
+        .short(".")
         .help(SHORT)
         .long_help(LONG)
         .overrides("no-hidden");


### PR DESCRIPTION
There was no short option for `--hidden`, I assume because `-H` is already taken by `--with-filename` from the original `grep`, and `-h` should always be `--help`.

The fact is, a lot of times when searching recursively in a directory, `--hidden` is needed to show files that start with an `.` (dot).

So doesn't it make sense to use a dot for the short flag?
`rg -. PATTERN`.

The only software I'm aware that uses `-.` is `feh`, however there seems to be no semantic relation with the dot itself, in contrast with `ripgrep`'s.