### PR TITLE
deps: use fs-err instead of std::fs in walkdir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fs-err"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd1163ae48bda72a20ae26d66a04d3094135cadab911cff418ae5e33f253431"
+
+[[package]]
 name = "fs_extra"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +270,7 @@ version = "0.4.16"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
+ "fs-err",
  "globset",
  "lazy_static",
  "log",

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -27,6 +27,7 @@ regex = "1.1"
 same-file = "1.0.4"
 thread_local = "1"
 walkdir = "2.2.7"
+fs-err = "2.5.0"
 
 [target.'cfg(windows)'.dependencies.winapi-util]
 version = "0.1.2"

--- a/crates/ignore/src/lib.rs
+++ b/crates/ignore/src/lib.rs
@@ -51,6 +51,7 @@ extern crate globset;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
+extern crate fs_err;
 extern crate memchr;
 extern crate regex;
 extern crate same_file;


### PR DESCRIPTION
Hi there, thanks so much for ripgrep, I use it every day!
I just stumbled upon this little crate called [fs-err](https://github.com/andrewhickman/fs-err) which produces nicer fs errors but is basically a drop in replacement for `std::err`.

I thought I'd give it a try in ripgrep et voilá

before:
```bash
~  /usr/bin/rg password /root
/root: Permission denied (os error 13)
```

after:
```bash
~  rg password /root 
/root: failed to read directory `/root`
```

thank you for your consideration