### PR TITLE
UTF-8 BOM Sniffing

### DIFF
--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -864,3 +864,12 @@ use B;
     ]);
     eqnice!("2\n", cmd.stdout());
 });
+
+// See: https://github.com/BurntSushi/ripgrep/issues/1638
+//
+// Tests if UTF-8 BOM is sniffed, then the column index is correct.
+rgtest!(r1638, |dir: Dir, mut cmd: TestCommand| {
+    dir.create_bytes("foo", b"\xef\xbb\xbfx");
+
+    eqnice!("foo:1:1:x\n", cmd.arg("--column").arg("x").stdout());
+});


### PR DESCRIPTION
UTF-8 encoded files with BOM didn't sniff the BOM from results, regardless of
config.bom_sniffing; ripgrep already implemented this option for UTF-16 files
correctly.

Fixes #1638