### PR TITLE
Add a type for minified files

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -138,6 +138,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("matlab", &["*.m"]),
     ("md", &["*.markdown", "*.md", "*.mdown", "*.mkdn"]),
     ("meson", &["meson.build", "meson_options.txt"]),
+    ("minified", &["*.min.html", "*.min.css", "*.min.js"]),
     ("mk", &["mkfile"]),
     ("ml", &["*.ml"]),
     ("msbuild", &[


### PR DESCRIPTION
Well, I don't know Rust and the directory structure looks weird. Thought it would be hard to make the change, but `rg` told me I was wrong, `rg '\*.toml'` shows me exactly what I want. Thank you for this awesome tool!

This PR is for issue #1710 