### PR TITLE
Remove regex unicode dependency from globset

### DIFF
--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -23,7 +23,7 @@ aho-corasick = "0.7.3"
 bstr = { version = "0.2.0", default-features = false, features = ["std"] }
 fnv = "1.0.6"
 log = "0.4.5"
-regex = "1.1.5"
+regex = { version = "1.1.5", default-features = false, features = ["perf", "std"] }
 serde = { version = "1.0.104", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
I don't think globset requires Unicode support in regex for path matching (correct me if I'm wrong). I removed the dependency to make the crate lighter.

This won't affect the size of ripgrep, since it depends on Unicode in regex elsewhere. However, I've been meaning to use globset in [zoxide](https://github.com/ajeetdsouza/zoxide), and I'd like to keep the binary size as small as possible.

I tested a trivial program before and after the change, and the executable size went from 2544 KB to 2084 KB.

Thanks!