### PR TITLE
Add Futhark recognition to ignore crate

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -68,6 +68,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
         "*.f90", "*.F90", "*.f95", "*.F95",
     ]),
     ("fsharp", &["*.fs", "*.fsx", "*.fsi"]),
+    ("fut", &[".fut"]),
     ("gap", &["*.g", "*.gap", "*.gi", "*.gd", "*.tst"]),
     ("gn", &["*.gn", "*.gni"]),
     ("go", &["*.go"]),


### PR DESCRIPTION
This adds recognition of [Futhark](https://futhark-lang.org/) files.

Thanks! :)