### PR TITLE
ci: install cross from crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,7 @@ jobs:
     - name: Use Cross
       if: matrix.target != ''
       run: |
-        # FIXME: to work around bugs in latest cross release, install master.
-        # See: https://github.com/rust-embedded/cross/issues/357
-        cargo install --git https://github.com/rust-embedded/cross
+        cargo install cross
         echo "::set-env name=CARGO::cross"
         echo "::set-env name=TARGET_FLAGS::--target ${{ matrix.target }}"
         echo "::set-env name=TARGET_DIR::./target/${{ matrix.target }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,9 +131,7 @@ jobs:
     - name: Use Cross
       # if: matrix.os != 'windows-2019'
       run: |
-        # FIXME: to work around bugs in latest cross release, install master.
-        # See: https://github.com/rust-embedded/cross/issues/357
-        cargo install --git https://github.com/rust-embedded/cross
+        cargo install cross
         echo "::set-env name=CARGO::cross"
         echo "::set-env name=TARGET_FLAGS::--target ${{ matrix.target }}"
         echo "::set-env name=TARGET_DIR::./target/${{ matrix.target }}"

--- a/ci/utils.sh
+++ b/ci/utils.sh
@@ -99,9 +99,7 @@ is_osx() {
 
 builder() {
     if is_musl && is_x86_64; then
-        # cargo install cross
-        # To work around https://github.com/rust-embedded/cross/issues/357
-        cargo install --git https://github.com/rust-embedded/cross --force
+        cargo install cross
         echo "cross"
     else
         echo "cargo"


### PR DESCRIPTION
Now that a new version of `cross` that includes the fix of https://github.com/rust-embedded/cross/issues/357 has been released (https://github.com/rust-embedded/cross/issues/359), we can resolve this FIXME.