### PR TITLE
Fix stdin detection when using Powershell in Unix (fix #1741)

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -210,7 +210,7 @@ pub fn is_readable_stdin() -> bool {
             Err(_) => return false,
             Ok(md) => md.file_type(),
         };
-        ft.is_file() || ft.is_fifo()
+        ft.is_file() || ft.is_fifo() || ft.is_socket()
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
It seems that Powershell uses sockets instead of FIFOs to redirect the output between commands