### PR TITLE
Cargo.toml: remove "readme" field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ has first class support on Windows, macOS and Linux.
 documentation = "https://github.com/BurntSushi/ripgrep"
 homepage = "https://github.com/BurntSushi/ripgrep"
 repository = "https://github.com/BurntSushi/ripgrep"
-readme = "README.md"
 keywords = ["regex", "grep", "egrep", "search", "pattern"]
 categories = ["command-line-utilities", "text-processing"]
 license = "Unlicense OR MIT"


### PR DESCRIPTION
It is no more required. See [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field).