### PR TITLE
Updates all dependencies; replaces memmap with memmap2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -51,21 +51,21 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0017894339f586ccb943b01b9555de56770c11cda818e7e3d8bd93f4ed7f46e"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 dependencies = [
  "jobserver",
 ]
@@ -95,12 +95,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,13 +106,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -258,15 +251,15 @@ dependencies = [
  "grep-matcher",
  "grep-regex",
  "log",
- "memmap",
+ "memmap2",
  "regex",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -290,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jemalloc-sys"
@@ -332,9 +325,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "libm"
@@ -344,9 +337,9 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -358,13 +351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "e73be3b7d04a0123e933fea1d50d126cc7196bbc0362c0ce426694f777194eee"
 dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]
@@ -427,18 +419,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -457,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "ripgrep"
@@ -498,15 +490,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "9bdd36f49e35b61d49efd8aa7fc068fd295961fd2286d0b2ee9a4c7a14e99cc3"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "552954ce79a059ddd5fd68c271592374bd15cab2274970380c000118aeffe1cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -515,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -532,9 +524,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -543,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -561,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,36 +42,36 @@ members = [
 ]
 
 [dependencies]
-bstr = "0.2.12"
+bstr = "0.2.14"
 grep = { version = "0.2.7", path = "crates/grep" }
 ignore = { version = "0.4.16", path = "crates/ignore" }
-lazy_static = "1.1.0"
-log = "0.4.5"
-num_cpus = "1.8.0"
-regex = "1.3.5"
-serde_json = "1.0.23"
-termcolor = "1.1.0"
+lazy_static = "1.4.0"
+log = "0.4.13"
+num_cpus = "1.13.0"
+regex = "1.4.3"
+serde_json = "1.0.61"
+termcolor = "1.1.2"
 
 [dependencies.clap]
-version = "2.33.0"
+version = "2.33.3"
 default-features = false
 features = ["suggestions"]
 
-[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.jemallocator]
-version = "0.3.0"
+[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies]
+jemallocator = "0.3.2"
 
 [build-dependencies]
-lazy_static = "1.1.0"
+lazy_static = "1.4.0"
 
 [build-dependencies.clap]
-version = "2.33.0"
+version = "2.33.3"
 default-features = false
 features = ["suggestions"]
 
 [dev-dependencies]
-serde = "1.0.77"
-serde_derive = "1.0.77"
-walkdir = "2"
+serde = "1.0.119"
+serde_derive = "1.0.119"
+walkdir = "2.3.1"
 
 [features]
 simd-accel = ["grep/simd-accel"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,14 +13,14 @@ keywords = ["regex", "grep", "cli", "utility", "util"]
 license = "Unlicense/MIT"
 
 [dependencies]
-atty = "0.2.11"
-bstr = "0.2.0"
+atty = "0.2.14"
+bstr = "0.2.14"
 globset = { version = "0.4.5", path = "../globset" }
-lazy_static = "1.1.0"
-log = "0.4.5"
-regex = "1.1"
-same-file = "1.0.4"
-termcolor = "1.0.4"
+lazy_static = "1.4.0"
+log = "0.4.13"
+regex = "1.4.3"
+same-file = "1.0.6"
+termcolor = "1.1.2"
 
-[target.'cfg(windows)'.dependencies.winapi-util]
-version = "0.1.1"
+[target.'cfg(windows)'.dependencies]
+winapi-util = "0.1.5"

--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -19,17 +19,17 @@ name = "globset"
 bench = false
 
 [dependencies]
-aho-corasick = "0.7.3"
-bstr = { version = "0.2.0", default-features = false, features = ["std"] }
-fnv = "1.0.6"
-log = "0.4.5"
-regex = { version = "1.1.5", default-features = false, features = ["perf", "std"] }
-serde = { version = "1.0.104", optional = true }
+aho-corasick = "0.7.15"
+bstr = { version = "0.2.14", default-features = false, features = ["std"] }
+fnv = "1.0.7"
+log = "0.4.13"
+regex = { version = "1.4.3", default-features = false, features = ["perf", "std"] }
+serde = { version = "1.0.119", optional = true }
 
 [dev-dependencies]
 glob = "0.3.0"
-lazy_static = "1"
-serde_json = "1.0.45"
+lazy_static = "1.4.0"
+serde_json = "1.0.61"
 
 [features]
 simd-accel = []

--- a/crates/grep/Cargo.toml
+++ b/crates/grep/Cargo.toml
@@ -21,8 +21,8 @@ grep-regex = { version = "0.1.8", path = "../regex" }
 grep-searcher = { version = "0.1.7", path = "../searcher" }
 
 [dev-dependencies]
-termcolor = "1.0.4"
-walkdir = "2.2.7"
+termcolor = "1.1.2"
+walkdir = "2.3.1"
 
 [features]
 simd-accel = ["grep-searcher/simd-accel"]

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -18,18 +18,18 @@ name = "ignore"
 bench = false
 
 [dependencies]
-crossbeam-utils = "0.8.0"
+crossbeam-utils = "0.8.1"
 globset = { version = "0.4.5", path = "../globset" }
-lazy_static = "1.1"
-log = "0.4.5"
-memchr = "2.1"
-regex = "1.1"
-same-file = "1.0.4"
-thread_local = "1"
-walkdir = "2.2.7"
+lazy_static = "1.4.0"
+log = "0.4.13"
+memchr = "2.3.4"
+regex = "1.4.3"
+same-file = "1.0.6"
+thread_local = "1.1.0"
+walkdir = "2.3.1"
 
-[target.'cfg(windows)'.dependencies.winapi-util]
-version = "0.1.2"
+[target.'cfg(windows)'.dependencies]
+winapi-util = "0.1.5"
 
 [dev-dependencies]
 crossbeam-channel = "0.5.0"

--- a/crates/matcher/Cargo.toml
+++ b/crates/matcher/Cargo.toml
@@ -14,10 +14,10 @@ license = "Unlicense/MIT"
 autotests = false
 
 [dependencies]
-memchr = "2.1"
+memchr = "2.3.4"
 
 [dev-dependencies]
-regex = "1.1"
+regex = "1.4.3"
 
 [[test]]
 name = "integration"

--- a/crates/pcre2/Cargo.toml
+++ b/crates/pcre2/Cargo.toml
@@ -14,4 +14,4 @@ license = "Unlicense/MIT"
 
 [dependencies]
 grep-matcher = { version = "0.1.2", path = "../matcher" }
-pcre2 = "0.2.0"
+pcre2 = "0.2.3"

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -19,13 +19,13 @@ serde1 = ["base64", "serde", "serde_derive", "serde_json"]
 
 [dependencies]
 base64 = { version = "0.13.0", optional = true }
-bstr = "0.2.0"
+bstr = "0.2.14"
 grep-matcher = { version = "0.1.2", path = "../matcher" }
 grep-searcher = { version = "0.1.4", path = "../searcher" }
-termcolor = "1.0.4"
-serde = { version = "1.0.77", optional = true }
-serde_derive = { version = "1.0.77", optional = true }
-serde_json = { version = "1.0.27", optional = true }
+termcolor = "1.1.2"
+serde = { version = "1.0.119", optional = true }
+serde_derive = { version = "1.0.119", optional = true }
+serde_json = { version = "1.0.61", optional = true }
 
 [dev-dependencies]
 grep-regex = { version = "0.1.3", path = "../regex" }

--- a/crates/regex/Cargo.toml
+++ b/crates/regex/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["regex", "grep", "search", "pattern", "line"]
 license = "Unlicense/MIT"
 
 [dependencies]
-aho-corasick = "0.7.3"
-bstr = "0.2.10"
+aho-corasick = "0.7.15"
+bstr = "0.2.14"
 grep-matcher = { version = "0.1.2", path = "../matcher" }
-log = "0.4.5"
-regex = "1.1"
-regex-syntax = "0.6.5"
-thread_local = "1"
+log = "0.4.13"
+regex = "1.4.3"
+regex-syntax = "0.6.22"
+thread_local = "1.1.0"

--- a/crates/regex/src/word.rs
+++ b/crates/regex/src/word.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use grep_matcher::{Match, Matcher, NoError};
 use regex::bytes::{CaptureLocations, Regex};
-use thread_local::CachedThreadLocal;
+use thread_local::ThreadLocal;
 
 use config::ConfiguredHIR;
 use error::Error;
@@ -21,7 +21,7 @@ pub struct WordMatcher {
     /// A map from capture group name to capture group index.
     names: HashMap<String, usize>,
     /// A reusable buffer for finding the match location of the inner group.
-    locs: Arc<CachedThreadLocal<RefCell<CaptureLocations>>>,
+    locs: Arc<ThreadLocal<RefCell<CaptureLocations>>>,
 }
 
 impl Clone for WordMatcher {
@@ -33,7 +33,7 @@ impl Clone for WordMatcher {
             regex: self.regex.clone(),
             original: self.original.clone(),
             names: self.names.clone(),
-            locs: Arc::new(CachedThreadLocal::new()),
+            locs: Arc::new(ThreadLocal::new()),
         }
     }
 }
@@ -53,7 +53,7 @@ impl WordMatcher {
             pat
         })?;
         let regex = word_expr.regex()?;
-        let locs = Arc::new(CachedThreadLocal::new());
+        let locs = Arc::new(ThreadLocal::new());
 
         let mut names = HashMap::new();
         for (i, optional_name) in regex.capture_names().enumerate() {

--- a/crates/searcher/Cargo.toml
+++ b/crates/searcher/Cargo.toml
@@ -13,17 +13,17 @@ keywords = ["regex", "grep", "egrep", "search", "pattern"]
 license = "Unlicense/MIT"
 
 [dependencies]
-bstr = { version = "0.2.0", default-features = false, features = ["std"] }
-bytecount = "0.6"
-encoding_rs = "0.8.14"
-encoding_rs_io = "0.1.6"
+bstr = { version = "0.2.14", default-features = false, features = ["std"] }
+bytecount = "0.6.2"
+encoding_rs = "0.8.26"
+encoding_rs_io = "0.1.7"
 grep-matcher = { version = "0.1.2", path = "../matcher" }
-log = "0.4.5"
-memmap = "0.7"
+log = "0.4.13"
+memmap2 = "0.2.0"
 
 [dev-dependencies]
 grep-regex = { version = "0.1.3", path = "../regex" }
-regex = "1.1"
+regex = "1.4.3"
 
 [features]
 default = ["bytecount/runtime-dispatch-simd"]

--- a/crates/searcher/src/lib.rs
+++ b/crates/searcher/src/lib.rs
@@ -106,7 +106,7 @@ extern crate encoding_rs_io;
 extern crate grep_matcher;
 #[macro_use]
 extern crate log;
-extern crate memmap;
+extern crate memmap2;
 #[cfg(test)]
 extern crate regex;
 

--- a/crates/searcher/src/searcher/mmap.rs
+++ b/crates/searcher/src/searcher/mmap.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::path::Path;
 
-use memmap::Mmap;
+use memmap2::Mmap;
 
 /// Controls the strategy used for determining when to use memory maps.
 ///


### PR DESCRIPTION
Fixes #1785 

Originally replaced memmap with memmap2 per `cargo-audit`;
Also upgraded all dependencies