### PR TITLE
Add *.BUILD and *.bazelrc patterns to the default bazel type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -21,7 +21,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("ats", &["*.ats", "*.dats", "*.sats", "*.hats"]),
     ("avro", &["*.avdl", "*.avpr", "*.avsc"]),
     ("awk", &["*.awk"]),
-    ("bazel", &["*.bazel", "*.bzl", "BUILD", "WORKSPACE"]),
+    ("bazel", &["*.bazel", "*.bzl", "*.BUILD", "BUILD", "WORKSPACE"]),
     ("bitbake", &["*.bb", "*.bbappend", "*.bbclass", "*.conf", "*.inc"]),
     ("brotli", &["*.br"]),
     ("buildstream", &["*.bst"]),

--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -21,7 +21,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("ats", &["*.ats", "*.dats", "*.sats", "*.hats"]),
     ("avro", &["*.avdl", "*.avpr", "*.avsc"]),
     ("awk", &["*.awk"]),
-    ("bazel", &["*.bazel", "*.bzl", "*.BUILD", "BUILD", "WORKSPACE"]),
+    ("bazel", &["*.bazel", "*.bzl", "*.BUILD", "*.bazelrc", "BUILD", "WORKSPACE"]),
     ("bitbake", &["*.bb", "*.bbappend", "*.bbclass", "*.conf", "*.inc"]),
     ("brotli", &["*.br"]),
     ("buildstream", &["*.bst"]),


### PR DESCRIPTION
It's common to use `foo.BUILD` for the external workspaces `@foo` build files in bazel.
Example from pytorch https://github.com/pytorch/pytorch/blob/master/third_party/cpuinfo.BUILD
See more files like that in the same folder.

Also, add `*.bazelrc` pattern while we are here.
https://docs.bazel.build/versions/master/guide.html#bazelrc-the-bazel-configuration-file

The default one used by bazel is just plain `.bazelrc`, but it's common to use `user.bazelrc` and other named groupings and import them from the top-level one.