### PR TITLE
Prevent crash when user provides bad input.

### DIFF
--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -269,12 +269,18 @@ impl LineTerminator {
 
     /// Returns true if and only if the given slice ends with this line
     /// terminator.
-    ///
-    /// If this line terminator is `CRLF`, then this only checks whether the
-    /// last byte is `\n`.
     #[inline]
     pub fn is_suffix(&self, slice: &[u8]) -> bool {
-        slice.last().map_or(false, |&b| b == self.as_byte())
+        match self.0 {
+            LineTerminatorImp::Byte(b) => {
+                // SAFETY: `b` index of 0 here is safe because it is a stack allocated [u8;1]
+                slice.last().map_or(false, |&c| c == b[0])
+            }
+            LineTerminatorImp::CRLF => match slice {
+                [.., cr, lf] => *cr == b'\r' && *lf == b'\n',
+                _ => false,
+            },
+        }
     }
 }
 


### PR DESCRIPTION
Running "echo '' | rg --crlf x?" should no longer crash.
I probably introduced performance regressions haha

Related issue: https://github.com/BurntSushi/ripgrep/issues/1765

aww shucks, sublice pattern is unstable. If you really want this, I could reimplement it using more backward compat ways.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>