### PR TITLE
Cargo.toml: try to make release binaries smaller

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,9 @@ pcre2 = ["grep/pcre2"]
 
 [profile.release]
 debug = 1
+lto = true
+codegen-units = 1
+opt-level = 3
 
 [package.metadata.deb]
 features = ["pcre2"]


### PR DESCRIPTION
Hello Andrew (and other contributors)! First off, congrats. on the great project ;)

This PR consists in
* Activating "fat" link-time optimization;
* Compiling on a single code generation unit;
* Setting `opt-level` to 3.

The most obvious (and possibly the only) downside I can see are slightly longer compilation times.

Compiling the latest (at the time of writing) `ripgrep` (master): 

```
    Finished release [optimized + debuginfo] target(s) in 1m 23s
```

Compiling `ripgrep` with this PR's `Cargo.toml`:

```
    Finished release [optimized + debuginfo] target(s) in 1m 29s
```

Both running on an AMD 4x 3.8GHz CPU, Linux 5.10.15 and a similarly undisturbed OS.

This is, of course, not the most scientific of tests but shows that the build time delta is not big.

The result in binary sizes are

```bash
$ du -sh rg
27M     rg           # Current Cargo.toml 
```

```bash
$ du -sh rg
18M     rg           # This PR's proposal
```

This is only anecdotal, but a 7.22% increase in build time gave us a 33.3% decrease in binary size, which seems (to me) a worthwhile investment.





