### PR TITLE
Compile under WASI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,10 @@ jobs:
         - build: win-gnu
           os: windows-2019
           rust: nightly-x86_64-gnu
+        - build: stable-wasi
+          os: ubuntu-18.04
+          rust: stable
+          target: wasm32-wasi
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -103,6 +107,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
         profile: minimal
         override: true
+        target: ${{ matrix.target }}
 
     - name: Use Cross
       if: matrix.target != ''
@@ -118,10 +123,11 @@ jobs:
         echo "target flag is: ${{ env.TARGET_FLAGS }}"
 
     - name: Build ripgrep and all crates
-      run: ${{ env.CARGO }} build --verbose --all ${{ env.TARGET_FLAGS }}
+      run: ${{ env.CARGO }} build --verbose --all ${{ env.TARGET_FLAGS }} --exclude grep-pcre2
 
     - name: Build ripgrep with PCRE2
       run: ${{ env.CARGO }} build --verbose --all --features pcre2 ${{ env.TARGET_FLAGS }}
+      if: matrix.target != 'wasm32-wasi'
 
     # This is useful for debugging problems when the expected build artifacts
     # (like shell completions and man pages) aren't generated.
@@ -146,7 +152,7 @@ jobs:
       # Every integration test spins up qemu to run 'rg', and when PCRE2 is
       # enabled, every integration test is run twice: one with the default
       # regex engine and once with PCRE2.
-      if: matrix.target != ''
+      if: matrix.target != '' && matrix.target != 'wasm32-wasi'
       run: ${{ env.CARGO }} test --verbose --all ${{ env.TARGET_FLAGS }}
 
     - name: Test for existence of build artifacts (Windows)

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -222,6 +222,11 @@ pub fn is_readable_stdin() -> bool {
             .unwrap_or(false)
     }
 
+    #[cfg(not(any(unix, windows)))]
+    fn imp() -> bool {
+        false
+    }
+
     !is_tty_stdin() && imp()
 }
 

--- a/crates/searcher/Cargo.toml
+++ b/crates/searcher/Cargo.toml
@@ -19,6 +19,8 @@ encoding_rs = "0.8.14"
 encoding_rs_io = "0.1.6"
 grep-matcher = { version = "0.1.2", path = "../matcher" }
 log = "0.4.5"
+
+[target.'cfg(any(unix, windows))'.dependencies]
 memmap = { package = "memmap2", version = "0.2.0" }
 
 [dev-dependencies]

--- a/crates/searcher/src/lib.rs
+++ b/crates/searcher/src/lib.rs
@@ -106,6 +106,7 @@ extern crate encoding_rs_io;
 extern crate grep_matcher;
 #[macro_use]
 extern crate log;
+#[cfg(any(unix, windows))]
 extern crate memmap;
 #[cfg(test)]
 extern crate regex;

--- a/crates/searcher/src/searcher/mmap.rs
+++ b/crates/searcher/src/searcher/mmap.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::path::Path;
 
+#[cfg(any(unix, windows))]
 use memmap::Mmap;
 
 /// Controls the strategy used for determining when to use memory maps.
@@ -63,6 +64,7 @@ impl MmapChoice {
     /// If this does attempt to open a memory map and it fails, then `None`
     /// is returned and the corresponding error (along with the file path, if
     /// present) is logged at the debug level.
+    #[cfg(any(unix, windows))]
     pub(crate) fn open(
         &self,
         file: &File,

--- a/crates/searcher/src/searcher/mod.rs
+++ b/crates/searcher/src/searcher/mod.rs
@@ -658,9 +658,12 @@ impl Searcher {
         M: Matcher,
         S: Sink,
     {
-        if let Some(mmap) = self.config.mmap.open(file, path) {
-            trace!("{:?}: searching via memory map", path);
-            return self.search_slice(matcher, &mmap, write_to);
+        #[cfg(any(windows, unix))]
+        {
+            if let Some(mmap) = self.config.mmap.open(file, path) {
+                trace!("{:?}: searching via memory map", path);
+                return self.search_slice(matcher, &mmap, write_to);
+            }
         }
         // Fast path for multi-line searches of files when memory maps are
         // not enabled. This pre-allocates a buffer roughly the size of the


### PR DESCRIPTION
Hi, and thank you for this awesome tool.

I'm currently playing around with porting some [Rust Alternative Command Line Tools](https://zaiste.net/posts/shell-commands-rust/) to wasm32-wasi. For most tools, this requires some rather unsavoury code changes, but rg is a pretty exception. So I decided to see if you don't want to add support for wasi as a compilation target.

I did say "pretty", but there are some points…
* memmap2 does not want to compile under anything except windows and unix ([conscious decision](https://github.com/RazrFalcon/memmap2-rs/pull/10#issuecomment-778788586)), so it requires some macros
* I did default `is_readable_stdin` to false on unsupported platforms (because same_file returns errors on unsupported platforms, and imp translates errors to false), but I'm not sure that is correct. Would it be better to panic, or leave the function unimplemented on unsupported platforms?
* PCRE2 won't build since it requires(?) pthreads
* Cross can't run tests on wasm32-wasi