### PR TITLE
Document glob alternatives syntax with {}

### DIFF
--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -1354,6 +1354,10 @@ used. Globbing rules match .gitignore globs. Precede a glob with a ! to exclude
 it. If multiple globs match a file or directory, the glob given later in the
 command line takes precedence.
 
+As an extension, globs support specifying alternatives: '-g ab{c,d}' is
+equivalet to '-g abc -g abd'. Empty alternatives ('-g ab{,c}') are not
+currently supported.
+
 When this flag is set, every file and directory is applied to it to test for
 a match. So for example, if you only want to search in a particular directory
 'foo', then *-g foo* is incorrect because 'foo/bar' does not match the glob


### PR DESCRIPTION
This syntax does not exist in `git`, so it is not documented in `man gitignore`. There is
a question of whether it *should* exist, but as long as it does, it should be documented
somewhere.

See also:
https://github.com/BurntSushi/ripgrep/issues/1221
https://github.com/BurntSushi/ripgrep/issues/1368

-------

**Update 1:** I'm especially interested in documenting the lack of empty alternatives, since the reason I
started looking for documentation is that I couldn't figure out whether `-g .git{,/*}` *should*
work.

**Update 2:** I like this syntax, but I'd prefer it if it was only valid in the command line (as opposed to ignore files), FWIW. That is, as long as having a slightly different syntax in the command line doesn't introduce too much complexity.