### PR TITLE
ci: fix deb build script in clean checkout

### DIFF
--- a/ci/build-deb
+++ b/ci/build-deb
@@ -17,16 +17,21 @@ if ! command -V cargo-deb > /dev/null 2>&1; then
     exit 1
 fi
 
+if ! command -V asciidoctor > /dev/null 2>&1; then
+    echo "asciidoctor command missing" >&2
+    exit 1
+fi
+
 # 'cargo deb' does not seem to provide a way to specify an asset that is
 # created at build time, such as ripgrep's man page. To work around this,
 # we force a debug build, copy out the man page (and shell completions)
 # produced from that build, put it into a predictable location and then build
 # the deb, which knows where to look.
+cargo build
 
 DEPLOY_DIR=deployment/deb
 OUT_DIR="$("$D"/cargo-out-dir target/debug/)"
 mkdir -p "$DEPLOY_DIR"
-cargo build
 
 # Copy man page and shell completions.
 cp "$OUT_DIR"/{rg.1,rg.bash,rg.fish} "$DEPLOY_DIR/"


### PR DESCRIPTION
If ripgrep hasn't been built yet (i.e. target/debug/ doesn't exist),
then cargo-out-dir can't find OUT_DIR and the copy commands fail. Fix by
running cargo build before finding OUT_DIR.

Also add a check to fail early with a sensible error message when
asciidoctor isn't installed, rather than failing because of a missing
rg.1 file after the build.