### PR TITLE
fix: Clarify the help of --files-with-matches and --files-without-match

### DIFF
--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -1266,10 +1266,10 @@ This is useful to determine whether a particular file is being searched or not.
 }
 
 fn flag_files_with_matches(args: &mut Vec<RGArg>) {
-    const SHORT: &str = "Only print the paths with at least one match.";
+    const SHORT: &str = "Print the paths with at least one match.";
     const LONG: &str = long!(
         "\
-Only print the paths with at least one match.
+Print the paths with at least one match and suppress match contents.
 
 This overrides --files-without-match.
 "
@@ -1283,11 +1283,11 @@ This overrides --files-without-match.
 }
 
 fn flag_files_without_match(args: &mut Vec<RGArg>) {
-    const SHORT: &str = "Only print the paths that contain zero matches.";
+    const SHORT: &str = "Print the paths that contain zero matches.";
     const LONG: &str = long!(
         "\
-Only print the paths that contain zero matches. This inverts/negates the
---files-with-matches flag.
+Print the paths that contain zero matches and suppress match contents. This
+inverts/negates the --files-with-matches flag.
 
 This overrides --files-with-matches.
 "


### PR DESCRIPTION
See
https://github.com/BurntSushi/ripgrep/issues/103#issuecomment-763083510

I was confused as to the meaning of these options and tried to clarify their descriptions.