### PR TITLE
core: Add field-match-separator and field-context-separator

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -314,6 +314,8 @@ _rg() {
     "--no-config[don't load configuration files]"
     '(-0 --null)'{-0,--null}'[print NUL byte after file names]'
     '--path-separator=[specify path separator to use when printing file names]:separator'
+    '--field-match-separator=[specify field match separator to use when printing file names]:separator'
+    '--field-context-separator=[specify field context separator to use when printing file names]:separator'
     '(-q --quiet)'{-q,--quiet}'[suppress normal output]'
     '--regex-size-limit=[specify upper size limit of compiled regex]:regex size (bytes)'
     '*'{-u,--unrestricted}'[reduce level of "smart" searching]'

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -614,6 +614,8 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_one_file_system(&mut args);
     flag_only_matching(&mut args);
     flag_path_separator(&mut args);
+    flag_field_match_separator(&mut args);
+    flag_field_context_separator(&mut args);
     flag_passthru(&mut args);
     flag_pcre2(&mut args);
     flag_pcre2_version(&mut args);
@@ -2334,6 +2336,34 @@ cygwin). A path separator is limited to a single byte.
     );
     let arg =
         RGArg::flag("path-separator", "SEPARATOR").help(SHORT).long_help(LONG);
+    args.push(arg);
+}
+
+fn flag_field_match_separator(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Set the field match separator.";
+    const LONG: &str = long!(
+        "\
+Set the field match separator to use when printing file paths. This defaults to
+:. A field match separator is limited to a single byte.
+"
+    );
+    let arg = RGArg::flag("field-match-separator", "SEPARATOR")
+        .help(SHORT)
+        .long_help(LONG);
+    args.push(arg);
+}
+
+fn flag_field_context_separator(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Set the field context separator.";
+    const LONG: &str = long!(
+        "\
+Set the field context separator to use when printing file paths. This defaults to
+-. A field context separator is limited to a single byte.
+"
+    );
+    let arg = RGArg::flag("field-context-separator", "SEPARATOR")
+        .help(SHORT)
+        .long_help(LONG);
     args.push(arg);
 }
 


### PR DESCRIPTION
This allows for the customization of the match and context separators. The match separator defaults to `:`, while the context separator defaults to `-`. Both are limited to a single byte.

Closes #1842