### PR TITLE
Updated formatting of nested list in GUIDE.md

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -178,11 +178,9 @@ search. By default, when you search a directory, ripgrep will ignore all of
 the following:
 
 1. Files and directories that match glob patterns in these three categories:
-  1. gitignore globs (including global and repo-specific globs).
-  2. `.ignore` globs, which take precedence over all gitignore globs when
-     there's a conflict.
-  3. `.rgignore` globs, which take precedence over all `.ignore` globs when
-     there's a conflict.
+      1. gitignore globs (including global and repo-specific globs).
+      2. `.ignore` globs, which take precedence over all gitignore globs when there's a conflict.
+      3. `.rgignore` globs, which take precedence over all `.ignore` globs when there's a conflict.
 2. Hidden files and directories.
 3. Binary files. (ripgrep considers any file with a `NUL` byte to be binary.)
 4. Symbolic links aren't followed.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -181,7 +181,7 @@ the following:
       1. gitignore globs (including global and repo-specific globs).
       2. `.ignore` globs, which take precedence over all gitignore globs
          when there's a conflict.
-      4. `.rgignore` globs, which take precedence over all `.ignore` globs
+      3. `.rgignore` globs, which take precedence over all `.ignore` globs
          when there's a conflict.
 2. Hidden files and directories.
 3. Binary files. (ripgrep considers any file with a `NUL` byte to be binary.)

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -179,8 +179,10 @@ the following:
 
 1. Files and directories that match glob patterns in these three categories:
       1. gitignore globs (including global and repo-specific globs).
-      2. `.ignore` globs, which take precedence over all gitignore globs when there's a conflict.
-      3. `.rgignore` globs, which take precedence over all `.ignore` globs when there's a conflict.
+      2. `.ignore` globs, which take precedence over all gitignore globs
+         when there's a conflict.
+      4. `.rgignore` globs, which take precedence over all `.ignore` globs
+         when there's a conflict.
 2. Hidden files and directories.
 3. Binary files. (ripgrep considers any file with a `NUL` byte to be binary.)
 4. Symbolic links aren't followed.


### PR DESCRIPTION
Updated formatting of nested list in file `GUIDE.md`

Github expects 4 spaces or a single tab before nested items inside list.