### PR TITLE
Correct types for crystal

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -40,7 +40,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
         "*.[ChH].in", "*.cc.in", "*.[ch]pp.in", "*.[ch]xx.in", "*.hh.in",
     ]),
     ("creole", &["*.creole"]),
-    ("crystal", &["*.cr", "*.ecr", "shard.yml"]),
+    ("crystal", &["Projectfile", "*.cr", "*.ecr", "shard.yml"]),
     ("cs", &["*.cs"]),
     ("csharp", &["*.cs"]),
     ("cshtml", &["*.cshtml"]),

--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -40,7 +40,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
         "*.[ChH].in", "*.cc.in", "*.[ch]pp.in", "*.[ch]xx.in", "*.hh.in",
     ]),
     ("creole", &["*.creole"]),
-    ("crystal", &["Projectfile", "*.cr"]),
+    ("crystal", &["*.cr", "*.ecr", "shard.yml"]),
     ("cs", &["*.cs"]),
     ("csharp", &["*.cs"]),
     ("cshtml", &["*.cshtml"]),


### PR DESCRIPTION
Instead of Projectfile used shard.yml (since some years). Also add ecr, crystal template type.