### PR TITLE
globset: make 'log' an optional dep

### DIFF
--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -23,7 +23,7 @@ bench = false
 aho-corasick = "0.7.3"
 bstr = { version = "0.2.0", default-features = false, features = ["std"] }
 fnv = "1.0.6"
-log = "0.4.5"
+log = { version = "0.4.5", optional = true }
 regex = { version = "1.1.5", default-features = false, features = ["perf", "std"] }
 serde = { version = "1.0.104", optional = true }
 
@@ -33,5 +33,6 @@ lazy_static = "1"
 serde_json = "1.0.45"
 
 [features]
+default = ["log"]
 simd-accel = []
 serde1 = ["serde"]

--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -125,6 +125,16 @@ mod pathutil;
 #[cfg(feature = "serde1")]
 mod serde_impl;
 
+#[cfg(feature = "log")]
+macro_rules! debug {
+    ($($token:tt)*) => (::log::debug!($($token)*);)
+}
+
+#[cfg(not(feature = "log"))]
+macro_rules! debug {
+    ($($token:tt)*) => {};
+}
+
 /// Represents an error that can occur when parsing a glob pattern.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Error {
@@ -413,12 +423,12 @@ impl GlobSet {
                     required_exts.add(i, ext, p.regex().to_owned());
                 }
                 MatchStrategy::Regex => {
-                    log::debug!("glob converted to regex: {:?}", p);
+                    debug!("glob converted to regex: {:?}", p);
                     regexes.add(i, p.regex().to_owned());
                 }
             }
         }
-        log::debug!(
+        debug!(
             "built glob set; {} literals, {} basenames, {} extensions, \
                 {} prefixes, {} suffixes, {} required extensions, {} regexes",
             lits.0.len(),


### PR DESCRIPTION
As in the title. Would be nice to avoid the dependency (and the transitive dependency on `cfg-if`) when `log` isn't being used. Made it a default so logs remain when updating the crate.

As an aside, does the `simd-accel` feature do anything in `globset`?