### PR TITLE
New option: Stop on non-match after a match

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -319,6 +319,7 @@ _rg() {
     '(-q --quiet)'{-q,--quiet}'[suppress normal output]'
     '--regex-size-limit=[specify upper size limit of compiled regex]:regex size (bytes)'
     '*'{-u,--unrestricted}'[reduce level of "smart" searching]'
+    '--stop-on-nonmatch[stop on first non-matching line after a matching one]'
 
     + operand # Operands
     '(--files --type-list file regexp)1: :_guard "^-*" pattern'

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -644,6 +644,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_vimgrep(&mut args);
     flag_with_filename(&mut args);
     flag_word_regexp(&mut args);
+    flag_stop_on_nonmatch(&mut args);
     args
 }
 
@@ -3105,5 +3106,25 @@ This overrides the --line-regexp flag.
         .help(SHORT)
         .long_help(LONG)
         .overrides("line-regexp");
+    args.push(arg);
+}
+
+fn flag_stop_on_nonmatch(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "After a successful match in a file, stop reading the file once a non-matching line is found.";
+    const LONG: &str = long!(
+        "\
+Enabling this option will cause ripgrep to stop reading a file once it encounters
+a non-matching line after it has encountered a matching one. This is useful if it
+is expected that all matches in a given file will be on sequential lines, for example
+due to the files being sorted and the pattern being matched on being at the start
+of the line.
+
+This overrides the -U/--multiline flag.
+"
+    );
+    let arg = RGArg::switch("stop-on-nonmatch")
+        .help(SHORT)
+        .long_help(LONG)
+        .overrides("multiline");
     args.push(arg);
 }

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -840,7 +840,8 @@ impl ArgMatches {
             .before_context(ctx_before)
             .after_context(ctx_after)
             .passthru(self.is_present("passthru"))
-            .memory_map(self.mmap_choice(paths));
+            .memory_map(self.mmap_choice(paths))
+            .stop_on_nonmatch(self.is_present("stop-on-nonmatch"));
         match self.encoding()? {
             EncodingMode::Some(enc) => {
                 builder.encoding(Some(enc));

--- a/crates/searcher/src/searcher/glue.rs
+++ b/crates/searcher/src/searcher/glue.rs
@@ -14,6 +14,7 @@ pub struct ReadByLine<'s, M, R, S> {
     config: &'s Config,
     core: Core<'s, M, S>,
     rdr: LineBufferReader<'s, R>,
+    stop_on_nonmatch: bool,
 }
 
 impl<'s, M, R, S> ReadByLine<'s, M, R, S>
@@ -27,6 +28,7 @@ where
         matcher: M,
         read_from: LineBufferReader<'s, R>,
         write_to: S,
+        stop_on_nonmatch: bool,
     ) -> ReadByLine<'s, M, R, S> {
         debug_assert!(!searcher.multi_line_with_matcher(&matcher));
 
@@ -34,6 +36,7 @@ where
             config: &searcher.config,
             core: Core::new(searcher, matcher, write_to, false),
             rdr: read_from,
+            stop_on_nonmatch: stop_on_nonmatch,
         }
     }
 

--- a/crates/searcher/src/searcher/mod.rs
+++ b/crates/searcher/src/searcher/mod.rs
@@ -173,6 +173,8 @@ pub struct Config {
     encoding: Option<Encoding>,
     /// Whether to do automatic transcoding based on a BOM or not.
     bom_sniffing: bool,
+    /// Whether to stop searching when a non-matching line is found after a match.
+    stop_on_nonmatch: bool,
 }
 
 impl Default for Config {
@@ -190,6 +192,7 @@ impl Default for Config {
             multi_line: false,
             encoding: None,
             bom_sniffing: true,
+            stop_on_nonmatch: false,
         }
     }
 }
@@ -555,6 +558,18 @@ impl SearcherBuilder {
         self.config.bom_sniffing = yes;
         self
     }
+
+    /// Stop searching a file when a non-matching line is found after a matching one.
+    ///
+    /// This is useful for searching sorted files where it is expected that all
+    /// the matches will be on adjacent lines.
+    pub fn stop_on_nonmatch(
+        &mut self,
+        stop_on_nonmatch: bool,
+    ) -> &mut SearcherBuilder {
+        self.config.stop_on_nonmatch = stop_on_nonmatch;
+        self
+    }
 }
 
 /// A searcher executes searches over a haystack and writes results to a caller
@@ -732,7 +747,14 @@ impl Searcher {
             let mut line_buffer = self.line_buffer.borrow_mut();
             let rdr = LineBufferReader::new(decoder, &mut *line_buffer);
             log::trace!("generic reader: searching via roll buffer strategy");
-            ReadByLine::new(self, matcher, rdr, write_to).run()
+            ReadByLine::new(
+                self,
+                matcher,
+                rdr,
+                write_to,
+                self.stop_on_nonmatch(),
+            )
+            .run()
         }
     }
 
@@ -836,6 +858,13 @@ impl Searcher {
     #[inline]
     pub fn multi_line(&self) -> bool {
         self.config.multi_line
+    }
+
+    /// Returns true if and only if this searcher is configured to stop
+    /// when in finds a non-matching line after a matching one.
+    #[inline]
+    pub fn stop_on_nonmatch(&self) -> bool {
+        self.config.stop_on_nonmatch
     }
 
     /// Returns true if and only if this searcher will choose a multi-line

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -975,3 +975,10 @@ rgtest!(no_unicode, |dir: Dir, mut cmd: TestCommand| {
     dir.create("test", "δ");
     cmd.arg("-i").arg("--no-unicode").arg("Δ").assert_err();
 });
+
+// See: https://github.com/BurntSushi/ripgrep/issues/1790
+rgtest!(stop_on_nonmatch, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("test", "line1\nline2\nline3\nline4\nline5");
+    cmd.args(&["--stop-on-nonmatch", "[235]"]);
+    eqnice!("test:line2\ntest:line3\n", cmd.stdout());
+});


### PR DESCRIPTION
Closes https://github.com/BurntSushi/ripgrep/issues/1790

This implements the option suggested in the linked issue. In particular, it adds a `--stop-on-nonmatch` flag that will stop reading a file once a non-matching line is found after a matching one. This is useful if, for example, a sorted file is being searched and the pattern being matched on is at the start of the line (so it is expected all matches will be adjacent).