### PR TITLE
Reduce `.crate` file size from 272 KB to 168 KB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,14 @@ repository = "https://github.com/BurntSushi/ripgrep"
 keywords = ["regex", "grep", "egrep", "search", "pattern"]
 categories = ["command-line-utilities", "text-processing"]
 license = "Unlicense OR MIT"
-exclude = ["HomebrewFormula"]
+exclude = [
+  "HomebrewFormula",
+  "/.github/",
+  "/ci/",
+  "/pkg/",
+  "/benchsuite/",
+  "/scripts/",
+]
 build = "build.rs"
 autotests = false
 edition = "2018"


### PR DESCRIPTION
The `ripgrep` crate currently includes test data, benchmark results, continuous integration configuration, and a few other miscellaneous items in its `.crate` file, bloating its size significantly ([crates.io](https://crates.io/crates/ripgrep) shows it presently weighs in at 272 KB). The changes in this PR ensure that these files are excluded from the `.crate` file going forward.