### PR TITLE
Force binary existance check

### DIFF
--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -132,7 +132,7 @@ impl DecompressionMatcherBuilder {
         A: AsRef<OsStr>,
     {
         let glob = glob.to_string();
-        let bin = resolve_binary(Path::new(program.as_ref()))?;
+        let bin = try_resolve_binary(Path::new(program.as_ref()), true)?;
         let args =
             args.into_iter().map(|a| a.as_ref().to_os_string()).collect();
         self.commands.push(DecompressionCommand { glob, bin, args });
@@ -419,8 +419,37 @@ impl io::Read for DecompressionReader {
 /// this explicitly, and thus, desires this behavior.
 ///
 /// On non-Windows, this is a no-op.
+///
+/// Callers should prefer `try_resolve_binary` which does not skip searching
+/// the path to verify the existence of a binary on non-Windows.
 pub fn resolve_binary<P: AsRef<Path>>(
     prog: P,
+) -> Result<PathBuf, CommandError> {
+    try_resolve_binary(prog, cfg!(windows))
+}
+
+/// Resolves a path to a program to a path by searching for the program in
+/// `PATH`.
+///
+/// If the program could not be resolved, then an error is returned.
+///
+/// The purpose of doing this instead of passing the path to the program
+/// directly to Command::new is that Command::new will hand relative paths
+/// to CreateProcess on Windows, which will implicitly search the current
+/// working directory for the executable. This could be undesirable for
+/// security reasons. e.g., running ripgrep with the -z/--search-zip flag on an
+/// untrusted directory tree could result in arbitrary programs executing on
+/// Windows.
+///
+/// Note that this could still return a relative path if PATH contains a
+/// relative path. We permit this since it is assumed that the user has set
+/// this explicitly, and thus, desires this behavior.
+///
+/// If `check_exists` is false or the path is already an absolute path this will
+/// return immediately.
+fn try_resolve_binary<P: AsRef<Path>>(
+    prog: P,
+    check_exists: bool,
 ) -> Result<PathBuf, CommandError> {
     use std::env;
 
@@ -433,7 +462,7 @@ pub fn resolve_binary<P: AsRef<Path>>(
     }
 
     let prog = prog.as_ref();
-    if !cfg!(windows) || prog.is_absolute() {
+    if !check_exists || prog.is_absolute() {
         return Ok(prog.to_path_buf());
     }
     let syspaths = match env::var_os("PATH") {


### PR DESCRIPTION
This PR allows for explicit checking for binary existence when using the `associate` and `try_associate` methods on the `DecompressionMatcherBuilder`. I have tried to preserve the current `resolve_binary` api being a no-op on non-windows as well.

Currently, a use tries to `{try_}associate` a program on a non-windows OS, `resolve_binary` no-ops and never checks the path to see if that binary actually exists or not.

This change forces a path check for existence even on non-windows OS so that a user can try to associate several different binaries with a glob and only the binaries found on the system will be associated.

Concrete example: https://github.com/sstadick/hck/blob/f5aca37b0a06523074fe229fa77bb863e4f8574c/src/lib/core.rs#L365

I want to associate `pigz` with `*.gz` only if `pigz` is installed on the users system, otherwise it can fail and `gzip` can be used. Currently `pigz` is not actually tested for existence, it's added as a matcher and then fails to find it when called resulting in no decompression happening. 