### PR TITLE
Add dependabot config for cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
Creates update PRs similar to https://github.com/dbast/ripgrep/pulls with history etc for review.

PRs can be merged if CI is green or closed to ignore the dependency regarding auto updates.