### PR TITLE
doc: install a ripgrep.1 symlink

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -106,6 +106,14 @@ fn generate_man_page<P: AsRef<Path>>(outdir: P) -> io::Result<()> {
             format!("'asciidoctor' failed with exit code {:?}", result.code());
         return Err(ioerr(msg));
     }
+
+    if cfg!(unix) {
+        std::os::unix::fs::symlink(
+            outdir.join("rg.1"),
+            outdir.join("ripgrep.1"),
+        )?;
+    }
+
     Ok(())
 }
 
@@ -147,6 +155,14 @@ fn legacy_generate_man_page<P: AsRef<Path>>(outdir: P) -> io::Result<()> {
         let msg = format!("'a2x' failed with exit code {:?}", result.code());
         return Err(ioerr(msg));
     }
+
+    if cfg!(unix) {
+        std::os::unix::fs::symlink(
+            outdir.join("rg.1"),
+            outdir.join("ripgrep.1"),
+        )?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
This makes it easier to find the manpage when you first install ripgrep, since `man ripgrep` will work.

This is basically the first Rust code I've ever written; please don't assume I know what I'm doing (but this is so trivial it seems difficult to screw up, hopefully?). I did, however, test both of the modified functions.