### PR TITLE
Add vimrc to vim and vimscript types

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -240,8 +240,8 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("vcl", &["*.vcl"]),
     ("verilog", &["*.v", "*.vh", "*.sv", "*.svh"]),
     ("vhdl", &["*.vhd", "*.vhdl"]),
-    ("vim", &["*.vim"]),
-    ("vimscript", &["*.vim"]),
+    ("vim", &["*.vim", "*vimrc"]),
+    ("vimscript", &["*.vim", "*vimrc"]),
     ("webidl", &["*.idl", "*.webidl", "*.widl"]),
     ("wiki", &["*.mediawiki", "*.wiki"]),
     ("xml", &[


### PR DESCRIPTION
This adds `*vimrc` to the vim and vimscript file types. Often this will
match `~/.vimrc` but given how unambiguous this is I think matching
more potential options like `~/.ideavimrc` (Intellij's vim plugin
configuration file) and others makes sense.