### PR TITLE
Handle smart case per each pattern separately

### DIFF
--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -2695,7 +2695,9 @@ fn flag_smart_case(args: &mut Vec<RGArg>) {
     const LONG: &str = long!(
         "\
 Searches case insensitively if the pattern is all lowercase. Search case
-sensitively otherwise.
+sensitively otherwise. Every individual search pattern follow this rule
+by itself, including PATTERN specified by -e and patterns in PATTERNFILE
+specified by -f.
 
 A pattern is considered all lowercase if both of the following rules hold:
 

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -691,7 +691,7 @@ impl ArgMatches {
         let res = if self.is_present("fixed-strings") {
             builder.build_literals(patterns)
         } else {
-            builder.build(&patterns.join("|"))
+            builder.build_patterns(patterns)
         };
         match res {
             Ok(m) => Ok(m),
@@ -738,7 +738,7 @@ impl ArgMatches {
         if self.is_present("crlf") {
             builder.crlf(true);
         }
-        Ok(builder.build(&patterns.join("|"))?)
+        Ok(builder.build_patterns(patterns)?)
     }
 
     /// Build a JSON printer that writes results to the given writer.

--- a/crates/regex/src/matcher.rs
+++ b/crates/regex/src/matcher.rs
@@ -43,7 +43,18 @@ impl RegexMatcherBuilder {
     /// The syntax supported is documented as part of the regex crate:
     /// <https://docs.rs/regex/#syntax>.
     pub fn build(&self, pattern: &str) -> Result<RegexMatcher, Error> {
-        let chir = self.config.hir(pattern)?;
+        self.build_patterns(&[pattern])
+    }
+
+    /// Build a new matcher using multiple patterns.
+    ///
+    /// The syntax supported is documented as part of the regex crate:
+    /// <https://docs.rs/regex/#syntax>.
+    pub fn build_patterns<B: AsRef<str>>(
+        &self,
+        patterns: &[B],
+    ) -> Result<RegexMatcher, Error> {
+        let chir = self.config.hir(patterns)?;
         let fast_line_regex = chir.fast_line_regex()?;
         let non_matching_bytes = chir.non_matching_bytes();
         if let Some(ref re) = fast_line_regex {
@@ -125,6 +136,9 @@ impl RegexMatcherBuilder {
     /// 2. Of the literals in the pattern, none of them are considered to be
     ///    uppercase according to Unicode. For example, `foo\pL` has no
     ///    uppercase literals but `Foo\pL` does.
+    ///
+    /// If multiple patterns are passed to `build_patterns()`, each pattern is
+    /// treated separately.
     pub fn case_smart(&mut self, yes: bool) -> &mut RegexMatcherBuilder {
         self.config.case_smart = yes;
         self

--- a/crates/regex/src/word.rs
+++ b/crates/regex/src/word.rs
@@ -195,7 +195,7 @@ mod tests {
     use grep_matcher::{Captures, Match, Matcher};
 
     fn matcher(pattern: &str) -> WordMatcher {
-        let chir = Config::default().hir(pattern).unwrap();
+        let chir = Config::default().hir(&[pattern]).unwrap();
         WordMatcher::new(&chir).unwrap()
     }
 

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -828,6 +828,13 @@ rgtest!(f1404_nothing_searched_ignored, |dir: Dir, mut cmd: TestCommand| {
     eqnice!(expected, stderr);
 });
 
+// See: https://github.com/BurntSushi/ripgrep/issues/1791
+rgtest!(f1791_multiple_smart_case_exprs, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("test", "foo\nfOo\nbar\nbAr\n");
+    cmd.args(&["--smart-case", "-e", "foo", "-e", "bAr"]);
+    eqnice!("test:foo\ntest:fOo\ntest:bAr\n", cmd.stdout());
+});
+
 // See: https://github.com/BurntSushi/ripgrep/issues/1842
 rgtest!(f1842_field_context_separator, |dir: Dir, _: TestCommand| {
     dir.create("sherlock", SHERLOCK);


### PR DESCRIPTION
When `-S`/`--smart-case` is enabled, analyze and apply a case-insensitivity flag to each search pattern separately rather than globally.

For the PCRE2 engine, wrap case-insensitive expressions into `(?i:…)`. I.e. `rg --pcre2 --smart-case -e foo -e bAr` gives `(?i:foo)|bAr`.

For the default engine, produce each expression HIR separately, then combine them using `Hir::alternation`.  Although the PCRE2 approach is also possible, it turned out to be slower on large pattern files.

Fixes #1791

---

As a side effect, each pattern is validated separately in the default engine; thus, this no longer works:
```
$ rg -e "something(" -e ")something"
regex parse error:
    something(
             ^
error: unclosed group
```
Also, this could be considered as a first step in fixing #478.