### PR TITLE
Re-enable mmap on 32-bit architectures

### DIFF
--- a/crates/searcher/src/searcher/mmap.rs
+++ b/crates/searcher/src/searcher/mmap.rs
@@ -71,16 +71,6 @@ impl MmapChoice {
         if !self.is_enabled() {
             return None;
         }
-        if !cfg!(target_pointer_width = "64") {
-            // For 32-bit systems, it looks like mmap will succeed even if it
-            // can't address the entire file. This seems to happen at least on
-            // Windows, even though it uses to work prior to ripgrep 13. The
-            // only Windows-related change in ripgrep 13, AFAIK, was statically
-            // linking vcruntime. So maybe that's related? But I'm not sure.
-            //
-            // See: https://github.com/BurntSushi/ripgrep/issues/1911
-            return None;
-        }
         if cfg!(target_os = "macos") {
             // I guess memory maps on macOS aren't great. Should re-evaluate.
             return None;


### PR DESCRIPTION
memmap2 v0.3.0 introduced a [regression](https://github.com/RazrFalcon/memmap2-rs/commit/5e271224c8411c89b42060294f9393cfc7b12a2a) when trying to map files larger than 4GB on 32-bit architectures which was subsequently [fixed](https://github.com/RazrFalcon/memmap2-rs/commit/9aa838aed99a4879d8357ff295a0ca1c98ba1ae5) in v0.3.1.

This commit bumps locked version of the memmap2 dependency to the current v0.5.0 and reverts fdfc418be55ff91e0c2efad6a3e27db054cb5534 to re-enable mmap on 32-bit architectures as a different approach to fixing #1911.

This was tested to report matches from the end of a 5GB file using MinGW and Wine:
```
~/.wine/drive_c> wine rg.exe 3z5llj3n8b56dcpoj5aj4rlmq3bdpie wikidatawiki-20210901-pages-articles1.xml-p1p441397 --debug
DEBUG|grep_regex::literal|crates/regex/src/literal.rs:58: literal prefixes detected: Literals { lits: [Complete(3z5llj3n8b56dcpoj5aj4rlmq3bdpie)], limit_size: 250, limit_class: 10 }
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: gzip: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: gzip: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: bzip2: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: bzip2: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: xz: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: xz: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: lz4: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: xz: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: brotli: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: zstd: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: zstd: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: uncompress: could not find executable in PATH
DEBUG|grep_searcher::searcher::mmap|crates/searcher/src/searcher/mmap.rs:86: wikidatawiki-20210901-pages-articles1.xml-p1p441397: failed to open memory map: memory map length overflows usize
1727003:      <sha1>3z5llj3n8b56dcpoj5aj4rlmq3bdpie</sha1>
```
whereas still using memmap2 v0.3.0 but fdfc418be55ff91e0c2efad6a3e27db054cb5534 reverted would silently fail
``` 
~/.wine/drive_c> wine rg.exe 3z5llj3n8b56dcpoj5aj4rlmq3bdpie wikidatawiki-20210901-pages-articles1.xml-p1p441397 --debug
DEBUG|grep_regex::literal|crates/regex/src/literal.rs:58: literal prefixes detected: Literals { lits: [Complete(3z5llj3n8b56dcpoj5aj4rlmq3bdpie)], limit_size: 250, limit_class: 10 }
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: gzip: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: gzip: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: bzip2: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: bzip2: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: xz: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: xz: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: lz4: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: xz: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: brotli: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: zstd: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: zstd: could not find executable in PATH
DEBUG|grep_cli::decompress|crates/cli/src/decompress.rs:482: uncompress: could not find executable in PATH
```