### PR TITLE
Add Ada filetypes, including gprbuild & alire

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -10,8 +10,10 @@
 /// columns (inclusive).
 #[rustfmt::skip]
 pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
+    ("ada", &["*.adb", "*.ads"]),
     ("agda", &["*.agda", "*.lagda"]),
     ("aidl", &["*.aidl"]),
+    ("alire", &["alire.toml"]),
     ("amake", &["*.mk", "*.bp"]),
     ("asciidoc", &["*.adoc", "*.asc", "*.asciidoc"]),
     ("asm", &["*.asm", "*.s", "*.S"]),
@@ -73,6 +75,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("gap", &["*.g", "*.gap", "*.gi", "*.gd", "*.tst"]),
     ("gn", &["*.gn", "*.gni"]),
     ("go", &["*.go"]),
+    ("gprbuild", &["*.gpr"]),
     ("gradle", &["*.gradle"]),
     ("groovy", &["*.groovy", "*.gradle"]),
     ("gzip", &["*.gz", "*.tgz"]),


### PR DESCRIPTION
*.adb and *.ads are the usual extensions for Ada source code,
and *.gpr indicates a GPRbuild project file used for Ada, and
these days often being combined with alire for package dependency
resolution. Alire stores a bunch of files named alire.toml in
different directories in your (gitignored) cache/dependencies/...