### PR TITLE
Fix futhark type extension

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -69,7 +69,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
         "*.f90", "*.F90", "*.f95", "*.F95",
     ]),
     ("fsharp", &["*.fs", "*.fsx", "*.fsi"]),
-    ("fut", &[".fut"]),
+    ("fut", &["*.fut"]),
     ("gap", &["*.g", "*.gap", "*.gi", "*.gd", "*.tst"]),
     ("gn", &["*.gn", "*.gni"]),
     ("go", &["*.go"]),


### PR DESCRIPTION
Currently, the `fut` type only matches files called `.fut`, while in reality we want to match all files with the `.fut` extension. This commit fixes that issue.