### PR TITLE
ignore/types: add lilypond

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -123,6 +123,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
         "MPL-*[0-9]*",
         "OFL-*[0-9]*",
     ]),
+    ("lilypond", &["*.ly", "*.ily"]),
     ("lisp", &["*.el", "*.jl", "*.lisp", "*.lsp", "*.sc", "*.scm"]),
     ("lock", &["*.lock", "package-lock.json"]),
     ("log", &["*.log"]),


### PR DESCRIPTION
This adds file detection for lilypond: https://lilypond.org/