### PR TITLE
Clarify the comment on `Worker.work_done`

### DIFF
--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -1682,7 +1682,7 @@ impl<'s> Worker<'s> {
         stack.pop()
     }
 
-    /// Signal that work has been received.
+    /// Signal that work has been finished.
     fn work_done(&self) {
         self.num_pending.fetch_sub(1, Ordering::SeqCst);
     }


### PR DESCRIPTION
I was reading a bit of ripgrep's code (really readable btw! :) and I think the comment here is a bit misleading (if I understand things correctly)