### PR TITLE
Detect Vim config files as 'vim' file type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -21,7 +21,9 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("ats", &["*.ats", "*.dats", "*.sats", "*.hats"]),
     ("avro", &["*.avdl", "*.avpr", "*.avsc"]),
     ("awk", &["*.awk"]),
-    ("bazel", &["*.bazel", "*.bzl", "*.BUILD", "*.bazelrc", "BUILD", "WORKSPACE"]),
+    ("bazel", &[
+        "*.bazel", "*.bzl", "*.BUILD", "*.bazelrc", "BUILD", "WORKSPACE",
+    ]),
     ("bitbake", &["*.bb", "*.bbappend", "*.bbclass", "*.conf", "*.inc"]),
     ("brotli", &["*.br"]),
     ("buildstream", &["*.bst"]),
@@ -243,8 +245,12 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("vcl", &["*.vcl"]),
     ("verilog", &["*.v", "*.vh", "*.sv", "*.svh"]),
     ("vhdl", &["*.vhd", "*.vhdl"]),
-    ("vim", &["*.vim", ".vimrc", ".gvimrc", "vimrc", "gvimrc", "_vimrc", "_gvimrc"]),
-    ("vimscript", &["*.vim", ".vimrc", ".gvimrc", "vimrc", "gvimrc", "_vimrc", "_gvimrc"]),
+    ("vim", &[
+        "*.vim", ".vimrc", ".gvimrc", "vimrc", "gvimrc", "_vimrc", "_gvimrc",
+    ]),
+    ("vimscript", &[
+        "*.vim", ".vimrc", ".gvimrc", "vimrc", "gvimrc", "_vimrc", "_gvimrc",
+    ]),
     ("webidl", &["*.idl", "*.webidl", "*.widl"]),
     ("wiki", &["*.mediawiki", "*.wiki"]),
     ("xml", &[


### PR DESCRIPTION
`.vimrc`, `vimrc`, `_vimrc`, `.gvimrc`, `gvimrc`, `_gvimrc` are file names for Vim configurations and written in Vim script.

This PR adds them for `vim` file type detection.

Documents:

- vimrc config: https://github.com/vim/vim/blob/2446ec9b567ce2b72bd06d121f200f40bbdc8a84/runtime/doc/starting.txt#L789-L795
- gvimrc config: https://github.com/vim/vim/blob/2446ec9b567ce2b72bd06d121f200f40bbdc8a84/runtime/doc/gui.txt#L97-L102