### PR TITLE
globset: add escaping mechanism

### DIFF
--- a/crates/globset/src/glob.rs
+++ b/crates/globset/src/glob.rs
@@ -137,6 +137,27 @@ impl GlobMatcher {
     }
 }
 
+impl PartialEq for GlobMatcher {
+    fn eq(&self, other: &GlobMatcher) -> bool {
+        self.pat == other.pat
+    }
+}
+
+impl Eq for GlobMatcher {
+}
+
+impl hash::Hash for GlobMatcher {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.pat.hash(state);
+    }
+}
+
+impl fmt::Display for GlobMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.pat.fmt(f)
+    }
+}
+
 /// A strategic matcher for a single pattern.
 #[cfg(test)]
 #[derive(Clone, Debug)]

--- a/crates/globset/src/glob.rs
+++ b/crates/globset/src/glob.rs
@@ -255,6 +255,13 @@ impl Glob {
     pub fn new(glob: &str) -> Result<Glob, Error> {
         GlobBuilder::new(glob).build()
     }
+    
+    /// Builds a new pattern that matches a literal string.
+    ///
+    /// This is a shorthand for `Glob::new(glob::escape("pattern"))`.
+    pub fn new_escaped(s: &str) -> Self {
+        Self::new(&crate::escape(s)).unwrap()
+    }
 
     /// Returns a matcher for this pattern.
     pub fn compile_matcher(&self) -> GlobMatcher {

--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -860,6 +860,28 @@ impl RequiredExtensionStrategyBuilder {
     }
 }
 
+/// Escape metacharacters within the given string by surrounding them in
+/// brackets. The resulting string will, when compiled into a `Glob`,
+/// match the input string and nothing else.
+pub fn escape(s: &str) -> String {
+    let mut escaped = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            // note that ! does not need escaping because it is only special
+            // inside brackets
+            '?' | '*' | '[' | ']' => {
+                escaped.push('[');
+                escaped.push(c);
+                escaped.push(']');
+            }
+            c => {
+                escaped.push(c);
+            }
+        }
+    }
+    escaped
+}
+
 #[cfg(test)]
 mod tests {
     use super::{GlobSet, GlobSetBuilder};
@@ -898,5 +920,17 @@ mod tests {
         let set: GlobSet = Default::default();
         assert!(!set.is_match(""));
         assert!(!set.is_match("a"));
+    }
+    
+    #[test]
+    fn escape() {
+        use super::escape;
+        assert_eq!("foo", escape("foo"));
+        assert_eq!("foo[*]", escape("foo*"));
+        assert_eq!("[[][]]", escape("[]"));
+        assert_eq!("[*][?]", escape("*?"));
+        assert_eq!("src/[*][*]/[*].rs", escape("src/**/*.rs"));
+        assert_eq!("bar[[]ab[]]baz", escape("bar[ab]baz"));
+        assert_eq!("bar[[]!![]]!baz", escape("bar[!!]!baz"));
     }
 }


### PR DESCRIPTION
Closes #2060. The implementation is taken 1:1 from the glob crate. Function signatures may be subject to bike shedding.

I feel that there may be some optimization potential in the `escape` method that doesn't allocate if there are no special characters to be escaped (probably by returning a `Cow`), but I would have to benchmark it and *creating* globs is usually not on the critical path.

I've seen some `Strategy` foo while skimming over the code. Will the crate automatically pick a `Literal` strategy or do I need to do something to activate it?