### PR TITLE
Improve err msg when it fails to read the file specified in RIPGREP_CONFIG_PATH

### DIFF
--- a/crates/core/config.rs
+++ b/crates/core/config.rs
@@ -28,7 +28,10 @@ pub fn args() -> Vec<OsString> {
     let (args, errs) = match parse(&config_path) {
         Ok((args, errs)) => (args, errs),
         Err(err) => {
-            message!("{}", err);
+            message!(
+                "failed to read the file specified in RIPGREP_CONFIG_PATH: {}",
+                err
+            );
             return vec![];
         }
     };


### PR DESCRIPTION
close: #1990

## Behavior before this change
```sh
$ RIPGREP_CONFIG_PATH=no_exist_path rg 'search regex'
no_exist_path: No such file or directory (os error 2)
```

## Behavior after this change
```sh
$ RIPGREP_CONFIG_PATH=no_exist_path rg 'search regex'
failed to read the file specified in RIPGREP_CONFIG_PATH: no_exist_path: No such file or directory (os error 2)
```