### PR TITLE
globset: Fix version in README.md

### DIFF
--- a/crates/globset/README.md
+++ b/crates/globset/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-globset = "0.3"
+globset = "0.4"
 ```
 
 ### Features


### PR DESCRIPTION
The README still says add `globset = "0.3"` to your Cargo.toml while globset is actually at 0.4 for 3,5 years (6c8b1e9).