### PR TITLE
ignore/gitignore: Support quoted INI values

### DIFF
--- a/crates/ignore/src/gitignore.rs
+++ b/crates/ignore/src/gitignore.rs
@@ -594,7 +594,7 @@ fn parse_excludes_file(data: &[u8]) -> Option<PathBuf> {
     // a full INI parser. Yuck.
     lazy_static::lazy_static! {
         static ref RE: Regex =
-            Regex::new(r"(?im)^\s*excludesfile\s*=\s*(.+)\s*$").unwrap();
+            Regex::new(r#"(?im)^\s*excludesfile\s*=\s*['"]?(.+?)['"]?\s*$"#).unwrap();
     };
     let caps = match RE.captures(data) {
         None => return None,


### PR DESCRIPTION
Fix parsing `excludesFile` values that are quoted to match Git and [other INI parsers](https://en.wikipedia.org/wiki/INI_file#Quoted_values).