### PR TITLE
ci: disable nightly-arm build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,15 +65,15 @@ jobs:
           os: ubuntu-18.04
           rust: nightly
           target: mips64-unknown-linux-gnuabi64
-        - build: nightly-arm
-          os: ubuntu-18.04
-          rust: nightly
-          # For stripping release binaries:
-          # docker run --rm -v $PWD/target:/target:Z \
-          #   rustembedded/cross:arm-unknown-linux-gnueabihf \
-          #   arm-linux-gnueabihf-strip \
-          #   /target/arm-unknown-linux-gnueabihf/debug/rg
-          target: arm-unknown-linux-gnueabihf
+        # - build: nightly-arm
+        #   os: ubuntu-18.04
+        #   rust: nightly
+        #   # For stripping release binaries:
+        #   # docker run --rm -v $PWD/target:/target:Z \
+        #   #   rustembedded/cross:arm-unknown-linux-gnueabihf \
+        #   #   arm-linux-gnueabihf-strip \
+        #   #   /target/arm-unknown-linux-gnueabihf/debug/rg
+        #   target: arm-unknown-linux-gnueabihf
         - build: macos
           os: macos-latest
           rust: nightly


### PR DESCRIPTION
Disables the `nightly-arm` build in `ci.yml` workflow.

Quick fix for #2130 so further `ci` runs aren't blocked.