### PR TITLE
Fix failing `nightly-arm` build on `ci` workflow

### DIFF
--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM rustembedded/cross:arm-unknown-linux-gnueabihf
+FROM rustembedded/cross:arm-unknown-linux-gnueabihf@sha256:596c68e9ceda8c4aa196abc28d762e0234588d11fb6e3b6a48f7619b7755fbe9
 
 COPY stage/ubuntu-install-packages /
 RUN /ubuntu-install-packages

--- a/ci/docker/arm-unknown-linux-gnueabihf/build
+++ b/ci/docker/arm-unknown-linux-gnueabihf/build
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 mkdir -p stage
-cp ../../ubuntu-install-packages ./stage/
+cp ../../ubuntu-install-packages-docker ./stage/ubuntu-install-packages
 docker build -t burntsushi/cross:arm-unknown-linux-gnueabihf .

--- a/ci/ubuntu-install-packages-docker
+++ b/ci/ubuntu-install-packages-docker
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+  asciidoctor \
+  zsh xz-utils liblz4-tool musl-tools \
+  brotli zstd

--- a/ci/ubuntu-install-packages-docker
+++ b/ci/ubuntu-install-packages-docker
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends \
+apt-get update
+apt-get install -y --no-install-recommends \
   asciidoctor \
   zsh xz-utils liblz4-tool musl-tools \
   brotli zstd


### PR DESCRIPTION
Some tests in `nightly-arm` fail when `brotli` and `zstd` is not found.

Fixes #2130, but first a new docker image has to be built and pushed to `burntsushi/cross:arm-unknown-linux-gnueabihf`