### PR TITLE
Add embedded puppet templates to the puppet type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -168,7 +168,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("postscript", &["*.eps", "*.ps"]),
     ("protobuf", &["*.proto"]),
     ("ps", &["*.cdxml", "*.ps1", "*.ps1xml", "*.psd1", "*.psm1"]),
-    ("puppet", &["*.erb", "*.pp", "*.rb"]),
+    ("puppet", &["*.epp", "*.erb", "*.pp", "*.rb"]),
     ("purs", &["*.purs"]),
     ("py", &["*.py"]),
     ("qmake", &["*.pro", "*.pri", "*.prf"]),


### PR DESCRIPTION
.epp files are getting more and more common in Puppet code bases so it
makes sense I think to include them as part of the "puppet" type.

https://puppet.com/docs/puppet/7/lang_template_epp.html