### PR TITLE
add DITA (Darwin Information Typing Architecture) file types

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -54,6 +54,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("dart", &["*.dart"]),
     ("dhall", &["*.dhall"]),
     ("diff", &["*.patch", "*.diff"]),
+    ("dita", &["*.dita", "*.ditamap", "*.ditaval"]),
     ("docker", &["*Dockerfile*"]),
     ("dvc", &["Dvcfile", "*.dvc"]),
     ("ebuild", &["*.ebuild"]),


### PR DESCRIPTION
Signed-off-by: chrispy <chrispy@synopsys.com>

DITA (Darwin Information Typing Architecture) is an XML-based documentation standard. This pull request seeks to make DITA file extensions (`*.dita`, `*.ditamap`, `*.ditaval`) known to `ripgrep`.

Relevant resources include:

[link to the OASIS DITA standard](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=dita)

[link to the open-source DITA Open Toolkit processor](https://www.dita-ot.org/)