### PR TITLE
Limit amount of matches during replacement

### DIFF
--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::cmp::max;
 use std::fmt;
 use std::io;
 use std::path::Path;
@@ -83,9 +84,9 @@ impl<M: Matcher> Replacer<M> {
             matches.clear();
 
             matcher
-                .replace_with_captures_at(
+                .replace_with_captures_in_range(
                     subject,
-                    range.start,
+                    &range,
                     caps,
                     dst,
                     |caps, dst| {

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1044,3 +1044,15 @@ rgtest!(r1891, |dir: Dir, mut cmd: TestCommand| {
     // happen when each match needs to be detected.
     eqnice!("1:\n2:\n2:\n", cmd.args(&["-won", "", "test"]).stdout());
 });
+
+// See: https://github.com/BurntSushi/ripgrep/issues/2095
+rgtest!(r2095, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("test", "foo\nbar\n\nbaz\n");
+    // When replacing a multiline match, there should be no extra
+    // content beyond the original match.
+    cmd.args(&["-U", "o\nb", "-r", "OB"]);
+    let expected = "\
+test:foOBar
+";
+    eqnice!(expected, cmd.stdout());
+});


### PR DESCRIPTION
The buffer passed to the replace function can be bigger than the original match
and cause extra matches to occur during replacement. This adds an extra replace
function that doesn't allow matches beyond the original range to get replaced.

I've added `replace_with_captures_in_range` to do this, but I'm not sure if this should be fixed within
`replace_with_captures_at` itself (as that one isn't always used with a range).

Fixes #2095 