### PR TITLE
Added checksums to release page and changed release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,21 +164,25 @@ jobs:
         if [ "${{ matrix.os }}" = "windows-2019" ]; then
           cp "target/${{ matrix.target }}/release/rg.exe" "$staging/"
           7z a "$staging.zip" "$staging"
+          sha256sum "$staging.zip" > "$staging.zip.sha256"
           echo "ASSET=$staging.zip" >> $GITHUB_ENV
+          echo "ASSET_SUM=$staging.tar.gz.sha256" >> $GITHUB_ENV
         else
           # The man page is only generated on Unix systems. ¯\_(ツ)_/¯
           cp "$outdir"/rg.1 "$staging/doc/"
           cp "target/${{ matrix.target }}/release/rg" "$staging/"
           tar czf "$staging.tar.gz" "$staging"
+          sha256sum "$staging.tar.gz" > "$staging.tar.gz.sha256"
           echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+          echo "ASSET_SUM=$staging.tar.gz.sha256" >> $GITHUB_ENV
         fi
 
     - name: Upload release archive
-      uses: actions/upload-release-asset@v1.0.1
+      uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create-release.outputs.upload_url }}
-        asset_path: ${{ env.ASSET }}
-        asset_name: ${{ env.ASSET }}
-        asset_content_type: application/octet-stream
+        files: |
+          ${{ env.ASSET }}
+          ${{ env.ASSET_SUM }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }}
         files: |
           ${{ env.ASSET }}
           ${{ env.ASSET_SUM }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
         if [ "${{ matrix.os }}" = "windows-2019" ]; then
           cp "target/${{ matrix.target }}/release/rg.exe" "$staging/"
           7z a "$staging.zip" "$staging"
-          sha256sum "$staging.zip" > "$staging.zip.sha256"
+          shasum -a 256 "$staging.zip" > "$staging.zip.sha256"
           echo "ASSET=$staging.zip" >> $GITHUB_ENV
           echo "ASSET_SUM=$staging.tar.gz.sha256" >> $GITHUB_ENV
         else
@@ -172,7 +172,7 @@ jobs:
           cp "$outdir"/rg.1 "$staging/doc/"
           cp "target/${{ matrix.target }}/release/rg" "$staging/"
           tar czf "$staging.tar.gz" "$staging"
-          sha256sum "$staging.tar.gz" > "$staging.tar.gz.sha256"
+          shasum -a 256 "$staging.tar.gz" > "$staging.tar.gz.sha256"
           echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
           echo "ASSET_SUM=$staging.tar.gz.sha256" >> $GITHUB_ENV
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
         if [ "${{ matrix.os }}" = "windows-2019" ]; then
           cp "target/${{ matrix.target }}/release/rg.exe" "$staging/"
           7z a "$staging.zip" "$staging"
-          Get-FileHash "$staging.zip" | Format-List > "$staging.zip.sha256"
+          certutil -hashfile "$staging.zip" SHA256 > "$staging.zip.sha256"
           echo "ASSET=$staging.zip" >> $GITHUB_ENV
           echo "ASSET_SUM=$staging.zip.sha256" >> $GITHUB_ENV
         else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,9 +164,9 @@ jobs:
         if [ "${{ matrix.os }}" = "windows-2019" ]; then
           cp "target/${{ matrix.target }}/release/rg.exe" "$staging/"
           7z a "$staging.zip" "$staging"
-          shasum -a 256 "$staging.zip" > "$staging.zip.sha256"
+          Get-FileHash "$staging.zip" | Format-List > "$staging.zip.sha256"
           echo "ASSET=$staging.zip" >> $GITHUB_ENV
-          echo "ASSET_SUM=$staging.tar.gz.sha256" >> $GITHUB_ENV
+          echo "ASSET_SUM=$staging.zip.sha256" >> $GITHUB_ENV
         else
           # The man page is only generated on Unix systems. ¯\_(ツ)_/¯
           cp "$outdir"/rg.1 "$staging/doc/"


### PR DESCRIPTION
fixes #1924 
This change should add checksum files "sha256" for each built tar ball / zip ball file.
`actions/upload-release-asset` is now archived and recommends using `softprops/action-gh-release` instead. Therefore, this commit replaces the old upload-release-asset.

Example Release: https://github.com/xEgoist/ripgrep/releases/tag/13.0.6 , action-gh-release can also be utilized to include a changelog file to automate the release process.
