### PR TITLE
ignore/types: Add "*.hh" to headers

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -80,7 +80,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("gradle", &["*.gradle"]),
     ("groovy", &["*.groovy", "*.gradle"]),
     ("gzip", &["*.gz", "*.tgz"]),
-    ("h", &["*.h", "*.hpp"]),
+    ("h", &["*.h", "*.hh", "*.hpp"]),
     ("haml", &["*.haml"]),
     ("haskell", &["*.hs", "*.lhs", "*.cpphs", "*.c2hs", "*.hsc"]),
     ("hbs", &["*.hbs"]),


### PR DESCRIPTION
Like .hpp, .hh is an occasionally used extension for C++ headers
(to distinguish them from C headers).