### PR TITLE
complete: add extra-verbose support to _rg_types

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -30,7 +30,7 @@ _rg() {
     [[ $_RG_COMPLETE_LIST_ARGS == (1|t*|y*) ]] ||
     # (--[imnp]* => --ignore*, --messages, --no-*, --pcre2-unicode)
     [[ $PREFIX$SUFFIX == --[imnp]* ]] ||
-    zstyle -t ":complete:$curcontext:*" complete-all
+    zstyle -t ":completion:${curcontext}:" complete-all
   then
     no=
   fi
@@ -432,9 +432,13 @@ _rg_types() {
   local -a expl
   local -aU _types
 
-  _types=( ${(@)${(f)"$( _call_program types rg --type-list )"}%%:*} )
+  _types=( ${(@)${(f)"$( _call_program types $words[1] --type-list )"}//:[[:space:]]##/:} )
 
-  _wanted types expl 'file type' compadd -a "$@" - _types
+  if zstyle -t ":completion:${curcontext}:types" extra-verbose; then
+    _describe -t types 'file type' _types
+  else
+    _wanted types expl 'file type' compadd "$@" - ${(@)_types%%:*}
+  fi
 }
 
 _rg "$@"


### PR DESCRIPTION
When the `extra-verbose` style is set for the `types` tag, completed types are displayed along with the patterns they correspond to. This can be enabled by e.g. adding the following to `.zshrc`:

```
zstyle ':completion:*:rg:*:types' extra-verbose true
```

This change also makes `_rg_types` use the actual `rg` specified on the command line to look up types, and it fixes a mangled `complete-all` style check

Fixes #2195