### PR TITLE
When using '--no-ignore-dot' ignore also '.rgignore'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Bug fixes:
   Fix bug when using `-w` with a regex that can match the empty string.
 * [BUG #1911](https://github.com/BurntSushi/ripgrep/issues/1911):
   Disable mmap searching in all non-64-bit environments.
-
+* [BUG #2198](https://github.com/BurntSushi/ripgrep/issues/2198):
+  Fix bug where `--no-ignore-dot` would not ignore `.rgignore`.
 
 13.0.0 (2021-06-12)
 ===================

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -887,7 +887,7 @@ impl ArgMatches {
             .git_exclude(!self.no_ignore_vcs() && !self.no_ignore_exclude())
             .require_git(!self.is_present("no-require-git"))
             .ignore_case_insensitive(self.ignore_file_case_insensitive());
-        if !self.no_ignore() {
+        if !self.no_ignore() && !self.no_ignore_dot() {
             builder.add_custom_ignore_filename(".rgignore");
         }
         let sortby = self.sort_by()?;

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1044,3 +1044,16 @@ rgtest!(r1891, |dir: Dir, mut cmd: TestCommand| {
     // happen when each match needs to be detected.
     eqnice!("1:\n2:\n2:\n", cmd.args(&["-won", "", "test"]).stdout());
 });
+
+// See: https://github.com/BurntSushi/ripgrep/issues/2198
+rgtest!(r2198, |dir: Dir, mut cmd: TestCommand| {
+  dir.create(".ignore", "a");
+  dir.create(".rgignore", "b");
+  dir.create("a", "");
+  dir.create("b", "");
+  dir.create("c", "");
+
+  cmd.arg("--files");
+  eqnice!("c\n", cmd.stdout());
+  eqnice!("b\nc\na\n", cmd.arg("--no-ignore-dot").stdout());
+});


### PR DESCRIPTION
Fixes #2198 and adds the test case you fortunately already provided in the issue.

Hopefully, I've got it right. Just let me know if sth. is improvable or missing.