### PR TITLE
Add MPR installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,14 @@ seem to work right and generate a number of very strange bug reports that I
 don't know how to fix and don't have the time to fix. Therefore, it is no
 longer a recommended installation option.)
 
+If you're a **makedeb** user, you can install makedeb from the [makedeb Package Repository](https://mpr.makedeb.org/packages/ripgrep):
+
+```
+$ git clone 'https://mpr.makedeb.org/ripgrep'
+$ cd ripgrep/
+$ makedeb -si
+```
+
 If you're a **FreeBSD** user, then you can install ripgrep from the
 [official ports](https://www.freshports.org/textproc/ripgrep/):
 


### PR DESCRIPTION
This adds installation instructions for the [makedeb Package Repository](https://mpr.makedeb.org), an AUR-like platform for Debian and Ubuntu based systems.

The MPR is a personal project of mine, but I thought it'd be helpful to include it here so people know its an option.