### PR TITLE
ignore/types: add dts to default types

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -57,6 +57,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("dhall", &["*.dhall"]),
     ("diff", &["*.patch", "*.diff"]),
     ("docker", &["*Dockerfile*"]),
+    ("dts", &["*.dts", "*.dtsi"]),
     ("dvc", &["Dvcfile", "*.dvc"]),
     ("ebuild", &["*.ebuild"]),
     ("edn", &["*.edn"]),


### PR DESCRIPTION
See [the Device Tree spec](https://devicetree-specification.readthedocs.io/en/v0.3/source-language.html) for more information. It is basically a format that describes the hardware that can be found on systems, used mainly in embedded land to describe boards. The I in DTSI stands for "include". Linux and bootloaders contain many of those files.

**I have not tested the patch as I do not have a Rust dev environment.** Sorry about that.

Please do ask if I have forgotten any information, and thanks for the project!