### PR TITLE
Add `patch` printer

### DIFF
--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -2383,11 +2383,11 @@ A patch file in the unified diff format (used by 'diff -u') will be generated;
 applying this patch file will replace every match with the replacement text
 specified by '--replace'. (Note that ripgrep will only generate the patch; it
 will not modify your files.)
+
+Note that using this option when reading from stdin will likely not result in a
+usable patch file.
 "
     );
-    // XXX is there a way to make this incompatible with streaming from stdin?
-    // Or at least show a warning in that case? The patch file will probably not
-    // be usable.
     let arg = RGArg::switch("patch")
         .help(SHORT)
         .long_help(LONG)

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -1665,6 +1665,7 @@ The JSON Lines format can be disabled with --no-json.
             "files",
             "files-with-matches",
             "files-without-match",
+            "patch",
         ]);
     args.push(arg);
 
@@ -2384,15 +2385,43 @@ XXX would need full docs here
         .help(SHORT)
         .long_help(LONG)
         .conflicts(&[
+            "after-context",
+            "auto-hybrid-regex",
+            "before-context",
+            "byte-offset",
+            "color",
+            "colors",
+            "column",
+            // "context", // for now, user must specify this explicitly
             "count",
             "count-matches",
+            "field-context-separator",
+            "field-match-separator",
             "files",
             "files-with-matches",
             "files-without-match",
+            "heading",
+            "include-zero",
+            "invert-match",
+            "json",
+            "line-number",
+            "max-count",
             "multiline",
+            "multiline-dotall",
+            "no-pcre2-unicode",
+            "null",
+            "null-data",
+            "path-separator",
+            "passthru",
+            "pcre2-version",
+            "pretty",
+            "quiet",
+            "sort-files",
             "stats",
-            "color",
-            // XXX probably others
+            "trim,",
+            "type-list",
+            "vimgrep",
+            "with-filename",
         ]);
     args.push(arg);
 }

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -2386,6 +2386,8 @@ will not modify your files.)
 
 Note that using this option when reading from stdin will likely not result in a
 usable patch file.
+
+This overrides '--no-line-number'.
 "
     );
     let arg = RGArg::switch("patch")

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -615,6 +615,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_null_data(&mut args);
     flag_one_file_system(&mut args);
     flag_only_matching(&mut args);
+    flag_patch(&mut args);
     flag_path_separator(&mut args);
     flag_passthru(&mut args);
     flag_pcre2(&mut args);
@@ -2367,6 +2368,32 @@ part on a separate output line.
     );
     let arg =
         RGArg::switch("only-matching").short("o").help(SHORT).long_help(LONG);
+    args.push(arg);
+}
+
+fn flag_patch(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Generate a patch file to perform a text substitution.";
+    const LONG: &str = long!(
+        "\
+Generate a patch file to perform a text substitution.
+
+XXX would need full docs here
+"
+    );
+    let arg = RGArg::switch("patch")
+        .help(SHORT)
+        .long_help(LONG)
+        .conflicts(&[
+            "count",
+            "count-matches",
+            "files",
+            "files-with-matches",
+            "files-without-match",
+            "multiline",
+            "stats",
+            "color",
+            // XXX probably others
+        ]);
     args.push(arg);
 }
 

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -2376,9 +2376,13 @@ fn flag_patch(args: &mut Vec<RGArg>) {
     const SHORT: &str = "Generate a patch file to perform a text substitution.";
     const LONG: &str = long!(
         "\
-Generate a patch file to perform a text substitution.
+Generate a patch file to perform a text substitution. This must be used in
+conjuction with '--replace'.
 
-XXX would need full docs here
+A patch file in the unified diff format (used by 'diff -u') will be generated;
+applying this patch file will replace every match with the replacement text
+specified by '--replace'. (Note that ripgrep will only generate the patch; it
+will not modify your files.)
 "
     );
     // XXX is there a way to make this incompatible with streaming from stdin?
@@ -2421,6 +2425,8 @@ XXX would need full docs here
             "pcre2-version",
             "pretty",
             "quiet",
+            "sort",
+            "sortr",
             "sort-files",
             "stats",
             "trim,",
@@ -2701,7 +2707,9 @@ fn flag_replace(args: &mut Vec<RGArg>) {
     const LONG: &str = long!(
         "\
 Replace every match with the text given when printing results. Neither this
-flag nor any other ripgrep flag will modify your files.
+flag nor any other ripgrep flag will modify your files; however, the '--patch'
+option will generate a file that can be used by the 'patch' utility to perform
+the specified replacement in the actual files.
 
 Capture group indices (e.g., $5) and names (e.g., $foo) are supported in the
 replacement string. Capture group indices are numbered based on the position of

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -2408,6 +2408,8 @@ XXX would need full docs here
             "invert-match",
             "json",
             "line-number",
+            "max-columns",
+            "max-columns-preview",
             "max-count",
             "multiline",
             "multiline-dotall",

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -2392,7 +2392,7 @@ XXX would need full docs here
             "color",
             "colors",
             "column",
-            // "context", // for now, user must specify this explicitly
+            "context",
             "count",
             "count-matches",
             "field-context-separator",

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -2381,6 +2381,9 @@ Generate a patch file to perform a text substitution.
 XXX would need full docs here
 "
     );
+    // XXX is there a way to make this incompatible with streaming from stdin?
+    // Or at least show a warning in that case? The patch file will probably not
+    // be usable.
     let arg = RGArg::switch("patch")
         .help(SHORT)
         .long_help(LONG)

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -1277,7 +1277,7 @@ impl ArgMatches {
             return OutputKind::Summary;
         } else if self.is_present("json") {
             return OutputKind::JSON;
-        } else /* XXX figure out how to add option if self.is_present("patch") */ {
+        } else if self.is_present("patch") {
             return OutputKind::Patch;
             // XXX also set context to 3
         }

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -1168,10 +1168,14 @@ impl ArgMatches {
         if self.output_kind() == OutputKind::Summary {
             return false;
         }
+        // Patch output always requires line numbers
+        if self.output_kind() == OutputKind::Patch {
+        return true
+        }
         if self.is_present("no-line-number") {
             return false;
         }
-        if self.output_kind() == OutputKind::JSON || self.output_kind() == OutputKind::Patch {
+        if self.output_kind() == OutputKind::JSON {
             return true;
         }
 

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -1021,6 +1021,10 @@ impl ArgMatches {
     /// If there was a problem parsing the values from the user as an integer,
     /// then an error is returned.
     fn contexts(&self) -> Result<(usize, usize)> {
+        if self.output_kind() == OutputKind::Patch {
+            // Standard context for patch-files
+            return Ok((3, 3));
+        }
         let after = self.usize_of("after-context")?.unwrap_or(0);
         let before = self.usize_of("before-context")?.unwrap_or(0);
         let both = self.usize_of("context")?.unwrap_or(0);
@@ -1279,7 +1283,6 @@ impl ArgMatches {
             return OutputKind::JSON;
         } else if self.is_present("patch") {
             return OutputKind::Patch;
-            // XXX also set context to 3
         }
 
         let (count, count_matches) = self.counts();

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -1279,6 +1279,7 @@ impl ArgMatches {
             return OutputKind::JSON;
         } else /* XXX figure out how to add option if self.is_present("patch") */ {
             return OutputKind::Patch;
+            // XXX also set context to 3
         }
 
         let (count, count_matches) = self.counts();

--- a/crates/core/search.rs
+++ b/crates/core/search.rs
@@ -483,21 +483,40 @@ fn search_path<M: Matcher, W: WriteColor>(
     printer: &mut Printer<W>,
     path: &Path,
 ) -> io::Result<SearchResult> {
-    let sink: &mut dyn Sink<Error = _> = match *printer {
-        Printer::Standard(ref mut p) =>
-            &mut p.sink_with_path(&matcher, path),
-        Printer::Summary(ref mut p) =>
-            &mut p.sink_with_path(&matcher, path),
-        Printer::JSON(ref mut p) =>
-            &mut p.sink_with_path(&matcher, path),
-        Printer::Patch(ref mut p) =>
-            &mut p.sink_with_path(&matcher, path),
-    };
-    searcher.search_path(&matcher, path, sink)?;
-    Ok(SearchResult {
-        has_match: sink.has_match(),
-        stats: sink.stats().map(|s| s.clone()),
-    })
+    match *printer {
+        Printer::Standard(ref mut p) => {
+            let mut sink = p.sink_with_path(&matcher, path);
+            searcher.search_path(&matcher, path, &mut sink)?;
+            Ok(SearchResult {
+                has_match: sink.has_match(),
+                stats: sink.stats().map(|s| s.clone()),
+            })
+        }
+        Printer::Summary(ref mut p) => {
+            let mut sink = p.sink_with_path(&matcher, path);
+            searcher.search_path(&matcher, path, &mut sink)?;
+            Ok(SearchResult {
+                has_match: sink.has_match(),
+                stats: sink.stats().map(|s| s.clone()),
+            })
+        }
+        Printer::JSON(ref mut p) => {
+            let mut sink = p.sink_with_path(&matcher, path);
+            searcher.search_path(&matcher, path, &mut sink)?;
+            Ok(SearchResult {
+                has_match: sink.has_match(),
+                stats: Some(sink.stats().clone()),
+            })
+        }
+        Printer::Patch(ref mut p) => {
+            let mut sink = p.sink_with_path(&matcher, path);
+            searcher.search_path(&matcher, path, &mut sink)?;
+            Ok(SearchResult {
+                has_match: sink.has_match(),
+                stats: sink.stats().map(|s| s.clone()),
+            })
+        }
+    }
 }
 
 /// Search the contents of the given reader using the given matcher, searcher

--- a/crates/core/search.rs
+++ b/crates/core/search.rs
@@ -554,12 +554,7 @@ fn search_reader<M: Matcher, R: io::Read, W: WriteColor>(
             })
         }
         Printer::Patch(ref mut p) => {
-            let mut sink = p.sink_with_path(&matcher, path);
-            searcher.search_reader(&matcher, &mut rdr, &mut sink)?;
-            Ok(SearchResult {
-                has_match: sink.has_match(),
-                stats: None,
-            })
+            unimplemented!("need to decide how to handle stream 'patching'")
         }
     }
 }

--- a/crates/core/search.rs
+++ b/crates/core/search.rs
@@ -554,7 +554,6 @@ fn search_reader<M: Matcher, R: io::Read, W: WriteColor>(
             })
         }
         Printer::Patch(ref mut p) => {
-            // XXX we still need to make sure that we actually have a filename here...
             let mut sink = p.sink_with_path(&matcher, path);
             searcher.search_reader(&matcher, &mut rdr, &mut sink)?;
             Ok(SearchResult {

--- a/crates/core/search.rs
+++ b/crates/core/search.rs
@@ -553,8 +553,13 @@ fn search_reader<M: Matcher, R: io::Read, W: WriteColor>(
                 stats: Some(sink.stats().clone()),
             })
         }
-        Printer::Patch(ref mut _p) => {
-            unimplemented!("need to decide how to handle stream 'patching'")
+        Printer::Patch(ref mut p) => {
+            let mut sink = p.sink_with_path(&matcher, path);
+            searcher.search_reader(&matcher, &mut rdr, &mut sink)?;
+            Ok(SearchResult {
+                has_match: sink.has_match(),
+                stats: Some(sink.stats().clone()),
+            })
         }
     }
 }

--- a/crates/core/search.rs
+++ b/crates/core/search.rs
@@ -10,7 +10,7 @@ use grep::matcher::Matcher;
 use grep::pcre2::RegexMatcher as PCRE2RegexMatcher;
 use grep::printer::{Standard, Stats, Summary, JSON, Patch};
 use grep::regex::RegexMatcher as RustRegexMatcher;
-use grep::searcher::{BinaryDetection, Searcher, Sink};
+use grep::searcher::{BinaryDetection, Searcher};
 use ignore::overrides::Override;
 use serde_json as json;
 use serde_json::json;
@@ -241,7 +241,7 @@ impl<W: WriteColor> Printer<W> {
         match *self {
             Printer::JSON(_) => self.print_stats_json(total_duration, stats),
             // XXX is 'patch' incompatible w/ 'stats'? Maybe not; check what git-patch does
-            Printer::Patch(_) => unimplemented!(),
+            Printer::Patch(_) => unimplemented!("not sure what 'stats' would mean for Patch printer"),
             Printer::Standard(_) | Printer::Summary(_) => {
                 self.print_stats_human(total_duration, stats)
             }
@@ -553,7 +553,7 @@ fn search_reader<M: Matcher, R: io::Read, W: WriteColor>(
                 stats: Some(sink.stats().clone()),
             })
         }
-        Printer::Patch(ref mut p) => {
+        Printer::Patch(ref mut _p) => {
             unimplemented!("need to decide how to handle stream 'patching'")
         }
     }

--- a/crates/core/search.rs
+++ b/crates/core/search.rs
@@ -513,7 +513,7 @@ fn search_path<M: Matcher, W: WriteColor>(
             searcher.search_path(&matcher, path, &mut sink)?;
             Ok(SearchResult {
                 has_match: sink.has_match(),
-                stats: sink.stats().map(|s| s.clone()),
+                stats: None,
             })
         }
     }
@@ -558,7 +558,7 @@ fn search_reader<M: Matcher, R: io::Read, W: WriteColor>(
             searcher.search_reader(&matcher, &mut rdr, &mut sink)?;
             Ok(SearchResult {
                 has_match: sink.has_match(),
-                stats: Some(sink.stats().clone()),
+                stats: None,
             })
         }
     }

--- a/crates/core/search.rs
+++ b/crates/core/search.rs
@@ -554,11 +554,12 @@ fn search_reader<M: Matcher, R: io::Read, W: WriteColor>(
             })
         }
         Printer::Patch(ref mut p) => {
+            // XXX we still need to make sure that we actually have a filename here...
             let mut sink = p.sink_with_path(&matcher, path);
             searcher.search_reader(&matcher, &mut rdr, &mut sink)?;
             Ok(SearchResult {
                 has_match: sink.has_match(),
-                stats: Some(sink.stats().clone()),
+                stats: None,
             })
         }
     }

--- a/crates/core/search.rs
+++ b/crates/core/search.rs
@@ -240,8 +240,7 @@ impl<W: WriteColor> Printer<W> {
     ) -> io::Result<()> {
         match *self {
             Printer::JSON(_) => self.print_stats_json(total_duration, stats),
-            // XXX is 'patch' incompatible w/ 'stats'? Maybe not; check what git-patch does
-            Printer::Patch(_) => unimplemented!("not sure what 'stats' would mean for Patch printer"),
+            Printer::Patch(_) => unimplemented!("these options are incompatible"),
             Printer::Standard(_) | Printer::Summary(_) => {
                 self.print_stats_human(total_duration, stats)
             }

--- a/crates/printer/src/json.rs
+++ b/crates/printer/src/json.rs
@@ -508,6 +508,10 @@ impl<W: io::Write> JSON<W> {
     /// Write the given message followed by a new line. The new line is
     /// determined from the configuration of the given searcher.
     // XXX how does that work, since it looks like it's literally writing b'\n'?
+    // Note: for `--patch`, it appears `\n` is not unified with the line-endings
+    // from the search content.
+    // ...also, searchers appear to only have line-endings configured for the
+    // purpose of matching on them, not for printing.
     fn write_message(
         &mut self,
         message: &jsont::Message<'_>,

--- a/crates/printer/src/json.rs
+++ b/crates/printer/src/json.rs
@@ -507,6 +507,7 @@ impl<W: io::Write> JSON<W> {
 
     /// Write the given message followed by a new line. The new line is
     /// determined from the configuration of the given searcher.
+    // XXX how does that work, since it looks like it's literally writing b'\n'?
     fn write_message(
         &mut self,
         message: &jsont::Message<'_>,

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -96,6 +96,7 @@ mod json;
 #[cfg(feature = "serde1")]
 mod jsont;
 mod patch;
+mod patcht;
 mod standard;
 mod stats;
 mod summary;

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -69,6 +69,7 @@ pub use crate::color::{
 };
 #[cfg(feature = "serde1")]
 pub use crate::json::{JSONBuilder, JSONSink, JSON};
+pub use crate::patch::{PatchBuilder, PatchSink, Patch};
 pub use crate::standard::{Standard, StandardBuilder, StandardSink};
 pub use crate::stats::Stats;
 pub use crate::summary::{Summary, SummaryBuilder, SummaryKind, SummarySink};
@@ -94,6 +95,7 @@ mod counter;
 mod json;
 #[cfg(feature = "serde1")]
 mod jsont;
+mod patch;
 mod standard;
 mod stats;
 mod summary;

--- a/crates/printer/src/patch.rs
+++ b/crates/printer/src/patch.rs
@@ -184,7 +184,6 @@ impl<'p, 's, M: Matcher, W: io::Write> PatchSink<'p, 's, M, W> {
         if self.begin_printed {
             return Ok(());
         }
-        // XXX need to select header type based on config style
         write_header(&mut self.patch.wtr, self.path)?;
         self.begin_printed = true;
         Ok(())
@@ -192,24 +191,20 @@ impl<'p, 's, M: Matcher, W: io::Write> PatchSink<'p, 's, M, W> {
 }
 
 fn write_header<W: io::Write>(wtr: &mut W, path: &Path) -> io::Result<()> {
-    // XXX for this, should the 'file2' path be different from 'file1'?
     let path_bytes = path.as_os_str().as_bytes();
     wtr.write(ORIG_PREFIX)?;
     wtr.write(path_bytes)?;
     // The GNU and POSIX documentation both state that diffs include file
     // timestamps, but git doesn't include one with either `diff` or
-    // `format-patch`.
-    // XXX figure out if this actually matters
-    // fs::metadata(self.path)?.modified()?
-    // wtr.write(b", 2002-02-21 23:30:39.942229878 -0800")?;
+    // `format-patch`, and indeed GNU `patch` doesn't seem to need timestamps.
+    // (Haven't checked BSD but I'd be surprised if it's different in this
+    // regard.)
 
     // XXX should the line-endings for patch files match the native line-endings?
-    // Will this be done automatically? (See comment in `json.rs`)
+    // Will this be done automatically by the `BufferWriter`?
     wtr.write(&[b'\n'])?;
     wtr.write(MOD_PREFIX)?;
     wtr.write(path_bytes)?;
-    // XXX see comment above about the timestamps
-    // wtr.write(b", 2002-02-21 23:30:39.942229878 -0800")?;
     wtr.write(&[b'\n'])?;
     Ok(())
 }

--- a/crates/printer/src/patch.rs
+++ b/crates/printer/src/patch.rs
@@ -1,0 +1,73 @@
+use std::io::{self, Write};
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+enum PatchStyle {
+    Normal,
+    Context,
+    Ed,
+}
+
+#[derive(Debug, Clone)]
+struct Config {
+    style: PatchStyle,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config { style: Normal, }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PatchBuilder {
+    config: Config,
+}
+
+#[derive(Debug)]
+pub struct Patch<W> {
+    matches: Vec<Match>,
+}
+
+#[derive(Debug)]
+pub struct PatchSink<'p, 's, M: Matcher, W> {
+    matcher: M,
+    patch: &'s mut Patch<W>,
+    path: Option<&'p Path>,
+    start_time: Instant,
+    match_count: u64,
+    after_context_remaining: u64,
+    binary_byte_offset: Option<u64>,
+    begin_printed: bool,
+    stats: Stats,
+}
+
+impl<W: io::Write> Patch<W> {
+    pub fn new(wtr: W) -> Patch<W> {
+        PatchBuilder::new().build(wtr)
+    }
+
+    pub fn sink_with_path<'p, 's, M, P>(
+        &'s mut self,
+        matcher: M,
+        path: &'p P,
+    ) -> PatchSink<'p, 's, M, W>
+    where
+        M: Matcher,
+        P: ?Sized + AsRef<Path>,
+    {
+        PatchSink {
+            matcher: matcher,
+            json: self,
+            path: Some(path.as_ref()),
+            start_time: Instant::now(),
+            match_count: 0,
+            after_context_remaining: 0,
+            binary_byte_offset: None,
+            begin_printed: false,
+            stats: Stats::new(),
+        }
+    }
+
+
+}

--- a/crates/printer/src/patch.rs
+++ b/crates/printer/src/patch.rs
@@ -199,9 +199,6 @@ fn write_header<W: io::Write>(wtr: &mut W, path: &Path) -> io::Result<()> {
     // `format-patch`, and indeed GNU `patch` doesn't seem to need timestamps.
     // (Haven't checked BSD but I'd be surprised if it's different in this
     // regard.)
-
-    // XXX should the line-endings for patch files match the native line-endings?
-    // Will this be done automatically by the `BufferWriter`?
     wtr.write(&[b'\n'])?;
     wtr.write(MOD_PREFIX)?;
     wtr.write(&ppath)?;

--- a/crates/printer/src/patch.rs
+++ b/crates/printer/src/patch.rs
@@ -1,8 +1,8 @@
 use std::io;
-use std::os::unix::prelude::OsStrExt;
 use std::path::Path;
 use std::time::Instant;
 
+use bstr::ByteVec;
 use grep_matcher::{Matcher, Match};
 use grep_searcher::{Searcher, Sink, SinkContextKind, SinkMatch, SinkContext, SinkFinish};
 
@@ -191,9 +191,9 @@ impl<'p, 's, M: Matcher, W: io::Write> PatchSink<'p, 's, M, W> {
 }
 
 fn write_header<W: io::Write>(wtr: &mut W, path: &Path) -> io::Result<()> {
-    let path_bytes = path.as_os_str().as_bytes();
+    let ppath = Vec::from_path_lossy(path);
     wtr.write(ORIG_PREFIX)?;
-    wtr.write(path_bytes)?;
+    wtr.write(&ppath)?;
     // The GNU and POSIX documentation both state that diffs include file
     // timestamps, but git doesn't include one with either `diff` or
     // `format-patch`, and indeed GNU `patch` doesn't seem to need timestamps.
@@ -204,7 +204,7 @@ fn write_header<W: io::Write>(wtr: &mut W, path: &Path) -> io::Result<()> {
     // Will this be done automatically by the `BufferWriter`?
     wtr.write(&[b'\n'])?;
     wtr.write(MOD_PREFIX)?;
-    wtr.write(path_bytes)?;
+    wtr.write(&ppath)?;
     wtr.write(&[b'\n'])?;
     Ok(())
 }

--- a/crates/printer/src/patch.rs
+++ b/crates/printer/src/patch.rs
@@ -1,79 +1,317 @@
-use std::cell::RefCell;
-use std::io::{self, Write};
+use std::{cell::RefCell};
+use std::io;
 use std::path::Path;
 use std::time::Instant;
 
 use grep_matcher::{Matcher, Match};
-use termcolor::WriteColor;
+use grep_searcher::{Searcher, Sink, SinkContextKind, SinkMatch, SinkContext, SinkFinish};
 
-use crate::Stats;
 use crate::counter::CounterWriter;
+use crate::util::{find_iter_at_in_context, Replacer};
 
 #[derive(Debug, Clone)]
 enum PatchStyle {
     Normal,
+    /* TODO: determine if it's useful to support these formats
     Context,
     Ed,
+    */
 }
 
 #[derive(Debug, Clone)]
 struct Config {
+    // Patch printing can only be used with a replacement.
+    replacement: Vec<u8>,
     style: PatchStyle,
 }
 
 impl Default for Config {
     fn default() -> Config {
-        Config { style: PatchStyle::Normal, }
+        Config { style: PatchStyle::Normal, replacement: Vec::default(), }
     }
 }
 
+/// Configuration for the patch-output printer
 #[derive(Clone, Debug)]
 pub struct PatchBuilder {
     config: Config,
+    replacement_set: bool,
 }
 
 impl PatchBuilder {
+    /// Return a new builder for configuring the patch printer.
     pub fn new() -> PatchBuilder {
-        PatchBuilder { config: Config::default() }
+        PatchBuilder { config: Config::default(), replacement_set: false, }
     }
 
-    pub fn build<W: WriteColor>(&self, wtr: W) -> Patch<W> {
-        Patch {
-            config: self.config.clone(),
-            wtr: RefCell::new(CounterWriter::new(wtr)),
-            matches: vec![],
+    /// Create a Patch printer that writes results to the given writer.
+    pub fn build<W: io::Write>(&self, wtr: W) -> Result<Patch<W>, io::Error> {
+        if !self.replacement_set {
+            return Err(io::Error::new(io::ErrorKind::Other, "replacement text not set"))
         }
+        Ok(Patch {
+            config: self.config.clone(),
+            wtr: CounterWriter::new(wtr),
+            matches: vec![],
+        })
+    }
+
+    /// Set the bytes that will be used to replace each occurrence of a match
+    /// found.
+    ///
+    /// The replacement bytes given may include references to capturing groups,
+    /// which may either be in index form (e.g., `$2`) or can reference named
+    /// capturing groups if present in the original pattern (e.g., `$foo`).
+    ///
+    /// For documentation on the full format, please see the `Capture` trait's
+    /// `interpolate` method in the
+    /// [grep-printer](https://docs.rs/grep-printer) crate.
+    pub fn replacement(
+        &mut self,
+        replacement: Vec<u8>,
+    ) -> &mut PatchBuilder {
+        self.replacement_set = true;
+        self.config.replacement = replacement;
+        self
     }
 }
 
+/// A printer for generating patch output, usable with the POSIX `patch`
+/// utility.
 #[derive(Debug)]
 pub struct Patch<W> {
     config: Config,
-    wtr: RefCell<CounterWriter<W>>,
+    wtr: CounterWriter<W>,
     matches: Vec<Match>,
 }
 
+impl<W> Patch<W> {
+    /// Returns true if and only if this printer has written at least one byte
+    /// to the underlying writer during any of the previous searches.
+    pub fn has_written(&self) -> bool {
+        self.wtr.total_count() > 0
+    }
+
+    /// Return a mutable reference to the underlying writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        self.wtr.get_mut()
+    }
+
+    /// Consume this printer and return back ownership of the underlying
+    /// writer.
+    pub fn into_inner(self) -> W {
+        self.wtr.into_inner()
+    }
+}
+
+/// An implementation of `Sink` associated with a matcher and an optional file
+/// path for the patch printer.
+///
+/// A `Sink` can be created via the
+/// [`Standard::sink`](struct.Standard.html#method.sink)
+/// or
+/// [`Standard::sink_with_path`](struct.Standard.html#method.sink_with_path)
+/// methods, depending on whether you want to include a file path in the
+/// printer's output.
 #[derive(Debug)]
 pub struct PatchSink<'p, 's, M: Matcher, W> {
     matcher: M,
     patch: &'s mut Patch<W>,
+    replacer: Replacer<M>,
     path: Option<&'p Path>,
     start_time: Instant,
     match_count: u64,
     after_context_remaining: u64,
     binary_byte_offset: Option<u64>,
     begin_printed: bool,
-    // XXX replace with 'Stats' if appropriate
-    has_match: bool,
 }
 
 impl<'p, 's, M: Matcher, W> PatchSink<'p, 's, M, W> {
-    fn has_match(&self) -> bool {
-        return self.has_match;
+    /// Returns true if and only if this printer received a match in the
+    /// previous search.
+    ///
+    /// This is unaffected by the result of searches before the previous
+    /// search on this sink.
+    pub fn has_match(&self) -> bool {
+        return self.match_count > 0;
+    }
+
+    /// Returns true if this printer should quit.
+    ///
+    /// This implements the logic for handling quitting after seeing a certain
+    /// amount of matches. In most cases, the logic is simple, but we must
+    /// permit all "after" contextual lines to print after reaching the limit.
+    fn should_quit(&self) -> bool {
+        false
+    }
+
+    /// Execute the matcher over the given bytes and record the match
+    /// locations if the current configuration demands match granularity.
+    fn record_matches(
+        &mut self,
+        searcher: &Searcher,
+        bytes: &[u8],
+        range: std::ops::Range<usize>,
+    ) -> io::Result<()> {
+        self.patch.matches.clear();
+
+        // Implementation taken from `Standard.record_matches`; see comment
+        // there about allocation
+        let matches = &mut self.patch.matches;
+        find_iter_at_in_context(
+            searcher,
+            &self.matcher,
+            bytes,
+            range.clone(),
+            |m| {
+                let (s, e) = (m.start() - range.start, m.end() - range.start);
+                matches.push(Match::new(s, e));
+                true
+            },
+        )?;
+        // Don't report empty matches appearing at the end of the bytes.
+        if !matches.is_empty()
+            && matches.last().unwrap().is_empty()
+            && matches.last().unwrap().start() >= range.end
+        {
+            matches.pop().unwrap();
+        }
+        Ok(())
+    }
+
+    /// If the configuration specifies a replacement, then this executes the
+    /// replacement, lazily allocating memory if necessary.
+    ///
+    /// To access the result of a replacement, use `replacer.replacement()`.
+    fn replace(
+        &mut self,
+        searcher: &Searcher,
+        bytes: &[u8],
+        range: std::ops::Range<usize>,
+    ) -> io::Result<()> {
+        self.replacer.clear();
+        // The Patch printer performs replacement unconditionally.
+        self.replacer.replace_all(
+            searcher,
+            &self.matcher,
+            bytes,
+            range,
+            &self.patch.config.replacement,
+        )
+    }
+
+    /// Write the "begin" message.
+    fn write_begin_message(&mut self) -> io::Result<()> {
+        if self.begin_printed {
+            return Ok(());
+        }
+        unimplemented!();
+        self.begin_printed = true;
+        Ok(())
+    }
+}
+
+impl<'p, 's, M: Matcher, W> Sink for PatchSink<'p, 's, M, W> {
+    type Error = io::Error;
+
+    fn matched(
+        &mut self,
+        searcher: &Searcher,
+        mat: &SinkMatch<'_>,
+    ) -> Result<bool, io::Error> {
+        self.write_begin_message()?;
+
+        self.match_count += 1;
+
+        self.record_matches(
+            searcher,
+            mat.buffer(),
+            mat.bytes_range_in_buffer(),
+        )?;
+        self.replace(searcher, mat.buffer(), mat.bytes_range_in_buffer())?;
+
+        if searcher.binary_detection().convert_byte().is_some() {
+            if self.binary_byte_offset.is_some() {
+                return Ok(false);
+            }
+        }
+
+        unimplemented!();
+    }
+
+    fn context(
+        &mut self,
+        searcher: &Searcher,
+        ctx: &SinkContext<'_>,
+    ) -> Result<bool, io::Error> {
+        self.patch.matches.clear();
+        self.replacer.clear();
+
+        if ctx.kind() == &SinkContextKind::After {
+            self.after_context_remaining =
+                self.after_context_remaining.saturating_sub(1);
+        }
+        if searcher.invert_match() {
+            self.record_matches(searcher, ctx.bytes(), 0..ctx.bytes().len())?;
+            self.replace(searcher, ctx.bytes(), 0..ctx.bytes().len())?;
+        }
+        if searcher.binary_detection().convert_byte().is_some() {
+            if self.binary_byte_offset.is_some() {
+                return Ok(false);
+            }
+        }
+
+        unimplemented!();
+    }
+
+    fn context_break(
+        &mut self,
+        searcher: &Searcher,
+    ) -> Result<bool, io::Error> {
+        // StandardImpl::new(searcher, self).write_context_separator()?;
+        Ok(true)
+    }
+
+    fn binary_data(
+        &mut self,
+        _searcher: &Searcher,
+        binary_byte_offset: u64,
+    ) -> Result<bool, io::Error> {
+        self.binary_byte_offset = Some(binary_byte_offset);
+        Ok(true)
+    }
+
+
+    fn begin(&mut self, _searcher: &Searcher) -> Result<bool, io::Error> {
+        self.patch.wtr.reset_count();
+        self.start_time = Instant::now();
+        self.match_count = 0;
+        self.after_context_remaining = 0;
+        self.binary_byte_offset = None;
+        self.write_begin_message()?;
+        Ok(true)
+    }
+
+    fn finish(
+        &mut self,
+        _searcher: &Searcher,
+        finish: &SinkFinish,
+    ) -> Result<(), io::Error> {
+        if !self.begin_printed {
+            return Ok(());
+        }
+
+        self.binary_byte_offset = finish.binary_byte_offset();
+
+        unimplemented!()
     }
 }
 
 impl<W: io::Write> Patch<W> {
+    /// Return an implementation of `Sink` associated with a file path.
+    ///
+    /// When the printer is associated with a path, then it may, depending on
+    /// its configuration, print the path along with the matches found.
     pub fn sink_with_path<'p, 's, M, P>(
         &'s mut self,
         matcher: M,
@@ -86,13 +324,13 @@ impl<W: io::Write> Patch<W> {
         PatchSink {
             matcher: matcher,
             patch: self,
+            replacer: Replacer::new(),
             path: Some(path.as_ref()),
             start_time: Instant::now(),
             match_count: 0,
             after_context_remaining: 0,
             binary_byte_offset: None,
             begin_printed: false,
-            has_match: false,
         }
     }
 

--- a/crates/printer/src/patch.rs
+++ b/crates/printer/src/patch.rs
@@ -1,5 +1,13 @@
+use std::cell::RefCell;
 use std::io::{self, Write};
 use std::path::Path;
+use std::time::Instant;
+
+use grep_matcher::{Matcher, Match};
+use termcolor::WriteColor;
+
+use crate::Stats;
+use crate::counter::CounterWriter;
 
 #[derive(Debug, Clone)]
 enum PatchStyle {
@@ -15,7 +23,7 @@ struct Config {
 
 impl Default for Config {
     fn default() -> Config {
-        Config { style: Normal, }
+        Config { style: PatchStyle::Normal, }
     }
 }
 
@@ -24,8 +32,24 @@ pub struct PatchBuilder {
     config: Config,
 }
 
+impl PatchBuilder {
+    pub fn new() -> PatchBuilder {
+        PatchBuilder { config: Config::default() }
+    }
+
+    pub fn build<W: WriteColor>(&self, wtr: W) -> Patch<W> {
+        Patch {
+            config: self.config.clone(),
+            wtr: RefCell::new(CounterWriter::new(wtr)),
+            matches: vec![],
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Patch<W> {
+    config: Config,
+    wtr: RefCell<CounterWriter<W>>,
     matches: Vec<Match>,
 }
 
@@ -39,14 +63,17 @@ pub struct PatchSink<'p, 's, M: Matcher, W> {
     after_context_remaining: u64,
     binary_byte_offset: Option<u64>,
     begin_printed: bool,
-    stats: Stats,
+    // XXX replace with 'Stats' if appropriate
+    has_match: bool,
+}
+
+impl<'p, 's, M: Matcher, W> PatchSink<'p, 's, M, W> {
+    fn has_match(&self) -> bool {
+        return self.has_match;
+    }
 }
 
 impl<W: io::Write> Patch<W> {
-    pub fn new(wtr: W) -> Patch<W> {
-        PatchBuilder::new().build(wtr)
-    }
-
     pub fn sink_with_path<'p, 's, M, P>(
         &'s mut self,
         matcher: M,
@@ -58,14 +85,14 @@ impl<W: io::Write> Patch<W> {
     {
         PatchSink {
             matcher: matcher,
-            json: self,
+            patch: self,
             path: Some(path.as_ref()),
             start_time: Instant::now(),
             match_count: 0,
             after_context_remaining: 0,
             binary_byte_offset: None,
             begin_printed: false,
-            stats: Stats::new(),
+            has_match: false,
         }
     }
 

--- a/crates/printer/src/patch.rs
+++ b/crates/printer/src/patch.rs
@@ -297,7 +297,6 @@ impl<'p, 's, M: Matcher, W: io::Write> Sink for PatchSink<'p, 's, M, W> {
         self.match_count = 0;
         self.after_context_remaining = 0;
         self.binary_byte_offset = None;
-        self.write_patch_header()?;
         Ok(true)
     }
 

--- a/crates/printer/src/patcht.rs
+++ b/crates/printer/src/patcht.rs
@@ -1,0 +1,94 @@
+/// This module defines the types we use for Patch generation.
+
+use std::io;
+
+use bstr::ByteVec;
+use grep_searcher::{SinkMatch, SinkContext};
+
+/// The patch styles match different possible input types accepted by the
+/// `patch` utiltiy.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PatchStyle {
+    // The Unified format (originally GNU-only)
+    Unified,
+    /* TODO: determine if it's useful to support these formats
+    Posix, // <- what should this be named? the 'classic' patch format
+    Context,
+    Ed,
+    */
+}
+
+#[derive(Debug, Default)]
+pub struct PatchHunk {
+    // Only one starting line number is necessary, because multi-line replace is
+    // not supported
+    starting_line_number: Option<u64>,
+    lines: Vec<PatchLine>,
+}
+
+/// A line in a hunk. Unfortunately, this must copy each line, since they cannot
+/// be printed until the header has been printed, and matches provided to
+/// `Sink.matched` are references that won't live that long.
+#[derive(Debug)]
+pub enum PatchLine {
+    Unchanged(Vec<u8>),
+    // Orig, new
+    Changed(Vec<u8>, Vec<u8>)
+}
+
+impl PatchHunk {
+    pub fn write<W: io::Write>(&self, wtr: &mut W, style: PatchStyle) -> Result<(), io::Error> {
+        if style != PatchStyle::Unified {
+            unimplemented!("only unified patch style supported for now");
+        }
+        match self.starting_line_number {
+            Some(number) => 
+                write!(
+                    wtr, "@@ -{line},{count} +{line},{count} @@\n",
+                    line=number, count=self.lines.len())?,
+            // XXX change error type
+            None => return Err(io::Error::new(io::ErrorKind::Other, "no line numbers")),
+        }
+        for line in &self.lines {
+            line.write(&mut *wtr)?;
+        }
+        Ok(())
+    }
+
+    pub fn add_context(&mut self, ctx: &SinkContext<'_>) {
+        self.lines.push(PatchLine::Unchanged(ctx.bytes().to_vec()));
+    }
+
+    pub fn add_match(&mut self, mat: &SinkMatch<'_>, replacement: &[u8]) {
+        // XXX validate `unwrap` here - when would a match not have a line
+        // number? (Presumably this case would not be supported by this printer)
+        let _ = self.starting_line_number.get_or_insert_with(|| mat.line_number().unwrap());
+        let orig = mat.bytes().to_vec();
+        let mut modified = replacement.to_vec();
+        // Unlike the match, the replacement does not include the line ending.
+        // XXX find out if line-endings need to be consolidated
+        modified.push_char('\n');
+        self.lines.push(PatchLine::Changed(orig, modified));
+    }
+}
+
+impl PatchLine {
+    fn write<W: io::Write>(&self, wtr: &mut W) -> Result<(), io::Error> {
+        use PatchLine::*;
+        match self {
+            Unchanged(line) => {
+                wtr.write(b" ")?;
+                // XXX figure out if lines will have newlines included
+                // XXX figure out if 'write' is still safe here, with potentially long lines
+                wtr.write(&line)?;
+            }
+            Changed(old, new) => {
+                wtr.write(b"-")?;
+                wtr.write(&old)?;
+                wtr.write(b"+")?;
+                wtr.write(&new)?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/printer/src/patcht.rs
+++ b/crates/printer/src/patcht.rs
@@ -78,8 +78,6 @@ impl PatchLine {
         match self {
             Unchanged(line) => {
                 wtr.write(b" ")?;
-                // XXX figure out if lines will have newlines included
-                // XXX figure out if 'write' is still safe here, with potentially long lines
                 wtr.write(&line)?;
             }
             Changed(old, new) => {

--- a/crates/printer/src/patcht.rs
+++ b/crates/printer/src/patcht.rs
@@ -66,8 +66,7 @@ impl PatchHunk {
     }
 
     pub fn add_match(&mut self, mat: &SinkMatch<'_>, replacement: &[u8]) {
-        // XXX validate `unwrap` here - when would a match not have a line
-        // number? (Presumably this case would not be supported by this printer)
+        // Line numbers are always tracked in patch-printing mode
         let _ = self.starting_line_number.get_or_insert_with(|| mat.line_number().unwrap());
         let orig = mat.bytes().to_vec();
         let mut modified = replacement.to_vec();

--- a/crates/printer/src/patcht.rs
+++ b/crates/printer/src/patcht.rs
@@ -71,7 +71,6 @@ impl PatchHunk {
         let orig = mat.bytes().to_vec();
         let mut modified = replacement.to_vec();
         // Unlike the match, the replacement does not include the line ending.
-        // XXX find out if line-endings need to be consolidated
         modified.push_char('\n');
         self.lines.push(PatchLine::Changed(orig, modified));
     }


### PR DESCRIPTION
Proof-of-concept for a grep-printer that works in conjunction with `--replace` to generate `patch` files, as suggested [here](https://github.com/BurntSushi/ripgrep/issues/74#issuecomment-251377251).