### PR TITLE
Add support for Solidity as a file extension

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -225,6 +225,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("slim", &["*.skim", "*.slim", "*.slime"]),
     ("smarty", &["*.tpl"]),
     ("sml", &["*.sml", "*.sig"]),
+    ("solidity", &["*.sol"]),
     ("soy", &["*.soy"]),
     ("spark", &["*.spark"]),
     ("spec", &["*.spec"]),


### PR DESCRIPTION
Adding support for Solidity as a language and the *.sol file extension corresponding to it. The idea is to allow for the use of the flag `--type solidity` in order to search only in Solidity files.

Solidity is a programming language for the Ethereum Virtual Machine and is one of the most popular languages for developing blockchain software.
https://soliditylang.org/about/
https://en.wikipedia.org/wiki/Solidity

Follow up to #2283. I'm not an experienced Rust dev and this is my first contribution to the repo so let me know if there are additional code locations to update or any other steps required for making a high-quality PR.