### PR TITLE
derive `Default` for `SubjectBuilder`

### DIFF
--- a/crates/core/subject.rs
+++ b/crates/core/subject.rs
@@ -4,15 +4,9 @@ use ignore::{self, DirEntry};
 use log;
 
 /// A configuration for describing how subjects should be built.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 struct Config {
     strip_dot_prefix: bool,
-}
-
-impl Default for Config {
-    fn default() -> Config {
-        Config { strip_dot_prefix: false }
-    }
 }
 
 /// A builder for constructing things to search over.


### PR DESCRIPTION
Hello,

I am reviewing potentially clippy false-positive/false-negative after a change to `clippy::derivable_impls`.
In this case the lint seems correct unless the manual implementation is to emphasise the `strip_dot_prefix: false`. In this case feel free to close