### PR TITLE
Add support for v language

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -252,6 +252,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("twig", &["*.twig"]),
     ("txt", &["*.txt"]),
     ("typoscript", &["*.typoscript", "*.ts"]),
+    ("v", &["*.v"]),
     ("vala", &["*.vala"]),
     ("vb", &["*.vb"]),
     ("vcl", &["*.vcl"]),


### PR DESCRIPTION
V (http://vlang.io) uses '.v' files.