### PR TITLE
bump bstr to 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-22.04
-          rust: 1.52.1
+          rust: 1.60.0
         - build: stable
           os: ubuntu-22.04
           rust: stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,13 +36,14 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd"
 dependencies = [
- "lazy_static",
  "memchr",
+ "once_cell",
  "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -353,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "packed_simd_2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = ["HomebrewFormula"]
 build = "build.rs"
 autotests = false
 edition = "2018"
+rust-version = "1.60"
 
 [[bin]]
 bench = false
@@ -41,7 +42,7 @@ members = [
 ]
 
 [dependencies]
-bstr = "0.2.12"
+bstr = "1.0"
 grep = { version = "0.2.8", path = "crates/grep" }
 ignore = { version = "0.4.18", path = "crates/ignore" }
 lazy_static = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ $ pkgman install ripgrep_x86
 
 If you're a **Rust programmer**, ripgrep can be installed with `cargo`.
 
-* Note that the minimum supported version of Rust for ripgrep is **1.34.0**,
+* Note that the minimum supported version of Rust for ripgrep is **1.60.0**,
   although ripgrep may work with older versions.
 * Note that the binary may be bigger than expected because it contains debug
   symbols. This is intentional. To remove debug symbols and therefore reduce

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 keywords = ["regex", "grep", "cli", "utility", "util"]
 license = "Unlicense OR MIT"
 edition = "2018"
+rust-version = "1.60"
 
 [dependencies]
 atty = "0.2.11"
-bstr = "0.2.0"
+bstr = "1.0"
 globset = { version = "0.4.9", path = "../globset" }
 lazy_static = "1.1.0"
 log = "0.4.5"

--- a/crates/core/config.rs
+++ b/crates/core/config.rs
@@ -80,7 +80,7 @@ fn parse<P: AsRef<Path>>(
 fn parse_reader<R: io::Read>(
     rdr: R,
 ) -> Result<(Vec<OsString>, Vec<Box<dyn Error>>)> {
-    let bufrdr = io::BufReader::new(rdr);
+    let mut bufrdr = io::BufReader::new(rdr);
     let (mut args, mut errs) = (vec![], vec![]);
     let mut line_number = 0;
     bufrdr.for_byte_line_with_terminator(|line| {

--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 keywords = ["regex", "glob", "multiple", "set", "pattern"]
 license = "Unlicense OR MIT"
 edition = "2018"
+rust-version = "1.60"
 
 [lib]
 name = "globset"
@@ -21,7 +22,7 @@ bench = false
 
 [dependencies]
 aho-corasick = "0.7.3"
-bstr = { version = "0.2.0", default-features = false, features = ["std"] }
+bstr = { version = "1.0", default-features = false, features = ["std"] }
 fnv = "1.0.6"
 log = { version = "0.4.5", optional = true }
 regex = { version = "1.1.5", default-features = false, features = ["perf", "std"] }

--- a/crates/grep/Cargo.toml
+++ b/crates/grep/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords = ["regex", "grep", "egrep", "search", "pattern"]
 license = "Unlicense OR MIT"
 edition = "2018"
+rust-version = "1.60"
 
 [dependencies]
 grep-cli = { version = "0.1.6", path = "../cli" }

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 keywords = ["glob", "ignore", "gitignore", "pattern", "file"]
 license = "Unlicense OR MIT"
 edition = "2018"
+rust-version = "1.60"
 
 [lib]
 name = "ignore"

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 keywords = ["grep", "pattern", "print", "printer", "sink"]
 license = "Unlicense OR MIT"
 edition = "2018"
+rust-version = "1.60"
 
 [features]
 default = ["serde1"]
@@ -20,7 +21,7 @@ serde1 = ["base64", "serde", "serde_json"]
 
 [dependencies]
 base64 = { version = "0.13.0", optional = true }
-bstr = "0.2.0"
+bstr = "1.0"
 grep-matcher = { version = "0.1.5", path = "../matcher" }
 grep-searcher = { version = "0.1.8", path = "../searcher" }
 termcolor = "1.0.4"

--- a/crates/regex/Cargo.toml
+++ b/crates/regex/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 keywords = ["regex", "grep", "search", "pattern", "line"]
 license = "Unlicense OR MIT"
 edition = "2018"
+rust-version = "1.60"
 
 [dependencies]
 aho-corasick = "0.7.3"
-bstr = "0.2.10"
+bstr = "1.0"
 grep-matcher = { version = "0.1.5", path = "../matcher" }
 log = "0.4.5"
 regex = "1.1"

--- a/crates/searcher/Cargo.toml
+++ b/crates/searcher/Cargo.toml
@@ -12,9 +12,10 @@ readme = "README.md"
 keywords = ["regex", "grep", "egrep", "search", "pattern"]
 license = "Unlicense OR MIT"
 edition = "2018"
+rust-version = "1.60"
 
 [dependencies]
-bstr = { version = "0.2.0", default-features = false, features = ["std"] }
+bstr = { version = "1.0", default-features = false, features = ["std"] }
 bytecount = "0.6"
 encoding_rs = "0.8.14"
 encoding_rs_io = "0.1.6"

--- a/crates/searcher/src/line_buffer.rs
+++ b/crates/searcher/src/line_buffer.rs
@@ -481,7 +481,7 @@ impl LineBuffer {
         }
 
         let roll_len = self.end - self.pos;
-        self.buf.copy_within_str(self.pos..self.end, 0);
+        self.buf.copy_within(self.pos..self.end, 0);
         self.pos = 0;
         self.last_lineterm = roll_len;
         self.end = roll_len;


### PR DESCRIPTION
updates bstr to 1.0 and closes #2310
This allows downstream crates to use bstr 1.0 (or other crates that depend on it) without compiling it twice.

This raises the MSRV to 1.60.
When I first filed #2310 I assumed that raising the MSRV was not an option because it was set to 1.34.
However I discovered that ripgrep already has an MSRV of 1.52 since 9f924ee187d4c62aa6ebe4903d0cfc6507a5adb5.
To avoid future confusions like this I also updated the README with the new MSRV.
