### PR TITLE
Enable Dependabot for the Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot automatically files PRs for updatable dependencies. As configured it watches all workflow files in `.github/workflows` for possible updates to any of the Actions depended upon.

---
It also supports updating rust dependencies, but I've kept this minimal to gauge interest. See https://github.com/eminence/terminal-size/pull/42 for an example of a PR you'll also automatically receive after merging this.
