### PR TITLE
Add ReScript and ReasonML default types

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -190,6 +190,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("rdoc", &["*.rdoc"]),
     ("readme", &["README*", "*README"]),
     ("red", &["*.r", "*.red", "*.reds"]),
+    ("rescript", &["*.res", "*.resi"]),
     ("robot", &["*.robot"]),
     ("rst", &["*.rst"]),
     ("ruby", &[

--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -189,6 +189,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("racket", &["*.rkt"]),
     ("rdoc", &["*.rdoc"]),
     ("readme", &["README*", "*README"]),
+    ("reasonml", &["*.re", "*.rei"]),
     ("red", &["*.r", "*.red", "*.reds"]),
     ("rescript", &["*.res", "*.resi"]),
     ("robot", &["*.robot"]),


### PR DESCRIPTION
[ReScript](https://rescript-lang.org/) is an OCaml-derived programming language that compiles to efficient and human-readable JavaaScript.

[ReasonML](https://reasonml.github.io/) is an alternative syntax for OCaml.