### PR TITLE
ignore/types: add automated test for sortedness

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -291,3 +291,26 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ]),
     ("zstd", &["*.zst", "*.zstd"]),
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::DEFAULT_TYPES;
+
+    #[test]
+    fn default_types_are_sorted() {
+        let mut names = DEFAULT_TYPES.iter().map(|(name, _exts)| name);
+
+        let Some(mut previous_name) = names.next() else { return; };
+
+        for name in names {
+            assert!(
+                name > previous_name,
+                r#""{}" should be sorted before "{}" in `DEFAULT_TYPES`"#,
+                name,
+                previous_name
+            );
+
+            previous_name = name;
+        }
+    }
+}


### PR DESCRIPTION
After I accidentally mixed up the sorting in #2349 and didn't notice, I thought I'd add a test so hopefully the next time it happens to someone it can be caught before it's sent in as a PR.