### PR TITLE
add '--hidden' to example configuration

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -567,12 +567,15 @@ $ cat $HOME/.ripgreprc
 --type-add
 web:*.{html,css,js}*
 
+# Search hidden files / directories (e.g. dotfiles) by default
+--hidden
+
 # Using glob patterns to include/exclude files or folders
---glob=!git/*
+--glob=!.git/*
 
 # or
 --glob
-!git/*
+!.git/*
 
 # Set the colors.
 --colors=line:none


### PR DESCRIPTION
Motivated by issues like:

https://github.com/BurntSushi/ripgrep/issues/623

I understand (and agree with) the decision to not change the defaults; this just presents the commonly-used:

```
--hidden
--glob=!.git/*
```

as a potential "default configuration" for users who want `rg` to scan dotfiles, and hopefully makes that more discoverable.