### PR TITLE
build: Use GITHUB_REF_NAME instead of GITHUB_REF

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,7 @@ jobs:
         shell: bash
         if: env.RG_VERSION == ''
         run: |
-          # Apparently, this is the right way to get a tag name. Really?
-          #
-          # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
-          echo "RG_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "RG_VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
           echo "version is: ${{ env.RG_VERSION }}"
       - name: Create GitHub release
         id: release


### PR DESCRIPTION
GitHub added it more recently: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables