### PR TITLE
fix: sorting nested results by system time

### DIFF
--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -352,6 +352,9 @@ impl Args {
             Ok(v) => v,
             Err(_) => return subjects,
         };
+        if sorter.check().is_err() {
+            return subjects;
+        }
         #[inline]
         fn unzip<K, V>(v: Vec<(K, V)>) -> Vec<V> {
             v.into_iter().map(|v| v.1).collect()
@@ -444,6 +447,24 @@ impl SortBy {
 
     fn none() -> SortBy {
         SortBy::asc(SortByKind::None)
+    }
+
+    /// Try to check that the sorting criteria selected is actually supported.
+    /// If it isn't, then an error is returned.
+    fn check(&self) -> Result<()> {
+        match self.kind {
+            SortByKind::None | SortByKind::Path => {}
+            SortByKind::LastModified => {
+                env::current_exe()?.metadata()?.modified()?;
+            }
+            SortByKind::LastAccessed => {
+                env::current_exe()?.metadata()?.accessed()?;
+            }
+            SortByKind::Created => {
+                env::current_exe()?.metadata()?.created()?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -472,8 +472,12 @@ impl SortBy {
         use SortByKind::*;
         match self.kind {
             Path => match self.reverse {
-                true => builder.sort_by_file_name(|a, b| a.cmp(b).reverse()),
-                false => builder.sort_by_file_name(|a, b| a.cmp(b)),
+                true => {
+                    builder.sort_by_file_name(|a, b| a.cmp(b).reverse());
+                }
+                false => {
+                    builder.sort_by_file_name(|a, b| a.cmp(b));
+                }
             },
             // these use `stat` calls and will be sorted in Args::sort_by_stat()
             LastModified | LastAccessed | Created | None => (),

--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -86,7 +86,6 @@ fn search(args: &Args) -> Result<bool> {
     let subjects = sorted_results(args);
     for subject in subjects {
         searched = true;
-        // searcher.search() contains the printing function
         let search_result = match searcher.search(&subject) {
             Ok(search_result) => search_result,
             Err(err) => {

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -826,11 +826,12 @@ impl WalkBuilder {
     /// by `sort_by_file_name`.
     ///
     /// Note that this is not used in the parallel iterator.
-    pub fn sort_by_file_path<F>(&mut self, cmp: F)
+    pub fn sort_by_file_path<F>(&mut self, cmp: F) -> &mut WalkBuilder
     where
         F: Fn(&Path, &Path) -> cmp::Ordering + Send + Sync + 'static,
     {
         self.sorter = Some(Sorter::ByPath(Arc::new(cmp)));
+        self
     }
 
     /// Set a function for sorting directory entries by file name.
@@ -844,11 +845,12 @@ impl WalkBuilder {
     /// by `sort_by_file_path`.
     ///
     /// Note that this is not used in the parallel iterator.
-    pub fn sort_by_file_name<F>(&mut self, cmp: F)
+    pub fn sort_by_file_name<F>(&mut self, cmp: F) -> &mut WalkBuilder
     where
         F: Fn(&OsStr, &OsStr) -> cmp::Ordering + Send + Sync + 'static,
     {
         self.sorter = Some(Sorter::ByName(Arc::new(cmp)));
+        self
     }
 
     /// Do not cross file system boundaries.

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -826,12 +826,11 @@ impl WalkBuilder {
     /// by `sort_by_file_name`.
     ///
     /// Note that this is not used in the parallel iterator.
-    pub fn sort_by_file_path<F>(&mut self, cmp: F) -> &mut WalkBuilder
+    pub fn sort_by_file_path<F>(&mut self, cmp: F)
     where
         F: Fn(&Path, &Path) -> cmp::Ordering + Send + Sync + 'static,
     {
         self.sorter = Some(Sorter::ByPath(Arc::new(cmp)));
-        self
     }
 
     /// Set a function for sorting directory entries by file name.
@@ -845,12 +844,11 @@ impl WalkBuilder {
     /// by `sort_by_file_path`.
     ///
     /// Note that this is not used in the parallel iterator.
-    pub fn sort_by_file_name<F>(&mut self, cmp: F) -> &mut WalkBuilder
+    pub fn sort_by_file_name<F>(&mut self, cmp: F)
     where
         F: Fn(&OsStr, &OsStr) -> cmp::Ordering + Send + Sync + 'static,
     {
         self.sorter = Some(Sorter::ByName(Arc::new(cmp)));
-        self
     }
 
     /// Do not cross file system boundaries.

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -787,6 +787,22 @@ rgtest!(f1466_no_ignore_files, |dir: Dir, mut cmd: TestCommand| {
     eqnice!("foo\n", cmd.arg("-u").stdout());
 });
 
+// See: https://github.com/BurntSushi/ripgrep/pull/2361
+rgtest!(f2361_sort_nested_files, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("foo", "1");
+    dir.create_dir("dir");
+    dir.create(dir.path().join("dir").join("bar"), "1");
+
+    cmd.arg("--sort").arg("modified").arg("--files");
+    eqnice!("foo\ndir/bar\n", cmd.stdout());
+
+    dir.create("foo", "2");
+    dir.create(dir.path().join("dir").join("bar"), "2");
+
+    cmd.arg("--sort").arg("modified").arg("--files");
+    eqnice!("foo\ndir/bar\n", cmd.stdout());
+});
+
 // See: https://github.com/BurntSushi/ripgrep/issues/1404
 rgtest!(f1404_nothing_searched_warning, |dir: Dir, mut cmd: TestCommand| {
     dir.create(".ignore", "ignored-dir/**");


### PR DESCRIPTION
Bug is aptly described in https://github.com/BurntSushi/ripgrep/issues/2243.

This PR aims to address this by delaying result sorting to after every match has been found.