### PR TITLE
Also gitignore with Sapling

### DIFF
--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -204,7 +204,7 @@ impl Ignore {
             igtmp.absolute_base = Some(absolute_base.clone());
             igtmp.has_git =
                 if self.0.opts.require_git && self.0.opts.git_ignore {
-                    parent.join(".git").exists()
+                    parent.join(".git").exists() || parent.join(".sl").exists()
                 } else {
                     false
                 };

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -2068,6 +2068,19 @@ mod tests {
     }
 
     #[test]
+    fn gitignore_parent_with_sl() {
+        let td = tmpdir();
+        mkdirp(td.path().join(".sl"));
+        mkdirp(td.path().join("a"));
+        wfile(td.path().join(".gitignore"), "foo");
+        wfile(td.path().join("a/foo"), "");
+        wfile(td.path().join("a/bar"), "");
+
+        let root = td.path().join("a");
+        assert_paths(&root, &WalkBuilder::new(&root), &["bar"]);
+    }
+
+    #[test]
     fn max_depth() {
         let td = tmpdir();
         mkdirp(td.path().join("a/b/c"));


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/BurntSushi/ripgrep/pull/2364).
* __->__ #2364

Also gitignore with Sapling

Sapling is a [new SCM system](https://sapling-scm.com), which has some
interesting properties, including Git compatibility. However, it uses a
different directory for repo state, `.sl`. Thus, ripgrep doesn't
gitignore by default in Sapling repos, even though Sapling does.

