### PR TITLE
Set rust-version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = ["HomebrewFormula"]
 build = "build.rs"
 autotests = false
 edition = "2018"
+rust-version = "1.65"
 
 [[bin]]
 bench = false


### PR DESCRIPTION
This MSRV was bumped higher than 1.56 in 8905d54a9f25f4c1e4e3ca8331f517473e174d87. Should this be added to any other crates as well?