### PR TITLE
Try harder to fix #916

### DIFF
--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -1495,6 +1495,7 @@ impl<'s> Worker<'s> {
             return WalkState::Skip;
         }
         for result in readdir {
+            let is_err = result.is_err();
             let state = self.generate_work(
                 &work.ignore,
                 depth + 1,
@@ -1503,6 +1504,12 @@ impl<'s> Worker<'s> {
             );
             if state.is_quit() {
                 return state;
+            }
+            // Break after we see an error.
+            // See https://github.com/rust-lang/rust/issues/50619
+            // and https://github.com/BurntSushi/ripgrep/issues/916
+            if is_err {
+                break;
             }
         }
         WalkState::Continue


### PR DESCRIPTION
The underlying Rust issue[1] was recently re-introduced and re-fixed.
Rather than wait for a new Rust release, apply effectively the same fix
as a workaround in the ignore crate itself.

[1]: https://github.com/rust-lang/rust/issues/50619
