### PR TITLE
fix(globset/serde1): allow deserializing owned strings into `Glob`

### DIFF
--- a/crates/globset/src/serde_impl.rs
+++ b/crates/globset/src/serde_impl.rs
@@ -1,6 +1,7 @@
+use std::fmt;
+
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
 
 use crate::Glob;
 
@@ -40,8 +41,9 @@ impl<'de> Deserialize<'de> for Glob {
 
 #[cfg(test)]
 mod tests {
-    use crate::glob::Glob;
     use std::collections::HashMap;
+
+    use crate::glob::Glob;
 
     #[test]
     fn glob_deserialize_borrowed() {

--- a/crates/globset/src/serde_impl.rs
+++ b/crates/globset/src/serde_impl.rs
@@ -23,7 +23,25 @@ impl<'de> Deserialize<'de> for Glob {
 
 #[cfg(test)]
 mod tests {
-    use Glob;
+    use crate::glob::Glob;
+    use std::collections::HashMap;
+
+    #[test]
+    fn glob_deserialize_borrowed() {
+        let string = r#"{"markdown": "*.md"}"#;
+
+        let map: HashMap<String, Glob> = serde_json::from_str(&string).unwrap();
+        assert_eq!(map["markdown"], Glob::new("*.md").unwrap());
+    }
+
+    #[test]
+    fn glob_deserialize_owned() {
+        let string = r#"{"markdown": "*.md"}"#;
+
+        let v: serde_json::Value = serde_json::from_str(&string).unwrap();
+        let map: HashMap<String, Glob> = serde_json::from_value(v).unwrap();
+        assert_eq!(map["markdown"], Glob::new("*.md").unwrap());
+    }
 
     #[test]
     fn glob_json_works() {

--- a/crates/globset/src/serde_impl.rs
+++ b/crates/globset/src/serde_impl.rs
@@ -19,7 +19,7 @@ impl<'a> Visitor<'a> for GlobVisitor {
     type Value = Glob;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a string or a borrowed string")
+        formatter.write_str("a glob pattern")
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>

--- a/crates/globset/src/serde_impl.rs
+++ b/crates/globset/src/serde_impl.rs
@@ -1,5 +1,6 @@
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Cow;
 
 use crate::Glob;
 
@@ -16,8 +17,8 @@ impl<'de> Deserialize<'de> for Glob {
     fn deserialize<D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Self, D::Error> {
-        let glob = <&str as Deserialize>::deserialize(deserializer)?;
-        Glob::new(glob).map_err(D::Error::custom)
+        let glob = <Cow<str> as Deserialize>::deserialize(deserializer)?;
+        Glob::new(&glob).map_err(D::Error::custom)
     }
 }
 
@@ -30,7 +31,8 @@ mod tests {
     fn glob_deserialize_borrowed() {
         let string = r#"{"markdown": "*.md"}"#;
 
-        let map: HashMap<String, Glob> = serde_json::from_str(&string).unwrap();
+        let map: HashMap<String, Glob> =
+            serde_json::from_str(&string).unwrap();
         assert_eq!(map["markdown"], Glob::new("*.md").unwrap());
     }
 


### PR DESCRIPTION
This PR modifies how `Glob` is deserialized such that it now allows for owned strings (previously, only borrowed) to be deserialized into `Glob`. This takes inspiration from what is done in the [`regex_serde` crate](https://github.com/tailhook/serde-regex/blob/336bb456ecd146ba9e3fcc2fef71870f603d72c5/src/lib.rs#L179-L191).

For more details, see the discussion in #2386.

The first commit includes tests, which fail without the solution.
The second commit include the solution.

This fixes #2386.

I'd be happy to hear from your thoughts and I'm open to any review :-)