### PR TITLE
fix(ignore): change msrv to 1.63

### DIFF
--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 keywords = ["glob", "ignore", "gitignore", "pattern", "file"]
 license = "Unlicense OR MIT"
 edition = "2018"
+rust-version = "1.63"
 
 [lib]
 name = "ignore"


### PR DESCRIPTION
Recent changes introduced by version 0.4.19 require rust 1.63. This formalizes that requirement.

See https://github.com/BurntSushi/ripgrep/commit/e95254a86f484eec663be4714924d91d3cf39cb8#commitcomment-95170910 for more context

See https://github.com/rust-lang/api-guidelines/discussions/231 for community discussion for how changes to MSRV impact versioning. Would be nice to bump MINOR to avoid compatibility issuers, however ignore is pre-v1, so you can do what you want.