### PR TITLE
ignore: respect local .git/config excludes

### DIFF
--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -20,7 +20,9 @@ use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
-use crate::gitignore::{self, Gitignore, GitignoreBuilder, parse_excludes_file, read_file_contents};
+use crate::gitignore::{
+    self, parse_excludes_file, read_file_contents, Gitignore, GitignoreBuilder,
+};
 use crate::overrides::{self, Override};
 use crate::pathutil::{is_hidden, strip_prefix};
 use crate::types::{self, Types};
@@ -250,10 +252,11 @@ impl Ignore {
         } else {
             has_git_config = true;
             match resolve_git_commondir(dir, git_type) {
-                Ok(git_dir) => {
-                    read_file_contents(&git_dir.join("config")).and_then(|config_contents| {
+                Ok(git_dir) => read_file_contents(&git_dir.join("config"))
+                    .and_then(|config_contents| {
                         parse_excludes_file(&config_contents)
-                    }).map(|excludes_file| {
+                    })
+                    .map(|excludes_file| {
                         let (m, err) = create_gitignore(
                             &dir,
                             &dir,
@@ -262,11 +265,11 @@ impl Ignore {
                         );
                         errs.maybe_push(err);
                         m
-                    }).unwrap_or_else(|| {
+                    })
+                    .unwrap_or_else(|| {
                         has_git_config = false;
                         Gitignore::empty()
-                    })
-                }
+                    }),
                 Err(err) => {
                     errs.maybe_push(err);
                     has_git_config = false;
@@ -450,7 +453,14 @@ impl Ignore {
             mut m_gc,
             mut m_gi_exclude,
             mut m_explicit,
-        ) = (Match::None, Match::None, Match::None, Match::None, Match::None, Match::None);
+        ) = (
+            Match::None,
+            Match::None,
+            Match::None,
+            Match::None,
+            Match::None,
+            Match::None,
+        );
         let any_git =
             !self.0.opts.require_git || self.parents().any(|ig| ig.0.has_git);
         let mut saw_git = false;

--- a/crates/ignore/src/gitignore.rs
+++ b/crates/ignore/src/gitignore.rs
@@ -539,26 +539,20 @@ fn gitconfig_excludes_path() -> Option<PathBuf> {
     // time, where the local .git/config takes precedence, then $HOME/.gitconfig and
     // then $XDG_CONFIG_HOME/git/config. So if .git/config defines a `core.excludesFile`,
     // then we're done.
-    gitconfig_local_contents()
+    gitconfig_home_contents()
         .and_then(|x| parse_excludes_file(&x))
-        .or_else(|| gitconfig_home_contents().and_then(|x| parse_excludes_file(&x)))
         .or_else(|| gitconfig_xdg_contents().and_then(|x| parse_excludes_file(&x)))
         .or_else(excludes_file_default)
 }
 
 /// Returns the file contents of the specified file.
-fn read_file_contents(path: &Path) -> Option<Vec<u8>> {
+pub fn read_file_contents(path: &Path) -> Option<Vec<u8>> {
     let mut file = match File::open(path) {
         Err(_) => return None,
         Ok(file) => io::BufReader::new(file),
     };
     let mut contents = vec![];
     file.read_to_end(&mut contents).ok().map(|_| contents)
-}
-
-/// Returns the file contents of git's local config file, if one exists.
-fn gitconfig_local_contents() -> Option<Vec<u8>> {
-    read_file_contents(Path::new(".git/config"))
 }
 
 /// Returns the file contents of git's global config file, if one exists, in
@@ -591,7 +585,7 @@ fn excludes_file_default() -> Option<PathBuf> {
 
 /// Extract git's `core.excludesfile` config setting from the raw file contents
 /// given.
-fn parse_excludes_file(data: &[u8]) -> Option<PathBuf> {
+pub fn parse_excludes_file(data: &[u8]) -> Option<PathBuf> {
     // N.B. This is the lazy approach, and isn't technically correct, but
     // probably works in more circumstances. I guess we would ideally have
     // a full INI parser. Yuck.

--- a/crates/ignore/src/gitignore.rs
+++ b/crates/ignore/src/gitignore.rs
@@ -541,7 +541,9 @@ fn gitconfig_excludes_path() -> Option<PathBuf> {
     // then we're done.
     gitconfig_home_contents()
         .and_then(|x| parse_excludes_file(&x))
-        .or_else(|| gitconfig_xdg_contents().and_then(|x| parse_excludes_file(&x)))
+        .or_else(|| {
+            gitconfig_xdg_contents().and_then(|x| parse_excludes_file(&x))
+        })
         .or_else(excludes_file_default)
 }
 


### PR DESCRIPTION
Currently, ripgrep respects `$HOME/.gitconfig` and `$XDG_CONFIG_HOME/git/config`, but not `.git/config` (the "local" or "project" config). Git makes it such that `.git/config` overrides the other two options, while still respecting the `./.gitignore`. This commit brings this functionality to ripgrep (while also cleaning a few repetitive segments of code).

To demonstrate with a reproducible example (of course, be careful with overriding any files):
```sh
$ mkdir test && cd test
$ touch file file.customexclude file.globalignore file.pwdignore
$ echo '*.pwdignore' > .gitignore
$ mkdir -p /tmp/tempdir && echo '*.customexclude' > /tmp/tempdir/.gitignore
$ git config core.excludesfile /tmp/tempdir/.gitignore
$ echo '*.globalignore' > ~/.gitignore
$ git config --global core.excludesfile ~/.gitignore
$ git status
...
	.gitignore
	file
	file.globalignore
...
$ rg --files # without this patch
file.customexclude
file
$ rg --files # with the patch
file
file.globalignore
```

Note that the global ignore file is [intended to be ignored](https://stackoverflow.com/questions/8801729/is-it-possible-to-have-different-git-configuration-for-different-projects) when a `.git/config` exists (as demonstrated by the output of git).

Fixes #2392