### PR TITLE
Added Clone and Debug for OverrideBuilder

### DIFF
--- a/crates/ignore/src/overrides.rs
+++ b/crates/ignore/src/overrides.rs
@@ -106,6 +106,7 @@ impl Override {
 }
 
 /// Builds a matcher for a set of glob overrides.
+#[derive(Clone, Debug)]
 pub struct OverrideBuilder {
     builder: GitignoreBuilder,
 }


### PR DESCRIPTION
I couldn't find a reason for this being intentional. `Clone` and `Debug` is also already implemented for `Override`, `Gitignore`, and `GitignoreBuilder`. But not for `OverrideBuilder`.

In my own project, I have a custom builder containing an `OverrideBuilder`, and would like to be able to add `Clone` to my builder.
