### PR TITLE
deps: require secure versions of regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ grep = { version = "0.2.11", path = "crates/grep" }
 ignore = { version = "0.4.19", path = "crates/ignore" }
 lazy_static = "1.1.0"
 log = "0.4.5"
-regex = "1.3.5"
+regex = "1.5.5"
 serde_json = "1.0.23"
 termcolor = "1.1.0"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,7 +19,7 @@ bstr = "1.1.0"
 globset = { version = "0.4.10", path = "../globset" }
 lazy_static = "1.1.0"
 log = "0.4.5"
-regex = "1.1"
+regex = "1.5.5"
 same-file = "1.0.4"
 termcolor = "1.0.4"
 

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4.5"
 memchr = "2.1"
 regex = "1.5.5"
 same-file = "1.0.4"
-thread_local = "1"
+thread_local = "1.1.4"
 walkdir = "2.2.7"
 
 [target.'cfg(windows)'.dependencies.winapi-util]

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -23,7 +23,7 @@ globset = { version = "0.4.10", path = "../globset" }
 lazy_static = "1.1"
 log = "0.4.5"
 memchr = "2.1"
-regex = "1.1"
+regex = "1.5.5"
 same-file = "1.0.4"
 thread_local = "1"
 walkdir = "2.2.7"

--- a/crates/matcher/Cargo.toml
+++ b/crates/matcher/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 memchr = "2.1"
 
 [dev-dependencies]
-regex = "1.1"
+regex = "1.5.5"
 
 [[test]]
 name = "integration"

--- a/crates/regex/Cargo.toml
+++ b/crates/regex/Cargo.toml
@@ -20,4 +20,4 @@ grep-matcher = { version = "0.1.6", path = "../matcher" }
 log = "0.4.5"
 regex = "1.5.5"
 regex-syntax = "0.6.5"
-thread_local = "1.1.2"
+thread_local = "1.1.4"

--- a/crates/regex/Cargo.toml
+++ b/crates/regex/Cargo.toml
@@ -18,6 +18,6 @@ aho-corasick = "0.7.3"
 bstr = "1.1.0"
 grep-matcher = { version = "0.1.6", path = "../matcher" }
 log = "0.4.5"
-regex = "1.1"
+regex = "1.5.5"
 regex-syntax = "0.6.5"
 thread_local = "1.1.2"

--- a/crates/searcher/Cargo.toml
+++ b/crates/searcher/Cargo.toml
@@ -24,7 +24,7 @@ memmap = { package = "memmap2", version = "0.5.3" }
 
 [dev-dependencies]
 grep-regex = { version = "0.1.11", path = "../regex" }
-regex = "1.1"
+regex = "1.5.5"
 
 [features]
 default = ["bytecount/runtime-dispatch-simd"]


### PR DESCRIPTION
addresses warnings seen here: https://deps.rs/repo/github/BurntSushi/ripgrep#vulnerabilities