### PR TITLE
crates/core/app.rs: Make "-D" an alias for "--max-depth"

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -182,7 +182,7 @@ _rg() {
     $no"--no-max-columns-preview[don't show preview for long lines (with -M)]"
 
     + '(max-depth)' # Directory-depth options
-    '--max-depth=[specify max number of directories to descend]:number of directories'
+    {-D+,--max-depth=}'[specify max number of directories to descend]:number of directories'
     '!--maxdepth=:number of directories'
 
     + '(messages)' # Error-message options

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -1827,6 +1827,7 @@ descended into. 'rg --max-depth 1 dir/' will search only the direct children of
 "
     );
     let arg = RGArg::flag("max-depth", "NUM")
+        .short("D")
         .help(SHORT)
         .long_help(LONG)
         .alias("maxdepth")


### PR DESCRIPTION
For better usability (at least for me), add an alias "-D" for the "--max-depth" option.