### PR TITLE
Enhance terraform default filter

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -251,7 +251,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("tex", &["*.tex", "*.ltx", "*.cls", "*.sty", "*.bib", "*.dtx", "*.ins"]),
     ("texinfo", &["*.texi"]),
     ("textile", &["*.textile"]),
-    ("tf", &["*.tf"]),
+    ("tf", &["*.tf", "*.auto.tfvars", "terraform.tfvars", "*.tf.json", "*.auto.tfvars.json", "terraform.tfvars.json", "*.terraformrc", "terraform.rc", "*.tfrc", "*.terraform.lock.hcl"]),
     ("thrift", &["*.thrift"]),
     ("toml", &["*.toml", "Cargo.lock"]),
     ("ts", &["*.ts", "*.tsx", "*.cts", "*.mts"]),

--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -251,7 +251,11 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("tex", &["*.tex", "*.ltx", "*.cls", "*.sty", "*.bib", "*.dtx", "*.ins"]),
     ("texinfo", &["*.texi"]),
     ("textile", &["*.textile"]),
-    ("tf", &["*.tf", "*.auto.tfvars", "terraform.tfvars", "*.tf.json", "*.auto.tfvars.json", "terraform.tfvars.json", "*.terraformrc", "terraform.rc", "*.tfrc", "*.terraform.lock.hcl"]),
+    ("tf", &[
+        "*.tf", "*.auto.tfvars", "terraform.tfvars", "*.tf.json",
+        "*.auto.tfvars.json", "terraform.tfvars.json", "*.terraformrc",
+        "terraform.rc", "*.tfrc", "*.terraform.lock.hcl",
+    ]),
     ("thrift", &["*.thrift"]),
     ("toml", &["*.toml", "Cargo.lock"]),
     ("ts", &["*.ts", "*.tsx", "*.cts", "*.mts"]),


### PR DESCRIPTION
The default filter for terraform only checks for *.tf files, but there are quite few other terraform filetypes.

The explanation for all of them can be found below:
_(including a link to the documentation from Hashicorp at the time of writing)_
- [*.tf.json & *.tfvars.json is to capture the files written in JSON-based variant of the Terraform language](https://developer.hashicorp.com/terraform/language/files)
- [*.tfvars is used to supply variables](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/variables#6-auto-tfvars-variable-files)
- [.terraform.lock.hcl is used as a Dependency lock file ](https://developer.hashicorp.com/terraform/language/files/dependency-lock
)
- [terraform.rc & .terraformrc, *.tfrc](https://developer.hashicorp.com/terraform/cli/config/config-file)
