### PR TITLE
ignore/types: add *.sln for msbuild

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -160,6 +160,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("motoko", &["*.mo"]),
     ("msbuild", &[
         "*.csproj", "*.fsproj", "*.vcxproj", "*.proj", "*.props", "*.targets",
+        "*.sln",
     ]),
     ("nim", &["*.nim", "*.nimf", "*.nimble", "*.nims"]),
     ("nix", &["*.nix"]),


### PR DESCRIPTION
.sln is the extension for Visual Studio Project Soltion files, one of the file types accepted as inputs by MSBuild.

I'm not sure if/how this kind of thing is tested, but I'd be happy to add a test if required.