### PR TITLE
ignore/types: add USD default types

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -263,6 +263,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("twig", &["*.twig"]),
     ("txt", &["*.txt"]),
     ("typoscript", &["*.typoscript", "*.ts"]),
+    ("usd", &["*.usd", "*.usda", "*.usdc"]),
     ("vala", &["*.vala"]),
     ("vb", &["*.vb"]),
     ("vcl", &["*.vcl"]),


### PR DESCRIPTION
[USD](https://www.pixar.com/usd) is open-source software that can robustly and scalably interchange 3D scenes that may be composed of many different assets, sources, and animations, while fostering highly collaborative workflows.