### PR TITLE
ignore/types: add Gentoo eclass type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -62,7 +62,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("docker", &["*Dockerfile*"]),
     ("dts", &["*.dts", "*.dtsi"]),
     ("dvc", &["Dvcfile", "*.dvc"]),
-    ("ebuild", &["*.ebuild"]),
+    ("ebuild", &["*.ebuild", "*.eclass"]),
     ("edn", &["*.edn"]),
     ("elisp", &["*.el"]),
     ("elixir", &["*.ex", "*.eex", "*.exs"]),


### PR DESCRIPTION
Eclasses are "ebuild libraries" and generally if you're filtering for/filtering out an ebuild/eclass, you don't want the other either.

Followup to 4dfea016b915bb1e88679361de83a91e60447835.