### PR TITLE
cli: don't let context flags override eachother

### DIFF
--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -698,7 +698,7 @@ fn flag_after_context(args: &mut Vec<RGArg>) {
         "\
 Show NUM lines after each match.
 
-This overrides the --context and --passthru flags.
+This overrides the --passthru flag.
 "
     );
     let arg = RGArg::flag("after-context", "NUM")
@@ -706,8 +706,7 @@ This overrides the --context and --passthru flags.
         .help(SHORT)
         .long_help(LONG)
         .number()
-        .overrides("passthru")
-        .overrides("context");
+        .overrides("passthru");
     args.push(arg);
 }
 
@@ -768,7 +767,7 @@ fn flag_before_context(args: &mut Vec<RGArg>) {
         "\
 Show NUM lines before each match.
 
-This overrides the --context and --passthru flags.
+This overrides the --passthru flag.
 "
     );
     let arg = RGArg::flag("before-context", "NUM")
@@ -776,8 +775,7 @@ This overrides the --context and --passthru flags.
         .help(SHORT)
         .long_help(LONG)
         .number()
-        .overrides("passthru")
-        .overrides("context");
+        .overrides("passthru");
     args.push(arg);
 }
 
@@ -1009,8 +1007,7 @@ fn flag_context(args: &mut Vec<RGArg>) {
 Show NUM lines before and after each match. This is equivalent to providing
 both the -B/--before-context and -A/--after-context flags with the same value.
 
-This overrides both the -B/--before-context and -A/--after-context flags,
-in addition to the --passthru flag.
+This overrides the --passthru flag.
 "
     );
     let arg = RGArg::flag("context", "NUM")
@@ -1018,9 +1015,7 @@ in addition to the --passthru flag.
         .help(SHORT)
         .long_help(LONG)
         .number()
-        .overrides("passthru")
-        .overrides("before-context")
-        .overrides("after-context");
+        .overrides("passthru");
     args.push(arg);
 }
 

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -1020,10 +1020,10 @@ impl ArgMatches {
     /// If there was a problem parsing the values from the user as an integer,
     /// then an error is returned.
     fn contexts(&self) -> Result<(usize, usize)> {
-        let after = self.usize_of("after-context")?.unwrap_or(0);
-        let before = self.usize_of("before-context")?.unwrap_or(0);
         let both = self.usize_of("context")?.unwrap_or(0);
-        Ok(if both > 0 { (both, both) } else { (before, after) })
+        let after = self.usize_of("after-context")?.unwrap_or(both);
+        let before = self.usize_of("before-context")?.unwrap_or(both);
+        Ok((before, after))
     }
 
     /// Returns the unescaped context separator in UTF-8 bytes.


### PR DESCRIPTION
Match the behavior of GNU grep which does not ignore before-context and after-context completely if the context flag is also provided.

Fixes #2288