### PR TITLE
Add support for searching in Docker compose files

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -60,6 +60,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("dhall", &["*.dhall"]),
     ("diff", &["*.patch", "*.diff"]),
     ("docker", &["*Dockerfile*"]),
+    ("dockercompose", &["docker-compose.yml", "docker-compose.*.yml"]),
     ("dts", &["*.dts", "*.dtsi"]),
     ("dvc", &["Dvcfile", "*.dvc"]),
     ("ebuild", &["*.ebuild"]),


### PR DESCRIPTION
Default file is docker-compose.yml and the documentation mentions overrides in the form of docker-compose.*.yml