### PR TITLE
Make gitignore.rs's `gitconfig_excludes_path` public

### DIFF
--- a/crates/ignore/src/gitignore.rs
+++ b/crates/ignore/src/gitignore.rs
@@ -533,7 +533,7 @@ impl GitignoreBuilder {
 /// Return the file path of the current environment's global gitignore file.
 ///
 /// Note that the file path returned may not exist.
-fn gitconfig_excludes_path() -> Option<PathBuf> {
+pub fn gitconfig_excludes_path() -> Option<PathBuf> {
     // git supports $HOME/.gitconfig and $XDG_CONFIG_HOME/git/config. Notably,
     // both can be active at the same time, where $HOME/.gitconfig takes
     // precedent. So if $HOME/.gitconfig defines a `core.excludesFile`, then


### PR DESCRIPTION
In Pantsbuild, we use `GitignoreBuilder` to determine which files our file watcher should look at.

We want to improve the file watcher to consider the global gitignore file. It would be exceptionally useful if we could reuse your logic: https://github.com/pantsbuild/pants/pull/18649

P.S. Thanks for ripgrep! You've saved me so much time 🙌