### PR TITLE
Add configurable hyperlinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - hyperlinks
   schedule:
   - cron: '00 01 * * *'
 jobs:
@@ -84,6 +85,17 @@ jobs:
           os: windows-2022
           rust: nightly-x86_64-gnu
     steps:
+    # Temp: the termcolor version with hyperlinks support needs to ba available.
+    - name: Checkout termcolor
+      uses: actions/checkout@v3
+      with:
+        repository: ltrzesniewski/termcolor
+        ref: hyperlinks
+        path: termcolor
+
+    - name: Move termcolor
+      run: mv termcolor ..
+
     - name: Checkout repository
       uses: actions/checkout@v3
 
@@ -194,8 +206,20 @@ jobs:
     name: Docs
     runs-on: ubuntu-22.04
     steps:
+      # Temp: the termcolor version with hyperlinks support needs to ba available.
+      - name: Checkout termcolor
+        uses: actions/checkout@v3
+        with:
+          repository: ltrzesniewski/termcolor
+          ref: hyperlinks
+          path: termcolor
+
+      - name: Move termcolor
+        run: mv termcolor ..
+
       - name: Checkout repository
         uses: actions/checkout@v3
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - master
     - hyperlinks
+    - hyperlinks-cfg
   schedule:
   - cron: '00 01 * * *'
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target
 /termcolor/Cargo.lock
 /wincolor/Cargo.lock
 /deployment
+/.idea
 
 # Snapcraft files
 stage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,8 +523,6 @@ dependencies = [
 [[package]]
 name = "termcolor"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
+name = "gethostname"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,9 +211,11 @@ version = "0.1.6"
 dependencies = [
  "base64",
  "bstr",
+ "gethostname",
  "grep-matcher",
  "grep-regex",
  "grep-searcher",
+ "lazy_static",
  "once_cell",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "grep-matcher",
  "grep-regex",
  "grep-searcher",
+ "once_cell",
  "serde",
  "serde_json",
  "termcolor",
@@ -353,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "packed_simd_2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ regex = "1.3.5"
 serde_json = "1.0.23"
 termcolor = "1.1.0"
 
+[patch.crates-io]
+termcolor = { path = "../termcolor" }
+
 [dependencies.clap]
 version = "2.33.0"
 default-features = false

--- a/complete/_rg
+++ b/complete/_rg
@@ -305,6 +305,7 @@ _rg() {
     '--debug[show debug messages]'
     '--field-context-separator[set string to delimit fields in context lines]'
     '--field-match-separator[set string to delimit fields in matching lines]'
+    '--hyperlink-format=[specify pattern for hyperlinks]:pattern'
     '--trace[show more verbose debug messages]'
     '--dfa-size-limit=[specify upper size limit of generated DFA]:DFA size (bytes)'
     "(1 stats)--files[show each file that would be searched (but don't search)]"

--- a/crates/cli/src/wtr.rs
+++ b/crates/cli/src/wtr.rs
@@ -103,6 +103,16 @@ impl termcolor::WriteColor for StandardStream {
     }
 
     #[inline]
+    fn supports_hyperlinks(&self) -> bool {
+        use self::StandardStreamKind::*;
+
+        match self.0 {
+            LineBuffered(ref w) => w.supports_hyperlinks(),
+            BlockBuffered(ref w) => w.supports_hyperlinks(),
+        }
+    }
+
+    #[inline]
     fn set_color(&mut self, spec: &termcolor::ColorSpec) -> io::Result<()> {
         use self::StandardStreamKind::*;
 

--- a/crates/cli/src/wtr.rs
+++ b/crates/cli/src/wtr.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use termcolor;
+use termcolor::HyperlinkSpec;
 
 use crate::is_tty_stdout;
 
@@ -108,6 +109,16 @@ impl termcolor::WriteColor for StandardStream {
         match self.0 {
             LineBuffered(ref mut w) => w.set_color(spec),
             BlockBuffered(ref mut w) => w.set_color(spec),
+        }
+    }
+
+    #[inline]
+    fn set_hyperlink(&mut self, link: &HyperlinkSpec) -> io::Result<()> {
+        use self::StandardStreamKind::*;
+
+        match self.0 {
+            LineBuffered(ref mut w) => w.set_hyperlink(link),
+            BlockBuffered(ref mut w) => w.set_hyperlink(link),
         }
     }
 

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -1505,6 +1505,7 @@ fn flag_hyperlink_format(args: &mut Vec<RGArg>) {
         "\
 Set the format of hyperlinks to match results. This defines a pattern which
 can contain the following placeholders: {file}, {line}, {column}, and {host}.
+An empty format disables hyperlinks.
 
 The {file} placeholder is required, and will be replaced with the absolute
 file path with a few adjustments: The leading '/' on Unix is removed,

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -580,6 +580,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_glob_case_insensitive(&mut args);
     flag_heading(&mut args);
     flag_hidden(&mut args);
+    flag_hyperlink_format(&mut args);
     flag_iglob(&mut args);
     flag_ignore_case(&mut args);
     flag_ignore_file(&mut args);
@@ -1495,6 +1496,25 @@ This flag can be disabled with --no-hidden.
     args.push(arg);
 
     let arg = RGArg::switch("no-hidden").hidden().overrides("hidden");
+    args.push(arg);
+}
+
+fn flag_hyperlink_format(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "Set the format of hyperlinks to match results.";
+    const LONG: &str = long!(
+        "\
+Set the format of hyperlinks to match results. This defines a pattern which
+can contain the following placeholders: {file}, {line}, {column}, and {host}.
+
+The {file} placeholder is required, and will be replaced with the absolute
+file path with a few adjustments: The leading '/' on Unix is removed,
+and '\\' is replaced with '/' on Windows.
+
+As an example, the default pattern on Unix systems is: 'file://{host}/{file}'
+"
+    );
+    let arg =
+        RGArg::flag("hyperlink-format", "FORMAT").help(SHORT).long_help(LONG);
     args.push(arg);
 }
 

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -1134,7 +1134,7 @@ impl ArgMatches {
     }
 
     /// Returns the hyperlink pattern to use. A default pattern suitable
-    /// for the current system is used if the value os not set.
+    /// for the current system is used if the value is not set.
     ///
     /// If an invalid pattern is provided, then an error is returned.
     fn hyperlink_pattern(&self) -> Result<HyperlinkPattern> {

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -1133,13 +1133,14 @@ impl ArgMatches {
         self.is_present("hidden") || self.unrestricted_count() >= 2
     }
 
-    /// Returns the hyperlink pattern to use.
+    /// Returns the hyperlink pattern to use. A default pattern suitable
+    /// for the current system is used if the value os not set.
     ///
     /// If an invalid pattern is provided, then an error is returned.
     fn hyperlink_pattern(&self) -> Result<HyperlinkPattern> {
         Ok(match self.value_of_lossy("hyperlink-format") {
             Some(pattern) => HyperlinkPattern::from_str(&pattern)?,
-            None => HyperlinkPattern::default(),
+            None => HyperlinkPattern::new_system_default(),
         })
     }
 

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -17,8 +18,8 @@ use grep::pcre2::{
     RegexMatcherBuilder as PCRE2RegexMatcherBuilder,
 };
 use grep::printer::{
-    default_color_specs, ColorSpecs, JSONBuilder, Standard, StandardBuilder,
-    Stats, Summary, SummaryBuilder, SummaryKind, JSON,
+    default_color_specs, ColorSpecs, HyperlinkPattern, JSONBuilder, Standard,
+    StandardBuilder, Stats, Summary, SummaryBuilder, SummaryKind, JSON,
 };
 use grep::regex::{
     RegexMatcher as RustRegexMatcher,
@@ -781,6 +782,7 @@ impl ArgMatches {
         let mut builder = StandardBuilder::new();
         builder
             .color_specs(self.color_specs()?)
+            .hyperlink_pattern(self.hyperlink_pattern()?)
             .stats(self.stats())
             .heading(self.heading())
             .path(self.with_filename(paths))
@@ -1127,6 +1129,16 @@ impl ArgMatches {
     /// searched.
     fn hidden(&self) -> bool {
         self.is_present("hidden") || self.unrestricted_count() >= 2
+    }
+
+    /// Returns the hyperlink pattern to use.
+    ///
+    /// If an invalid pattern is provided, then an error is returned.
+    fn hyperlink_pattern(&self) -> Result<HyperlinkPattern> {
+        Ok(match self.value_of_lossy("hyperlink-format") {
+            Some(pattern) => HyperlinkPattern::from_str(&pattern)?,
+            None => HyperlinkPattern::default(),
+        })
     }
 
     /// Returns true if ignore files should be processed case insensitively.

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -237,6 +237,7 @@ impl Args {
         let mut builder = PathPrinterBuilder::new();
         builder
             .color_specs(self.matches().color_specs()?)
+            .hyperlink_pattern(self.matches().hyperlink_pattern()?)
             .separator(self.matches().path_separator()?)
             .terminator(self.matches().path_terminator().unwrap_or(b'\n'));
         Ok(builder.build(wtr))
@@ -822,6 +823,7 @@ impl ArgMatches {
         builder
             .kind(self.summary_kind().expect("summary format"))
             .color_specs(self.color_specs()?)
+            .hyperlink_pattern(self.hyperlink_pattern()?)
             .stats(self.stats())
             .path(self.with_filename(paths))
             .max_matches(self.max_count()?)

--- a/crates/core/path_printer.rs
+++ b/crates/core/path_printer.rs
@@ -103,7 +103,7 @@ impl<W: WriteColor> PathPrinter<W> {
         if !self.wtr.supports_color() {
             self.wtr.write_all(ppath.as_bytes())?;
         } else {
-            let mut wrote_hyperlink = false;
+            let mut hyperlink = false;
             if self.wtr.supports_hyperlinks() {
                 if let Some(spec) = ppath.hyperlink(
                     &self.config.hyperlink_pattern,
@@ -112,7 +112,7 @@ impl<W: WriteColor> PathPrinter<W> {
                     &mut self.buf,
                 ) {
                     self.wtr.set_hyperlink(&spec)?;
-                    wrote_hyperlink = true;
+                    hyperlink = true;
                 }
             }
 
@@ -120,7 +120,7 @@ impl<W: WriteColor> PathPrinter<W> {
             self.wtr.write_all(ppath.as_bytes())?;
             self.wtr.reset()?;
 
-            if wrote_hyperlink {
+            if hyperlink {
                 self.wtr.set_hyperlink(&HyperlinkSpec::none())?;
             }
         }

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -21,8 +21,10 @@ serde1 = ["base64", "serde", "serde_json"]
 [dependencies]
 base64 = { version = "0.13.0", optional = true }
 bstr = "0.2.0"
+gethostname = "0.3.0"
 grep-matcher = { version = "0.1.5", path = "../matcher" }
 grep-searcher = { version = "0.1.8", path = "../searcher" }
+lazy_static = "1.1.0"
 once_cell = "1.15.0"
 termcolor = "1.0.4"
 serde = { version = "1.0.77", optional = true, features = ["derive"] }

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -23,6 +23,7 @@ base64 = { version = "0.13.0", optional = true }
 bstr = "0.2.0"
 grep-matcher = { version = "0.1.5", path = "../matcher" }
 grep-searcher = { version = "0.1.8", path = "../searcher" }
+once_cell = "1.15.0"
 termcolor = "1.0.4"
 serde = { version = "1.0.77", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.27", optional = true }

--- a/crates/printer/src/counter.rs
+++ b/crates/printer/src/counter.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use termcolor::{ColorSpec, WriteColor};
+use termcolor::{ColorSpec, HyperlinkSpec, WriteColor};
 
 /// A writer that counts the number of bytes that have been successfully
 /// written.
@@ -78,6 +78,10 @@ impl<W: WriteColor> WriteColor for CounterWriter<W> {
 
     fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
         self.wtr.set_color(spec)
+    }
+
+    fn set_hyperlink(&mut self, link: &HyperlinkSpec) -> io::Result<()> {
+        self.wtr.set_hyperlink(link)
     }
 
     fn reset(&mut self) -> io::Result<()> {

--- a/crates/printer/src/counter.rs
+++ b/crates/printer/src/counter.rs
@@ -76,6 +76,10 @@ impl<W: WriteColor> WriteColor for CounterWriter<W> {
         self.wtr.supports_color()
     }
 
+    fn supports_hyperlinks(&self) -> bool {
+        self.wtr.supports_hyperlinks()
+    }
+
     fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
         self.wtr.set_color(spec)
     }

--- a/crates/printer/src/hyperlink.rs
+++ b/crates/printer/src/hyperlink.rs
@@ -260,7 +260,7 @@ mod tests {
                 &gethostname::gethostname().to_string_lossy()
             )
         );
-        assert_eq!(pattern.parts.len(), 4);
+        assert_eq!(pattern.parts.len(), 6);
         assert!(pattern.parts.contains(&Part::File));
         assert!(pattern.parts.contains(&Part::Line));
     }

--- a/crates/printer/src/hyperlink.rs
+++ b/crates/printer/src/hyperlink.rs
@@ -1,0 +1,238 @@
+use bstr::ByteSlice;
+use std::error::Error;
+use std::fmt::Display;
+use std::str::FromStr;
+
+/// A hyperlink pattern with placeholders.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HyperlinkPattern {
+    parts: Vec<Part>,
+}
+
+/// A hyperlink pattern part.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Part {
+    /// Static text. Can include invariant placeholders such as the hostname.
+    Text(Vec<u8>),
+    /// Placeholder for the file path.
+    File,
+    /// Placeholder for the line number.
+    Line,
+    /// Placeholder for the column number.
+    Column,
+}
+
+/// An error that can occur when parsing a hyperlink pattern.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HyperlinkPatternError {
+    /// This occurs when the pattern syntax is not valid.
+    InvalidSyntax,
+    /// This occurs when the {file} placeholder is missing.
+    NoFilePlaceholder,
+    /// This occurs when an unknown placeholder is used.
+    InvalidPlaceholder(String),
+}
+
+impl HyperlinkPattern {
+    /// Creates an empty hyperlink pattern.
+    pub fn new() -> Self {
+        HyperlinkPattern { parts: Vec::new() }
+    }
+
+    fn append_text(&mut self, text: &[u8]) {
+        if let Some(Part::Text(contents)) = self.parts.last_mut() {
+            contents.extend_from_slice(text);
+        } else if !text.is_empty() {
+            self.parts.push(Part::Text(text.to_vec()));
+        }
+    }
+
+    fn append_hostname(&mut self) {
+        self.append_text(
+            gethostname::gethostname().to_string_lossy().as_bytes(),
+        );
+    }
+
+    fn append_placeholder(&mut self, part: Part) {
+        self.parts.push(part);
+    }
+
+    /// Returns true if this pattern is empty.
+    pub fn is_empty(&self) -> bool {
+        self.parts.is_empty()
+    }
+}
+
+impl Default for HyperlinkPattern {
+    #[cfg(unix)]
+    fn default() -> Self {
+        let mut pattern = Self::new();
+        pattern.append_text(b"file://");
+
+        if let Ok(wsl_distro) = std::env::var("WSL_DISTRO_NAME") {
+            pattern.append_text(b"wsl$/");
+            pattern.append_text(wsl_distro.as_bytes());
+        } else {
+            pattern.append_hostname();
+        }
+
+        pattern.append_text(b"/");
+        pattern.append_placeholder(Part::File);
+        pattern
+    }
+
+    #[cfg(windows)]
+    fn default() -> Self {
+        let mut pattern = Self::new();
+        pattern.append_text(b"file:///");
+        pattern.append_placeholder(Part::File);
+        pattern
+    }
+}
+
+impl FromStr for HyperlinkPattern {
+    type Err = HyperlinkPatternError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut pattern = Self::new();
+        let mut input = s.as_bytes();
+
+        loop {
+            if input.is_empty() {
+                break;
+            }
+
+            if input[0] == b'{' {
+                // Placeholder
+                let end = input
+                    .find_byte(b'}')
+                    .ok_or(HyperlinkPatternError::InvalidSyntax)?;
+
+                match &input[1..end] {
+                    b"file" => pattern.append_placeholder(Part::File),
+                    b"line" => pattern.append_placeholder(Part::Line),
+                    b"column" => pattern.append_placeholder(Part::Column),
+                    b"host" => pattern.append_hostname(),
+                    other => {
+                        return Err(HyperlinkPatternError::InvalidPlaceholder(
+                            String::from_utf8_lossy(other).to_string(),
+                        ))
+                    }
+                }
+
+                input = &input[(end + 1)..];
+            } else {
+                // Static text
+                let end = input.find_byte(b'{').unwrap_or(input.len());
+                pattern.append_text(&input[..end]);
+                input = &input[end..];
+            }
+        }
+
+        if !pattern.parts.is_empty() && !pattern.parts.contains(&Part::File) {
+            return Err(HyperlinkPatternError::NoFilePlaceholder);
+        }
+
+        Ok(pattern)
+    }
+}
+
+impl ToString for HyperlinkPattern {
+    fn to_string(&self) -> String {
+        self.parts.iter().map(|p| p.to_string()).collect()
+    }
+}
+
+impl ToString for Part {
+    fn to_string(&self) -> String {
+        match self {
+            Part::Text(text) => String::from_utf8_lossy(text).to_string(),
+            Part::File => "{file}".to_string(),
+            Part::Line => "{line}".to_string(),
+            Part::Column => "{column}".to_string(),
+        }
+    }
+}
+
+impl Display for HyperlinkPatternError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HyperlinkPatternError::InvalidSyntax => {
+                write!(f, "invalid hyperlink pattern syntax.")
+            }
+            HyperlinkPatternError::NoFilePlaceholder => {
+                write!(f, "the {{file}} placeholder is required in hyperlink patterns.")
+            }
+            HyperlinkPatternError::InvalidPlaceholder(name) => {
+                write!(
+                    f,
+                    "invalid hyperlink pattern placeholder: '{}'. Choose from: \
+                        file, line, column, host.",
+                    name
+                )
+            }
+        }
+    }
+}
+
+impl Error for HyperlinkPatternError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn combine_text_parts() {
+        let mut pattern = HyperlinkPattern::new();
+        pattern.append_text(b"foo");
+        pattern.append_text(b"bar");
+        pattern.append_text(b"baz");
+        assert_eq!(pattern.to_string(), "foobarbaz");
+        assert_eq!(pattern.parts.len(), 1);
+    }
+
+    #[test]
+    fn parse_pattern() {
+        let pattern = HyperlinkPattern::from_str(
+            "foo://{host}/bar/{file}:{line}:{column}",
+        )
+        .unwrap();
+        assert_eq!(
+            pattern.to_string(),
+            "foo://{host}/bar/{file}:{line}:{column}".replace(
+                "{host}",
+                &gethostname::gethostname().to_string_lossy()
+            )
+        );
+        assert_eq!(pattern.parts.len(), 4);
+        assert!(pattern.parts.contains(&Part::File));
+        assert!(pattern.parts.contains(&Part::Line));
+    }
+
+    #[test]
+    fn parse_different_cases() {
+        assert_eq!(
+            HyperlinkPattern::from_str("foo://{file}").unwrap().to_string(),
+            "foo://{file}"
+        );
+        assert_eq!(
+            HyperlinkPattern::from_str("foo://{file}/bar")
+                .unwrap()
+                .to_string(),
+            "foo://{file}/bar"
+        );
+        assert_eq!(
+            HyperlinkPattern::from_str("foo://bar").unwrap_err(),
+            HyperlinkPatternError::NoFilePlaceholder
+        );
+        assert_eq!(
+            HyperlinkPattern::from_str("foo://{bar}").unwrap_err(),
+            HyperlinkPatternError::InvalidPlaceholder("bar".to_string())
+        );
+        assert_eq!(
+            HyperlinkPattern::from_str("foo://{file").unwrap_err(),
+            HyperlinkPatternError::InvalidSyntax
+        );
+        assert!(HyperlinkPattern::from_str("").unwrap().parts.is_empty());
+    }
+}

--- a/crates/printer/src/hyperlink_aliases.rs
+++ b/crates/printer/src/hyperlink_aliases.rs
@@ -1,0 +1,11 @@
+/// Aliases to well-known hyperlink schemes.
+///
+/// These need to be sorted by name.
+pub const HYPERLINK_PATTERN_ALIASES: &[(&str, &str)] = &[
+    #[cfg(unix)]
+    ("file", "file://{host}/{file}"),
+    #[cfg(windows)]
+    ("file", "file:///{file}"),
+    ("kitty", "file://{host}/{file}#{line}"),
+    ("vscode", "vscode://file/{file}:{line}:{column}"),
+];

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -67,6 +67,7 @@ fn example() -> Result<(), Box<Error>> {
 pub use crate::color::{
     default_color_specs, ColorError, ColorSpecs, UserColorSpec,
 };
+pub use crate::hyperlink::{HyperlinkPattern, HyperlinkPatternError};
 #[cfg(feature = "serde1")]
 pub use crate::json::{JSONBuilder, JSONSink, JSON};
 pub use crate::standard::{Standard, StandardBuilder, StandardSink};
@@ -90,6 +91,7 @@ mod macros;
 
 mod color;
 mod counter;
+mod hyperlink;
 #[cfg(feature = "serde1")]
 mod json;
 #[cfg(feature = "serde1")]

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -68,7 +68,7 @@ pub use crate::color::{
     default_color_specs, ColorError, ColorSpecs, UserColorSpec,
 };
 pub use crate::hyperlink::{
-    HyperlinkPattern, HyperlinkPatternError, HyperlinkValues,
+    HyperlinkPattern, HyperlinkPatternError, HyperlinkSpan, HyperlinkValues,
 };
 #[cfg(feature = "serde1")]
 pub use crate::json::{JSONBuilder, JSONSink, JSON};

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -94,6 +94,7 @@ mod macros;
 mod color;
 mod counter;
 mod hyperlink;
+mod hyperlink_aliases;
 #[cfg(feature = "serde1")]
 mod json;
 #[cfg(feature = "serde1")]

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -67,7 +67,9 @@ fn example() -> Result<(), Box<Error>> {
 pub use crate::color::{
     default_color_specs, ColorError, ColorSpecs, UserColorSpec,
 };
-pub use crate::hyperlink::{HyperlinkPattern, HyperlinkPatternError};
+pub use crate::hyperlink::{
+    HyperlinkPattern, HyperlinkPatternError, HyperlinkValues,
+};
 #[cfg(feature = "serde1")]
 pub use crate::json::{JSONBuilder, JSONSink, JSON};
 pub use crate::standard::{Standard, StandardBuilder, StandardSink};

--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -1520,7 +1520,6 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
 
     fn write_path(&self, path: &PrinterPath) -> io::Result<()> {
         let mut wtr = self.wtr().borrow_mut();
-        wtr.set_color(self.config().colors.path())?;
 
         let link = if wtr.supports_hyperlinks() {
             path.hyperlink().map_or(HyperlinkSpec::none(), HyperlinkSpec::new)
@@ -1528,9 +1527,9 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
             HyperlinkSpec::none()
         };
 
+        wtr.set_color(self.config().colors.path())?;
         wtr.write_hyperlink(&link, path.as_bytes())?;
-        wtr.reset()?;
-        Ok(())
+        wtr.reset()
     }
 
     fn start_color_match(&self) -> io::Result<()> {

--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -125,6 +125,7 @@ impl StandardBuilder {
         Standard {
             config: self.config.clone(),
             wtr: RefCell::new(CounterWriter::new(wtr)),
+            buf: RefCell::new(vec![]),
             matches: vec![],
         }
     }
@@ -481,6 +482,7 @@ impl StandardBuilder {
 pub struct Standard<W> {
     config: Config,
     wtr: RefCell<CounterWriter<W>>,
+    buf: RefCell<Vec<u8>>,
     matches: Vec<Match>,
 }
 
@@ -1557,7 +1559,7 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
     ) -> io::Result<()> {
         let mut wtr = self.wtr().borrow_mut();
         if wtr.supports_hyperlinks() {
-            let mut buf = vec![]; // TODO: Don't allocate a buffer for each link
+            let mut buf = self.buf().borrow_mut();
             if let Some(spec) = path.hyperlink(
                 &self.config().hyperlink_pattern,
                 line_number,
@@ -1629,6 +1631,11 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
     /// Return the underlying writer that we are printing to.
     fn wtr(&self) -> &'a RefCell<CounterWriter<W>> {
         &self.sink.standard.wtr
+    }
+
+    /// Return a temporary buffer, which may be used for anything.
+    fn buf(&self) -> &'a RefCell<Vec<u8>> {
+        &self.sink.standard.buf
     }
 
     /// Return the path associated with this printer, if one exists.

--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -1521,7 +1521,7 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
         wtr.set_color(self.config().colors.path())?;
 
         if let Some(link) =
-            if wtr.supports_color() { path.hyperlink() } else { None }
+            if wtr.supports_hyperlinks() { path.hyperlink() } else { None }
         {
             wtr.set_hyperlink(&HyperlinkSpec::new(link))?;
             wtr.write_all(path.as_bytes())?;

--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -17,6 +17,7 @@ use termcolor::{
 
 use crate::color::ColorSpecs;
 use crate::counter::CounterWriter;
+use crate::hyperlink::HyperlinkPattern;
 use crate::stats::Stats;
 use crate::util::{
     find_iter_at_in_context, trim_ascii_prefix, trim_line_terminator,
@@ -31,6 +32,7 @@ use crate::util::{
 #[derive(Debug, Clone)]
 struct Config {
     colors: ColorSpecs,
+    hyperlink_pattern: HyperlinkPattern,
     stats: bool,
     heading: bool,
     path: bool,
@@ -56,6 +58,7 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             colors: ColorSpecs::default(),
+            hyperlink_pattern: HyperlinkPattern::default(),
             stats: false,
             heading: false,
             path: true,
@@ -159,6 +162,17 @@ impl StandardBuilder {
     /// builder.
     pub fn color_specs(&mut self, specs: ColorSpecs) -> &mut StandardBuilder {
         self.config.colors = specs;
+        self
+    }
+
+    /// Set the hyperlink pattern to use for hyperlinks output by this printer.
+    ///
+    /// Colors need to be enabled for hyperlinks to be output.
+    pub fn hyperlink_pattern(
+        &mut self,
+        pattern: HyperlinkPattern,
+    ) -> &mut StandardBuilder {
+        self.config.hyperlink_pattern = pattern;
         self
     }
 

--- a/crates/printer/src/summary.rs
+++ b/crates/printer/src/summary.rs
@@ -6,12 +6,13 @@ use std::time::Instant;
 
 use grep_matcher::Matcher;
 use grep_searcher::{Searcher, Sink, SinkError, SinkFinish, SinkMatch};
-use termcolor::{ColorSpec, NoColor, WriteColor};
+use termcolor::{ColorSpec, HyperlinkSpec, NoColor, WriteColor};
 
 use crate::color::ColorSpecs;
 use crate::counter::CounterWriter;
 use crate::stats::Stats;
 use crate::util::{find_iter_at_in_context, PrinterPath};
+use crate::HyperlinkPattern;
 
 /// The configuration for the summary printer.
 ///
@@ -22,6 +23,7 @@ use crate::util::{find_iter_at_in_context, PrinterPath};
 struct Config {
     kind: SummaryKind,
     colors: ColorSpecs,
+    hyperlink_pattern: HyperlinkPattern,
     stats: bool,
     path: bool,
     max_matches: Option<u64>,
@@ -36,6 +38,7 @@ impl Default for Config {
         Config {
             kind: SummaryKind::Count,
             colors: ColorSpecs::default(),
+            hyperlink_pattern: HyperlinkPattern::default(),
             stats: false,
             path: true,
             max_matches: None,
@@ -160,6 +163,7 @@ impl SummaryBuilder {
         Summary {
             config: self.config.clone(),
             wtr: RefCell::new(CounterWriter::new(wtr)),
+            buf: vec![],
         }
     }
 
@@ -203,6 +207,17 @@ impl SummaryBuilder {
     /// The default color specifications provide no styling.
     pub fn color_specs(&mut self, specs: ColorSpecs) -> &mut SummaryBuilder {
         self.config.colors = specs;
+        self
+    }
+
+    /// Set the hyperlink pattern to use for hyperlinks output by this printer.
+    ///
+    /// Colors need to be enabled for hyperlinks to be output.
+    pub fn hyperlink_pattern(
+        &mut self,
+        pattern: HyperlinkPattern,
+    ) -> &mut SummaryBuilder {
+        self.config.hyperlink_pattern = pattern;
         self
     }
 
@@ -328,6 +343,7 @@ impl SummaryBuilder {
 pub struct Summary<W> {
     config: Config,
     wtr: RefCell<CounterWriter<W>>,
+    buf: Vec<u8>,
 }
 
 impl<W: WriteColor> Summary<W> {
@@ -532,12 +548,9 @@ impl<'p, 's, M: Matcher, W: WriteColor> SummarySink<'p, 's, M, W> {
     /// write that path to the underlying writer followed by a line terminator.
     /// (If a path terminator is set, then that is used instead of the line
     /// terminator.)
-    fn write_path_line(&self, searcher: &Searcher) -> io::Result<()> {
-        if let Some(ref path) = self.path {
-            self.write_spec(
-                self.summary.config.colors.path(),
-                path.as_bytes(),
-            )?;
+    fn write_path_line(&mut self, searcher: &Searcher) -> io::Result<()> {
+        if self.path.is_some() {
+            self.write_path()?;
             if let Some(term) = self.summary.config.path_terminator {
                 self.write(&[term])?;
             } else {
@@ -551,16 +564,46 @@ impl<'p, 's, M: Matcher, W: WriteColor> SummarySink<'p, 's, M, W> {
     /// write that path to the underlying writer followed by the field
     /// separator. (If a path terminator is set, then that is used instead of
     /// the field separator.)
-    fn write_path_field(&self) -> io::Result<()> {
-        if let Some(ref path) = self.path {
-            self.write_spec(
-                self.summary.config.colors.path(),
-                path.as_bytes(),
-            )?;
+    fn write_path_field(&mut self) -> io::Result<()> {
+        if self.path.is_some() {
+            self.write_path()?;
             if let Some(term) = self.summary.config.path_terminator {
                 self.write(&[term])?;
             } else {
                 self.write(&self.summary.config.separator_field)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// If this printer has a file path associated with it, then this will
+    /// write that path to the underlying writer in the appropriate style
+    /// (color and hyperlink).
+    fn write_path(&mut self) -> io::Result<()> {
+        if let Some(ref path) = self.path {
+            let mut wrote_hyperlink = false;
+            if self.summary.wtr.borrow_mut().supports_hyperlinks() {
+                if let Some(spec) = path.hyperlink(
+                    &self.summary.config.hyperlink_pattern,
+                    None,
+                    None,
+                    &mut self.summary.buf,
+                ) {
+                    self.summary.wtr.borrow_mut().set_hyperlink(&spec)?;
+                    wrote_hyperlink = true;
+                }
+            }
+
+            self.write_spec(
+                self.summary.config.colors.path(),
+                path.as_bytes(),
+            )?;
+
+            if wrote_hyperlink {
+                self.summary
+                    .wtr
+                    .borrow_mut()
+                    .set_hyperlink(&HyperlinkSpec::none())?;
             }
         }
         Ok(())
@@ -704,11 +747,11 @@ impl<'p, 's, M: Matcher, W: WriteColor> Sink for SummarySink<'p, 's, M, W> {
             }
             SummaryKind::CountMatches => {
                 if show_count {
+                    self.write_path_field()?;
                     let stats = self
                         .stats
                         .as_ref()
                         .expect("CountMatches should enable stats tracking");
-                    self.write_path_field()?;
                     self.write(stats.matches().to_string().as_bytes())?;
                     self.write_line_term(searcher)?;
                 }

--- a/crates/printer/src/summary.rs
+++ b/crates/printer/src/summary.rs
@@ -581,7 +581,7 @@ impl<'p, 's, M: Matcher, W: WriteColor> SummarySink<'p, 's, M, W> {
     /// (color and hyperlink).
     fn write_path(&mut self) -> io::Result<()> {
         if let Some(ref path) = self.path {
-            let mut wrote_hyperlink = false;
+            let mut hyperlink = false;
             if self.summary.wtr.borrow_mut().supports_hyperlinks() {
                 if let Some(spec) = path.hyperlink(
                     &self.summary.config.hyperlink_pattern,
@@ -590,7 +590,7 @@ impl<'p, 's, M: Matcher, W: WriteColor> SummarySink<'p, 's, M, W> {
                     &mut self.summary.buf,
                 ) {
                     self.summary.wtr.borrow_mut().set_hyperlink(&spec)?;
-                    wrote_hyperlink = true;
+                    hyperlink = true;
                 }
             }
 
@@ -599,7 +599,7 @@ impl<'p, 's, M: Matcher, W: WriteColor> SummarySink<'p, 's, M, W> {
                 path.as_bytes(),
             )?;
 
-            if wrote_hyperlink {
+            if hyperlink {
                 self.summary
                     .wtr
                     .borrow_mut()

--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -342,6 +342,7 @@ impl<'a> PrinterPath<'a> {
     ) -> Option<HyperlinkSpec<'b>> {
         let file_path = self.hyperlink_file_path()?;
         let values = HyperlinkValues::new(file_path, line_number, column);
+        buffer.clear();
         pattern.render(&values, buffer).ok()?;
         Some(HyperlinkSpec::new(buffer))
     }

--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -386,9 +386,16 @@ impl EnvironmentInfo {
     #[cfg(unix)]
     fn build_hyperlink_prefix() -> Vec<u8> {
         let mut prefix = Vec::from(Self::HYPERLINK_SCHEME);
-        prefix.extend_from_slice(
-            gethostname::gethostname().to_string_lossy().as_bytes(),
-        );
+
+        if let Ok(wsl_distro) = std::env::var("WSL_DISTRO_NAME") {
+            prefix.extend_from_slice(b"wsl$/");
+            prefix.extend_from_slice(wsl_distro.as_bytes());
+        } else {
+            prefix.extend_from_slice(
+                gethostname::gethostname().to_string_lossy().as_bytes(),
+            );
+        }
+
         prefix
     }
 

--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -312,7 +312,7 @@ impl<'a> PrinterPath<'a> {
     /// environments, only `/` is treated as a path separator.
     fn replace_separator(&mut self, new_sep: u8) {
         let transformed_path: Vec<u8> = self
-            .bytes
+            .as_bytes()
             .bytes()
             .map(|b| {
                 if b == b'/' || (cfg!(windows) && b == b'\\') {

--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -13,8 +13,8 @@ use grep_searcher::{
 use serde::{Serialize, Serializer};
 use termcolor::HyperlinkSpec;
 
-use crate::hyperlink::HyperlinkValues;
-use crate::{HyperlinkPattern, MAX_LOOK_AHEAD};
+use crate::hyperlink::{HyperlinkPattern, HyperlinkValues};
+use crate::MAX_LOOK_AHEAD;
 
 /// A type for handling replacements while amortizing allocation.
 pub struct Replacer<M: Matcher> {
@@ -333,7 +333,7 @@ impl<'a> PrinterPath<'a> {
 
     /// Creates a hyperlink for this path and the given line and column, using the specified
     /// pattern. Uses the given buffer to store the hyperlink.
-    pub fn hyperlink<'b>(
+    pub fn create_hyperlink<'b>(
         &self,
         pattern: &HyperlinkPattern,
         line_number: Option<u64>,

--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -340,6 +340,9 @@ impl<'a> PrinterPath<'a> {
         column: Option<u64>,
         buffer: &'b mut Vec<u8>,
     ) -> Option<HyperlinkSpec<'b>> {
+        if pattern.is_empty() {
+            return None;
+        }
         let file_path = self.hyperlink_file_path()?;
         let values = HyperlinkValues::new(file_path, line_number, column);
         buffer.clear();

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -369,27 +369,31 @@ rgtest!(r405, |dir: Dir, mut cmd: TestCommand| {
     eqnice!("bar/foo/file2.txt:test\n", cmd.stdout());
 });
 
-// See: https://github.com/BurntSushi/ripgrep/issues/428
-#[cfg(not(windows))]
-rgtest!(r428_color_context_path, |dir: Dir, mut cmd: TestCommand| {
-    dir.create("sherlock", "foo\nbar");
-    cmd.args(&[
-        "-A1",
-        "-H",
-        "--no-heading",
-        "-N",
-        "--colors=match:none",
-        "--color=always",
-        "foo",
-    ]);
+// TODO(ltrzesniewski): This regression test has been temporarily disabled
+// as it currently inserts hyperlinks. Figure out the behavior we want
+// (e.g. do we want a --hyperlinks command line argument?)
 
-    let expected = format!(
-        "{colored_path}:foo\n{colored_path}-bar\n",
-        colored_path =
-            "\x1b\x5b\x30\x6d\x1b\x5b\x33\x35\x6dsherlock\x1b\x5b\x30\x6d"
-    );
-    eqnice!(expected, cmd.stdout());
-});
+// // See: https://github.com/BurntSushi/ripgrep/issues/428
+// #[cfg(not(windows))]
+// rgtest!(r428_color_context_path, |dir: Dir, mut cmd: TestCommand| {
+//     dir.create("sherlock", "foo\nbar");
+//     cmd.args(&[
+//         "-A1",
+//         "-H",
+//         "--no-heading",
+//         "-N",
+//         "--colors=match:none",
+//         "--color=always",
+//         "foo",
+//     ]);
+//
+//     let expected = format!(
+//         "{colored_path}:foo\n{colored_path}-bar\n",
+//         colored_path =
+//             "\x1b\x5b\x30\x6d\x1b\x5b\x33\x35\x6dsherlock\x1b\x5b\x30\x6d"
+//     );
+//     eqnice!(expected, cmd.stdout());
+// });
 
 // See: https://github.com/BurntSushi/ripgrep/issues/428
 rgtest!(r428_unrecognized_style, |dir: Dir, mut cmd: TestCommand| {

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -369,31 +369,28 @@ rgtest!(r405, |dir: Dir, mut cmd: TestCommand| {
     eqnice!("bar/foo/file2.txt:test\n", cmd.stdout());
 });
 
-// TODO(ltrzesniewski): This regression test has been temporarily disabled
-// as it currently inserts hyperlinks. Figure out the behavior we want
-// (e.g. do we want a --hyperlinks command line argument?)
+// See: https://github.com/BurntSushi/ripgrep/issues/428
+#[cfg(not(windows))]
+rgtest!(r428_color_context_path, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("sherlock", "foo\nbar");
+    cmd.args(&[
+        "-A1",
+        "-H",
+        "--no-heading",
+        "-N",
+        "--colors=match:none",
+        "--color=always",
+        "--hyperlink-format=",
+        "foo",
+    ]);
 
-// // See: https://github.com/BurntSushi/ripgrep/issues/428
-// #[cfg(not(windows))]
-// rgtest!(r428_color_context_path, |dir: Dir, mut cmd: TestCommand| {
-//     dir.create("sherlock", "foo\nbar");
-//     cmd.args(&[
-//         "-A1",
-//         "-H",
-//         "--no-heading",
-//         "-N",
-//         "--colors=match:none",
-//         "--color=always",
-//         "foo",
-//     ]);
-//
-//     let expected = format!(
-//         "{colored_path}:foo\n{colored_path}-bar\n",
-//         colored_path =
-//             "\x1b\x5b\x30\x6d\x1b\x5b\x33\x35\x6dsherlock\x1b\x5b\x30\x6d"
-//     );
-//     eqnice!(expected, cmd.stdout());
-// });
+    let expected = format!(
+        "{colored_path}:foo\n{colored_path}-bar\n",
+        colored_path =
+            "\x1b\x5b\x30\x6d\x1b\x5b\x33\x35\x6dsherlock\x1b\x5b\x30\x6d"
+    );
+    eqnice!(expected, cmd.stdout());
+});
 
 // See: https://github.com/BurntSushi/ripgrep/issues/428
 rgtest!(r428_unrecognized_style, |dir: Dir, mut cmd: TestCommand| {


### PR DESCRIPTION
This PR adds hyperlinks to search results in terminals which support them:

![image](https://user-images.githubusercontent.com/7913492/229365208-8e89dbb0-53d1-4e82-b6ed-3d27004dd830.png)

Compared to the previous PR (#2322), it adds a `--hyperlink-format PATTERN` command line option which lets you configure the output.

`PATTERN` can be:

- An URL pattern with the following placeholders:
	- `{file}` for the absolute file name. This one is required.
		- Without the leading `/` on Unix (as this makes the patterns more intuitive)
		- With `\` replaced by `/` on Windows
    - `{line}` for the line number of the result
    - `{column}` for the column number of the result. `{line}` is required of this is used.
    - `{host}` for the hostname
- An alias to a well-known pattern, such as `vscode`. Only a few are currently defined but hopefully more could be added over time, on the same principle than file types (`default_types.rs`)

The default patterns are the ones which are the most widely supported:

- Unix: `file://{host}/{file}`
- Windows: `file:///{file}`
- WSL `file://wsl$/{distro}/{file}`

This makes ripgrep only output hyperlinks on the file headings by default, like in the screenshot above.

If a patten includes `{line}` however, each line prelude becomes a link. Here's an example with `--hyperlink format vscode`:

![image](https://user-images.githubusercontent.com/7913492/229365867-aa1c8387-61f0-4f1b-9b2d-bb7ed06748af.png)

The idea is for a user to add `--hyperlink-format` to their configuration file to enable more features.

This PR depends on https://github.com/BurntSushi/termcolor/pull/65 to write hyperlink control codes to the terminal. I had to make changes to the CI in order to build ripgrep without that PR having shipped. I'll revert them once the updated termcolor crate is published. Of course, if any change is requested there, I'll update this PR accordingly.

I tried my best to write high-quality code, I hope it's good enough, but I'd appreciate any feedback on how I could have done things better, since Rust isn't my day-to-day language. 🙂

Closes #665 
Supersedes #2322

> **Note**
> - Preview optimized builds can be found [here](https://github.com/ltrzesniewski/ripgrep/actions/workflows/preview.yml?query=is%3Asuccess), for those interested.
> - For Windows Terminal users, [this change](https://github.com/microsoft/terminal/pull/14993) needs to ship before any scheme other than the default can be used.
