### PR TITLE
args: use non-capturing groups when joining multiple patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Bug fixes:
   Disable mmap searching in all non-64-bit environments.
 * [BUG #2236](https://github.com/BurntSushi/ripgrep/issues/2236):
   Fix gitignore parsing bug where a trailing `\/` resulted in an error.
+* [BUG #2480](https://github.com/BurntSushi/ripgrep/issues/2480):
+  Fix bug when using flags with '-e'.
 
 
 13.0.0 (2021-06-12)

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -700,7 +700,13 @@ impl ArgMatches {
         let res = if self.is_present("fixed-strings") {
             builder.build_literals(patterns)
         } else {
-            builder.build(&patterns.join("|"))
+            builder.build(
+                &patterns
+                    .iter()
+                    .map(|s| format!("(?:{})", s))
+                    .collect::<Vec<String>>()
+                    .join("|"),
+            )
         };
         match res {
             Ok(m) => Ok(m),

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -700,13 +700,16 @@ impl ArgMatches {
         let res = if self.is_present("fixed-strings") {
             builder.build_literals(patterns)
         } else {
-            builder.build(
-                &patterns
-                    .iter()
-                    .map(|s| format!("(?:{})", s))
-                    .collect::<Vec<String>>()
-                    .join("|"),
-            )
+            match patterns.len() {
+                1 => builder.build(&patterns[0]),
+                _ => builder.build(
+                    &patterns
+                        .iter()
+                        .map(|s| format!("(?:{})", s))
+                        .collect::<Vec<String>>()
+                        .join("|"),
+                ),
+            }
         };
         match res {
             Ok(m) => Ok(m),

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -700,16 +700,8 @@ impl ArgMatches {
         let res = if self.is_present("fixed-strings") {
             builder.build_literals(patterns)
         } else {
-            match patterns.len() {
-                1 => builder.build(&patterns[0]),
-                _ => builder.build(
-                    &patterns
-                        .iter()
-                        .map(|s| format!("(?:{})", s))
-                        .collect::<Vec<String>>()
-                        .join("|"),
-                ),
-            }
+            let joined = self.join_patterns(&patterns);
+            builder.build(&joined)
         };
         match res {
             Ok(m) => Ok(m),
@@ -717,6 +709,16 @@ impl ArgMatches {
         }
     }
 
+    fn join_patterns(&self, patterns: &[String]) -> String {
+        match patterns.len() {
+            1 => patterns[0].to_owned(),
+            _ => patterns
+                .iter()
+                .map(|s| format!("(?:{})", s))
+                .collect::<Vec<String>>()
+                .join("|"),
+        }
+    }
     /// Build a matcher using PCRE2.
     ///
     /// If there was a problem building the matcher (such as a regex syntax
@@ -756,7 +758,8 @@ impl ArgMatches {
         if self.is_present("crlf") {
             builder.crlf(true);
         }
-        Ok(builder.build(&patterns.join("|"))?)
+        let joined = self.join_patterns(&patterns);
+        Ok(builder.build(&joined)?)
     }
 
     /// Build a JSON printer that writes results to the given writer.

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1131,7 +1131,17 @@ rgtest!(r2236, |dir: Dir, mut cmd: TestCommand| {
 rgtest!(r2480, |dir: Dir, mut cmd: TestCommand| {
     dir.create("file", "FooBar\n");
 
+    // no regression in empty pattern behavior
+    cmd.args(&["-e", "", "file"]);
+    eqnice!("FooBar\n", cmd.stdout());
+
+    // no regression in single pattern behavior
+    let mut cmd = dir.command();
+    cmd.args(&["-e", ")(", "file"]);
+    cmd.assert_err();
+
     // no regression in multiple patterns behavior
+    let mut cmd = dir.command();
     cmd.args(&["--only-matching", "-e", "Foo", "-e", "Bar", "file"]);
     eqnice!("Foo\nBar\n", cmd.stdout());
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1126,3 +1126,27 @@ rgtest!(r2236, |dir: Dir, mut cmd: TestCommand| {
     dir.create("foo/bar", "test\n");
     cmd.args(&["test"]).assert_err();
 });
+
+// See: https://github.com/BurntSushi/ripgrep/issues/2480
+rgtest!(r2480, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("file", "FooBar\n");
+
+    // no regression in multiple patterns behavior
+    cmd.args(&["--only-matching", "-e", "Foo", "-e", "Bar", "file"]);
+    eqnice!("Foo\nBar\n", cmd.stdout());
+
+    // no regression in capture groups behavior
+    let mut cmd = dir.command();
+    cmd.args(&["-e", "Fo(oB)a(r)", "--replace", "${0}_${1}_${2}${3}", "file"]);
+    eqnice!("FooBar_oB_r\n", cmd.stdout()); // note: ${3} expected to be empty
+
+    // flag does not leak into next pattern on match
+    let mut cmd = dir.command();
+    cmd.args(&["--only-matching", "-e", "(?i)foo", "-e", "bar", "file"]);
+    eqnice!("Foo\n", cmd.stdout());
+
+    // flag does not leak into next pattern on mismatch
+    let mut cmd = dir.command();
+    cmd.args(&["--only-matching", "-e", "(?i)notfoo", "-e", "bar", "file"]);
+    cmd.assert_err();
+});


### PR DESCRIPTION
Fixes #2480

Fix the joined pattern so that multiple VALID patterns cannot affect each other.
e.g. worked before but fixed now:
`echo FooBar | rg -e '(?i)notfoo' -e bar # no result` 

Wontfix the joined pattern to handle some cases of multiple INVALID patterns that are "coordinated" to fix each other.
e.g. still works but is unexpected:
`echo 'FooBar' | rg -e '(' -e ')' # matches with an empty string`

also, introduces a new class of invalid patterns that work now but wouldn't work before:
e.g. got parse error before but not now:
`echo 'FooBar' | rg ')(' # matches with an empty string`

edit: pushed another commit to avoid the regerssion for a single pattern.
the new class still applies for multiple patterns:
e.g. got parse error before but not now:
`echo 'FooBar' | rg -e ')(' -e 'x' # matches with an empty string`