### PR TITLE
Fix code block label in docs

### DIFF
--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -5,7 +5,7 @@ Glob set matching is the process of matching one or more glob patterns against
 a single candidate path simultaneously, and returning all of the globs that
 matched. For example, given this set of globs:
 
-```ignore
+```text
 *.rs
 src/lib.rs
 src/**/foo.rs


### PR DESCRIPTION
I changed the attribute (info string) `ignore` to `text`. `ignore` is used for Rust code that should not be run and also receives a label in the generated documentation, which is incorrect for the modified block. Changing it to `text` removes syntax highlighting (though the previous highlighting was incorrect).

Additional links:
- [Rustdoc code attributes](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#attributes)
- [Commonmark spec on info string](https://spec.commonmark.org/0.30/#info-string)