### PR TITLE
deps: update to aho-corasick 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,7 +148,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 name = "globset"
 version = "0.4.10"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.0.1",
  "bstr",
  "fnv",
  "glob",
@@ -213,7 +222,7 @@ dependencies = [
 name = "grep-regex"
 version = "0.1.11"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.0.1",
  "bstr",
  "grep-matcher",
  "log",
@@ -409,7 +418,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "memchr",
  "regex-syntax",
 ]

--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -20,7 +20,7 @@ name = "globset"
 bench = false
 
 [dependencies]
-aho-corasick = "0.7.3"
+aho-corasick = "1.0.1"
 bstr = { version = "1.1.0", default-features = false, features = ["std"] }
 fnv = "1.0.6"
 log = { version = "0.4.5", optional = true }

--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -818,7 +818,7 @@ impl MultiStrategyBuilder {
 
     fn prefix(self) -> PrefixStrategy {
         PrefixStrategy {
-            matcher: AhoCorasick::new_auto_configured(&self.literals),
+            matcher: AhoCorasick::new(&self.literals).unwrap(),
             map: self.map,
             longest: self.longest,
         }
@@ -826,7 +826,7 @@ impl MultiStrategyBuilder {
 
     fn suffix(self) -> SuffixStrategy {
         SuffixStrategy {
-            matcher: AhoCorasick::new_auto_configured(&self.literals),
+            matcher: AhoCorasick::new(&self.literals).unwrap(),
             map: self.map,
             longest: self.longest,
         }

--- a/crates/regex/Cargo.toml
+++ b/crates/regex/Cargo.toml
@@ -14,7 +14,7 @@ license = "Unlicense OR MIT"
 edition = "2018"
 
 [dependencies]
-aho-corasick = "0.7.3"
+aho-corasick = "1.0.1"
 bstr = "1.1.0"
 grep-matcher = { version = "0.1.6", path = "../matcher" }
 log = "0.4.5"

--- a/crates/regex/src/multi.rs
+++ b/crates/regex/src/multi.rs
@@ -1,4 +1,4 @@
-use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
+use aho_corasick::{AhoCorasick, MatchKind};
 use grep_matcher::{Match, Matcher, NoError};
 use regex_syntax::hir::Hir;
 
@@ -23,10 +23,9 @@ impl MultiLiteralMatcher {
     pub fn new<B: AsRef<[u8]>>(
         literals: &[B],
     ) -> Result<MultiLiteralMatcher, Error> {
-        let ac = AhoCorasickBuilder::new()
+        let ac = AhoCorasick::builder()
             .match_kind(MatchKind::LeftmostFirst)
-            .auto_configure(literals)
-            .build_with_size::<usize, _, _>(literals)
+            .build(literals)
             .map_err(Error::regex)?;
         Ok(MultiLiteralMatcher { ac })
     }


### PR DESCRIPTION
I think nothing changed in public APIs, but maybe MSRV has been bumped by this