### PR TITLE
cli: make `resolve_binary()` take COM executables into account

### DIFF
--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -455,9 +455,11 @@ pub fn resolve_binary<P: AsRef<Path>>(
             return Ok(abs_prog.to_path_buf());
         }
         if abs_prog.extension().is_none() {
-            let abs_prog = abs_prog.with_extension("exe");
-            if is_exe(&abs_prog) {
-                return Ok(abs_prog.to_path_buf());
+            for extension in ["com", "exe"] {
+                let abs_prog = abs_prog.with_extension(extension);
+                if is_exe(&abs_prog) {
+                    return Ok(abs_prog.to_path_buf());
+                }
             }
         }
     }


### PR DESCRIPTION
When `resolve_binary()` attempts to resolve a path to a program on Windows while searching for a program in `PATH` without an extension, `ripgrep` will assume the extension of the file to be `.exe` as it's the *de facto* standard, which will work most (99.99%) of the time...

...unless the binary is a COM executable (we're on Windows, duh).

(It feels weird being the first person to run into this.)

Related: sharkdp/bat#2570 (`more` is a COM executable)