### PR TITLE
Upgrade `aho-corasick` to `1.0.1` in `globset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 name = "globset"
 version = "0.4.10"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick 1.0.1",
  "bstr",
  "fnv",
  "glob",

--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -20,7 +20,7 @@ name = "globset"
 bench = false
 
 [dependencies]
-aho-corasick = "0.7.3"
+aho-corasick = "1.0.1"
 bstr = { version = "1.1.0", default-features = false, features = ["std"] }
 fnv = "1.0.6"
 log = { version = "0.4.5", optional = true }


### PR DESCRIPTION
Hi!

I noticed that `aho-corasick` was still on version `0.7.20` so it's getting built twice in downstream projects that use the latest version alongside `globset`.

Updating required:

- Change from `AhoCorasick::new_auto_configured` to `AhoCorasick::new`
- A new `GlobSet::ErrorKind` for handling of `AhoCorasick::BuildError`

I named the error `MatchBuild` following the pattern used for `Regex` compilation errors.

I'm new to Rust so any feedback is welcome!