### PR TITLE
Add `.cml` to default_types.rs

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -38,6 +38,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ("ceylon", &["*.ceylon"]),
     ("clojure", &["*.clj", "*.cljc", "*.cljs", "*.cljx"]),
     ("cmake", &["*.cmake", "CMakeLists.txt"]),
+    ("cml", &["*.cml"]),
     ("coffeescript", &["*.coffee"]),
     ("config", &["*.cfg", "*.conf", "*.config", "*.ini"]),
     ("coq", &["*.v"]),


### PR DESCRIPTION
Use on Fuchsia to mean "component manifest language": [1].

It's also the "Chemical Markup Language" [2] and shares the same extension.

[1]: https://fuchsia.dev/reference/cml?hl=en
[2]: https://www.reviversoft.com/en/file-extensions/cml