### PR TITLE
Fix rust-version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["HomebrewFormula"]
 build = "build.rs"
 autotests = false
 edition = "2018"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [[bin]]
 bench = false

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ $ cargo install ripgrep
 
 ripgrep is written in Rust, so you'll need to grab a
 [Rust installation](https://www.rust-lang.org/) in order to compile it.
-ripgrep compiles with Rust 1.65.0 (stable) or newer. In general, ripgrep tracks
+ripgrep compiles with Rust 1.70.0 (stable) or newer. In general, ripgrep tracks
 the latest stable release of the Rust compiler.
 
 To build ripgrep:


### PR DESCRIPTION
ripgrep requires Rust 1.70, which is already documented in the Readme. This change adjusts the Cargo.toml to reflect this.