### PR TITLE
ignore/types: add Windows Command Prompt files

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -24,6 +24,7 @@ pub const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["ats"], &["*.ats", "*.dats", "*.sats", "*.hats"]),
     (&["avro"], &["*.avdl", "*.avpr", "*.avsc"]),
     (&["awk"], &["*.awk"]),
+    (&["bat", "batch"], &["*.bat"]),
     (&["bazel"], &[
         "*.bazel", "*.bzl", "*.BUILD", "*.bazelrc", "BUILD", "MODULE.bazel",
         "WORKSPACE", "WORKSPACE.bazel",
@@ -40,6 +41,7 @@ pub const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["ceylon"], &["*.ceylon"]),
     (&["clojure"], &["*.clj", "*.cljc", "*.cljs", "*.cljx"]),
     (&["cmake"], &["*.cmake", "CMakeLists.txt"]),
+    (&["cmd"], &["*.bat", "*.cmd"]),
     (&["cml"], &["*.cml"]),
     (&["coffeescript"], &["*.coffee"]),
     (&["config"], &["*.cfg", "*.conf", "*.config", "*.ini"]),


### PR DESCRIPTION
This PR adds `*.bat` and `*.cmd` file types.

In doing so, it makes a distinction between batch files (old standard from the MS-DOS era) and command scripts (new flavor - can operate on batch files, although `*.cmd` is preferred for various reasons, the main one being batch files will set `ERRORLEVEL` following inconsistent MS-DOS style rules).