### PR TITLE
ignore/types: add TCC files

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -268,6 +268,7 @@ pub const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         "*.timer",
     ]),
     (&["taskpaper"], &["*.taskpaper"]),
+    (&["tcc"], &["*.bat", "*.btm", "*.cmd"]),
     (&["tcl"], &["*.tcl"]),
     (&["tex"], &["*.tex", "*.ltx", "*.cls", "*.sty", "*.bib", "*.dtx", "*.ins"]),
     (&["texinfo"], &["*.texi"]),


### PR DESCRIPTION
This PR adds file types for TCC, a `cmd.exe` extension.

Extensions are the same as for `cmd` itself + `*.btm`[1].

[1]: https://jpsoft.com/help/batchtype.htm