### PR TITLE
ignore/types: tweak Gradle file types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Unreleased changes. Release notes have not yet been written.
 
 Feature enhancements:
 
-* Added or improved file type filtering for Ada, DITA, Elixir, Fuchsia, Gentoo, GraphQL, Markdown, Raku, TypeScript, USD, V
+* Added or improved file type filtering for Ada, DITA, Elixir, Fuchsia, Gentoo,
+  Gradle, GraphQL, Markdown, Raku, TypeScript, USD, V
 * [FEATURE #1790](https://github.com/BurntSushi/ripgrep/issues/1790):
   Add new `--stop-on-nonmatch` flag.
 * [FEATURE #2195](https://github.com/BurntSushi/ripgrep/issues/2195):

--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -91,7 +91,10 @@ pub const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["gn"], &["*.gn", "*.gni"]),
     (&["go"], &["*.go"]),
     (&["gprbuild"], &["*.gpr"]),
-    (&["gradle"], &["*.gradle"]),
+    (&["gradle"], &[
+        "*.gradle", "*.gradle.kts", "gradle.properties", "gradle-wrapper.*",
+        "gradlew", "gradlew.bat",
+    ]),
     (&["graphql"], &["*.graphql", "*.graphqls"]),
     (&["groovy"], &["*.groovy", "*.gradle"]),
     (&["gzip"], &["*.gz", "*.tgz"]),


### PR DESCRIPTION
This PR extends Gradle file types with the following:

 - Kotlin DSL buildscripts (`*.gradle.kts`)
 - Gradle Java properties (`gradle.properties`)
 - wrapper files (`gradle-wrapper.*`)
 - wrapper scripts (`gradlew`, `gradlew.bat`)