### PR TITLE
ignore/types: add Prolog file types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Unreleased changes. Release notes have not yet been written.
 Feature enhancements:
 
 * Added or improved file type filtering for Ada, DITA, Elixir, Fuchsia, Gentoo,
-  Gradle, GraphQL, Markdown, Raku, TypeScript, USD, V
+  Gradle, GraphQL, Markdown, Prolog, Raku, TypeScript, USD, V
 * [FEATURE #1790](https://github.com/BurntSushi/ripgrep/issues/1790):
   Add new `--stop-on-nonmatch` flag.
 * [FEATURE #2195](https://github.com/BurntSushi/ripgrep/issues/2195):

--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -201,6 +201,7 @@ pub const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["po"], &["*.po"]),
     (&["pod"], &["*.pod"]),
     (&["postscript"], &["*.eps", "*.ps"]),
+    (&["prolog"], &["*.pl", "*.pro", "*.prolog", "*.P"]),
     (&["protobuf"], &["*.proto"]),
     (&["ps"], &["*.cdxml", "*.ps1", "*.ps1xml", "*.psd1", "*.psm1"]),
     (&["puppet"], &["*.epp", "*.erb", "*.pp", "*.rb"]),


### PR DESCRIPTION
 - `.pl` is the most common extension in the wild, though `.pro` is preferred in places where file extension may clash with Perl[1]
 - `.P` is used for compatibility with XSB Prolog dialect[2]

[1]: https://www.swi-prolog.org/pldoc/man?section=fileext
[2]: https://www.swi-prolog.org/pldoc/man?section=xsb-source