### PR TITLE
implemented filelist to get list of paths

### DIFF
--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -570,6 +570,7 @@ pub fn all_args_and_flags() -> Vec<RGArg> {
     flag_engine(&mut args);
     flag_field_context_separator(&mut args);
     flag_field_match_separator(&mut args);
+    flag_file_list(&mut args);
     flag_file(&mut args);
     flag_files(&mut args);
     flag_files_with_matches(&mut args);
@@ -1260,6 +1261,19 @@ character is the default value.
     let arg = RGArg::flag("field-match-separator", "SEPARATOR")
         .help(SHORT)
         .long_help(LONG);
+    args.push(arg);
+}
+fn flag_file_list(args: &mut Vec<RGArg>) {
+    const SHORT: &str = "A file that contains list of paths to include";
+    const LONG: &str = long!(
+        "\
+A file that contains list of paths to include
+"
+    );
+    let arg = RGArg::flag("filelist", "FILE")
+        .help(SHORT)
+        .long_help(LONG)
+        .allow_leading_hyphen();
     args.push(arg);
 }
 

--- a/crates/core/args.rs
+++ b/crates/core/args.rs
@@ -1123,6 +1123,27 @@ impl ArgMatches {
         self.is_present("ignore-file-case-insensitive")
     }
 
+    //returns list of paths written inside filelist 
+    fn list_paths(&self) -> Vec<String> {
+        let path = self.value_of_os("filelist").unwrap();
+
+use std::fs::File;
+use std::io::BufRead;
+    // Open the file
+    //let file = File::open(Path::new(path));
+    // Create a buffer reader
+    let reader = io::BufReader::new(fs::File::open(Path::new(path)).unwrap());
+    // Collect the paths into a vector
+    let paths: Vec<String> = reader.lines()
+        .filter_map(|line| line.ok()) // Filter out any lines with read errors
+        .filter_map(|line| {
+            Some(line.trim().to_string()) // Extract the path and trim whitespace
+        })
+        .collect();
+
+            paths 
+    } 
+
     /// Return all of the ignore file paths given on the command line.
     fn ignore_paths(&self) -> Vec<PathBuf> {
         let paths = match self.values_of_os("ignore-file") {
@@ -1319,6 +1340,13 @@ impl ArgMatches {
         {
             if let Some(path) = self.value_of_os("pattern") {
                 paths.insert(0, Path::new(path).to_path_buf());
+            }
+        }
+        if self.is_present("filelist")
+        {
+            let fnlist= self.list_paths();  
+            for path in fnlist {
+                paths.push(Path::new(&path).to_path_buf());
             }
         }
         paths


### PR DESCRIPTION
Added option to get list of paths. I got into trouble trying to work with list of files in neovim (leaderf or other), when the list of files I wanted to search over was very long.  I believe it solves https://github.com/BurntSushi/ripgrep/issues/273 . 

See also https://vi.stackexchange.com/questions/42785/how-to-do-fuzzy-live-grep-on-git-files/42915#42915