### PR TITLE
ignore/types: Add *.vsh to V type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -289,7 +289,7 @@ pub const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["txt"], &["*.txt"]),
     (&["typoscript"], &["*.typoscript", "*.ts"]),
     (&["usd"], &["*.usd", "*.usda", "*.usdc"]),
-    (&["v"], &["*.v"]),
+    (&["v"], &["*.v", "*.vsh"]),
     (&["vala"], &["*.vala"]),
     (&["vb"], &["*.vb"]),
     (&["vcl"], &["*.vcl"]),


### PR DESCRIPTION
The V language (vlang.io) also uses *.vsh (V shell) as extension: https://github.com/vlang/v/blob/master/doc/docs.md#cross-platform-shell-scripts-in-v. 