### PR TITLE
ignore/types: Add *.sarif for SARIF format files

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -112,7 +112,7 @@ pub const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["jinja"], &["*.j2", "*.jinja", "*.jinja2"]),
     (&["jl"], &["*.jl"]),
     (&["js"], &["*.js", "*.jsx", "*.vue", "*.cjs", "*.mjs"]),
-    (&["json"], &["*.json", "composer.lock"]),
+    (&["json"], &["*.json", "composer.lock", "*.sarif"]),
     (&["jsonl"], &["*.jsonl"]),
     (&["julia"], &["*.jl"]),
     (&["jupyter"], &["*.ipynb", "*.jpynb"]),


### PR DESCRIPTION
[SARIF][] is a format for reporting static analysis results. It is [used by GitHub CodeQL][GH] for example.

Here are some samples from Microsoft's VSCode extension:

https://github.com/microsoft/sarif-vscode-extension/tree/main/samples

The SARIF format is built on top of JSON. This PR associates `*.sarif` files with JSON.

[SARIF]: https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html
[GH]: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning