### PR TITLE
Respect global .gitignore when excludesFile path uses surrounding double quotes

### DIFF
--- a/crates/ignore/src/gitignore.rs
+++ b/crates/ignore/src/gitignore.rs
@@ -605,7 +605,7 @@ fn parse_excludes_file(data: &[u8]) -> Option<PathBuf> {
         Regex::builder()
             .configure(Regex::config().utf8_empty(false))
             .syntax(syntax::Config::new().utf8(false))
-            .build(r"(?im-u)^\s*excludesfile\s*=[\x22\s]*(\S+?)[\x22\s]*$")
+            .build(r#"(?im-u)^\s*excludesfile\s*=\s*"?\s*(\S+?)\s*"?\s*$"#)
             .unwrap()
     });
     // We don't care about amortizing allocs here I think. This should only
@@ -780,6 +780,11 @@ mod tests {
             path_string(got.unwrap()),
             super::expand_tilde("~/foo/bar")
         );
+    }
+    #[test]
+    fn parse_excludes_file5() {
+        let data = bytes("[core]\nexcludesFile = \" \"~/foo/bar \" \"");
+        assert!(super::parse_excludes_file(&data).is_none());
     }
 
     // See: https://github.com/BurntSushi/ripgrep/issues/106


### PR DESCRIPTION
Related Issue: #2392 

# Summary of problem:
In a .gitconfig file, a user may specify additional file patterns they may want to ignore when committing changes by using the `core.excludesFile` setting. RipGrep respects these file patterns as well. 

Git also handles file paths that are surrounded by double quotes like
```
[core]
    excludesFile = "~/foo/bar"
```
RipGrep's logic does not handle for double quotes. 

# Changes
The regex used to parse the `excludesFile` section of the .gitconfig adds double quotes (\x22)  as a part of the parsing pattern.

# Tests
Wrote `parse_excludes_file4`  for unit testing

Manually tested from issue's example:
```
$ mkdir rg_global_gitignore
$ cd rg_global_gitignore
$ git init

# adding the config this way will strip the quotation marks
# git config --global core.excludesFile "~/.gitignore"

# open ~/.gitconfig and add:
#
# [core]
# 	excludesFile = "~/.gitignore"

$ echo "*.sql" > ~/.gitignore

$ touch backup backup.sql backup123.sql db_backup.sql
$ <path>/ripgrep/target/release/rg --files --debug
DEBUG|grep_regex::config|crates/regex/src/config.rs:173: assembling HIR from 0 fixed string literals
DEBUG|rg::args|crates/core/args.rs:555: running with 8 threads for parallelism
DEBUG|rg::args|crates/core/args.rs:1148: hyperlink format: "file://{host}{path}"
[126, 47, 46, 103, 105, 116, 105, 103, 110, 111, 114, 101]
DEBUG|globset|crates/globset/src/lib.rs:445: built glob set; 0 literals, 0 basenames, 1 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 0 regexes
DEBUG|globset|crates/globset/src/lib.rs:445: built glob set; 0 literals, 0 basenames, 1 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 0 regexes
DEBUG|ignore::walk|crates/ignore/src/walk.rs:1804: ignoring ./db_backup.sql: Ignore(IgnoreMatch(Gitignore(Glob { from: Some("/Users/kento/.gitignore"), original: "*.sql", actual: "**/*.sql", is_whitelist: false, is_only_dir: false })))
DEBUG|ignore::walk|crates/ignore/src/walk.rs:1804: ignoring ./backup123.sql: Ignore(IgnoreMatch(Gitignore(Glob { from: Some("/Users/kento/.gitignore"), original: "*.sql", actual: "**/*.sql", is_whitelist: false, is_only_dir: false })))
DEBUG|ignore::walk|crates/ignore/src/walk.rs:1804: ignoring ./.gitignore: Ignore(IgnoreMatch(Hidden))
DEBUG|ignore::walk|crates/ignore/src/walk.rs:1804: ignoring ./.git: Ignore(IgnoreMatch(Hidden))
DEBUG|ignore::walk|crates/ignore/src/walk.rs:1804: ignoring ./backup.sql: Ignore(IgnoreMatch(Gitignore(Glob { from: Some("/Users/kento/.gitignore"), original: "*.sql", actual: "**/*.sql", is_whitelist: false, is_only_dir: false })))
backup
```