### PR TITLE
globset: Add GlobSet::builder

### DIFF
--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -304,6 +304,14 @@ pub struct GlobSet {
 }
 
 impl GlobSet {
+    /// Create a new [`GlobSetBuilder`]. A `GlobSetBuilder` can be used to add
+    /// new patterns. Once all patterns have been added, `build` should be
+    /// called to produce a `GlobSet`, which can then be used for matching.
+    #[inline]
+    pub fn builder() -> GlobSetBuilder {
+        GlobSetBuilder::new()
+    }
+
     /// Create an empty `GlobSet`. An empty set matches nothing.
     #[inline]
     pub fn empty() -> GlobSet {

--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -485,9 +485,9 @@ pub struct GlobSetBuilder {
 }
 
 impl GlobSetBuilder {
-    /// Create a new GlobSetBuilder. A GlobSetBuilder can be used to add new
+    /// Create a new `GlobSetBuilder`. A `GlobSetBuilder` can be used to add new
     /// patterns. Once all patterns have been added, `build` should be called
-    /// to produce a `GlobSet`, which can then be used for matching.
+    /// to produce a [`GlobSet`], which can then be used for matching.
     pub fn new() -> GlobSetBuilder {
         GlobSetBuilder { pats: vec![] }
     }


### PR DESCRIPTION
It's a somewhat common pattern to have `Type::builder` be an alias for `TypeBuilder::new` (or even the only way of constructing `TypeBuilder`). It means you don't have to import the builder type separately for common usage.

Thanks for this very handy small library 💚 