### PR TITLE
Add -d as short command for --max-depth

### DIFF
--- a/complete/_rg
+++ b/complete/_rg
@@ -182,7 +182,7 @@ _rg() {
     $no"--no-max-columns-preview[don't show preview for long lines (with -M)]"
 
     + '(max-depth)' # Directory-depth options
-    '--max-depth=[specify max number of directories to descend]:number of directories'
+    '(-d --max-depth)'{-d+,--max-depth=}'=[specify max number of directories to descend]:number of directories'
     '!--maxdepth=:number of directories'
 
     + '(messages)' # Error-message options

--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -1934,6 +1934,7 @@ descended into. 'rg --max-depth 1 dir/' will search only the direct children of
 "
     );
     let arg = RGArg::flag("max-depth", "NUM")
+        .short("d")
         .help(SHORT)
         .long_help(LONG)
         .alias("maxdepth")


### PR DESCRIPTION
I've given a go to #2643, partly just as an experiment into how easy it would be - the answer was pretty easy with the tools available.

I've not:
* Updated much documentation. The help is generated automatically, and I followed the model of `--max-count / -m` while making this change, where it's exclusively referred to by the long name
* Added or updated any tests - I couldn't see that the `--max-depth` functionality is tested anywhere, so I didn't see anywhere to add or tweak for the short form. I can add some if you would like

I have given my best go at updating the zsh completions, but I'd be lying if I said I understood exactly how it worked. I've followed the example of `--max-count` and `--max-columns`, but I'd appreciate your eye to make sure it's been implemented correctly.

I've also tested locally, and it seems to work the same as `--max-depth` does:

```
$./target/debug/rg.exe glue --max-depth 4
$./target/debug/rg.exe glue -d 4
$./target/debug/rg.exe glue -d4
$./target/debug/rg.exe glue -d=4
$./target/debug/rg.exe glue --max-depth 5
crates\searcher\src\searcher\mod.rs
20:    searcher::glue::{MultiLine, ReadByLine, SliceByLine},
27:mod glue;
$./target/debug/rg.exe glue -d 5
crates\searcher\src\searcher\mod.rs
20:    searcher::glue::{MultiLine, ReadByLine, SliceByLine},
27:mod glue;
$./target/debug/rg.exe glue -d5
crates\searcher\src\searcher\mod.rs
20:    searcher::glue::{MultiLine, ReadByLine, SliceByLine},
27:mod glue;
$./target/debug/rg.exe glue -d=5
crates\searcher\src\searcher\mod.rs
20:    searcher::glue::{MultiLine, ReadByLine, SliceByLine},
27:mod glue;
```

If you agree with the premise of the change, let me know if there is anything I should update or check for.

Thanks!