### PR TITLE
rollup PR queue + drop asciidoc/asciidoctor + drop serde_derive + drop base64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,11 +101,6 @@ jobs:
       run: |
         ci/ubuntu-install-packages
 
-    - name: Install packages (macOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        ci/macos-install-packages
-
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,7 @@ jobs:
         echo "BIN=$bin" >> $GITHUB_ENV
 
     - name: Strip release binary (macos)
-      if: matrix.os == 'macos'
+      if: matrix.os == 'macos-latest'
       shell: bash
       run: strip "$BIN"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,12 +115,6 @@ jobs:
       run: |
         ci/ubuntu-install-packages
 
-    - name: Install packages (macOS)
-      if: matrix.os == 'macos-latest'
-      shell: bash
-      run: |
-        ci/macos-install-packages
-
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Unreleased changes. Release notes have not yet been written.
   `rg -B1 -A2`. That is, `-A` and `-B` no longer completely override `-C`.
   Instead, they only partially override `-C`.
 
+Build process changes:
+
+* ripgrep's shell completions and man page are now created by running ripgrep
+with a new `--generate` flag. For example, `rg --generate man` will write a
+man page in `roff` format on stdout. The release archives have not changed.
+* The optional build dependency on `asciidoc` or `asciidoctor` has been
+dropped. Previously, it was used to produce ripgrep's man page. ripgrep now
+owns this process itself by writing `roff` directly.
+
 Performance improvements:
 
 * [PERF #1760](https://github.com/BurntSushi/ripgrep/issues/1760):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Performance improvements:
   Make most searches with `\b` look-arounds (among others) much faster.
 * [PERF #2591](https://github.com/BurntSushi/ripgrep/pull/2591):
   Parallel directory traversal now uses work stealing for faster searches.
+* [PERF #2642](https://github.com/BurntSushi/ripgrep/pull/2642):
+  Parallel directory traversal has some contention reduced.
 
 Feature enhancements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Feature enhancements:
   When `extra-verbose` mode is enabled in zsh, show extra file type info.
 * [FEATURE #2409](https://github.com/BurntSushi/ripgrep/pull/2409):
   Added installation instructions for `winget`.
+* [FEATURE #2643](https://github.com/BurntSushi/ripgrep/issues/2643):
+  Make `-d` a short flag for `--max-depth`.
 
 Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Bug fixes:
   Fix gitignore parsing bug where a trailing `\/` resulted in an error.
 * [BUG #2243](https://github.com/BurntSushi/ripgrep/issues/2243):
   Fix `--sort` flag for values other than `path`.
+* [BUG #2381](https://github.com/BurntSushi/ripgrep/issues/2381):
+  Make `-p/--pretty` override flags like `--no-line-number`.
 * [BUG #2392](https://github.com/BurntSushi/ripgrep/issues/2392):
   Improve global git config parsing of the `excludesFile` field.
 * [BUG #2480](https://github.com/BurntSushi/ripgrep/issues/2480):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ Bug fixes:
   Fix bug in `-w/--word-regexp` that would result in incorrect match offsets.
 * [BUG #2623](https://github.com/BurntSushi/ripgrep/issues/2623):
   Fix a number of bugs with the `-w/--word-regexp` flag.
+* [BUG #2636](https://github.com/BurntSushi/ripgrep/pull/2636):
+  Strip release binaries for macOS.
 
 
 13.0.0 (2021-06-12)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,6 @@ dependencies = [
  "grep-searcher",
  "log",
  "serde",
- "serde_derive",
  "serde_json",
  "termcolor",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,12 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
-
-[[package]]
 name = "bstr"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,7 +179,6 @@ dependencies = [
 name = "grep-printer"
 version = "0.1.7"
 dependencies = [
- "base64",
  "bstr",
  "grep-matcher",
  "grep-regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "grep-searcher",
  "log",
  "serde",
+ "serde_derive",
  "serde_json",
  "termcolor",
 ]
@@ -458,18 +459,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/FAQ.md
+++ b/FAQ.md
@@ -61,18 +61,24 @@ patch release out with a fix. However, no promises are made.
 Does ripgrep have a man page?
 </h3>
 
-Yes! Whenever ripgrep is compiled on a system with `asciidoctor` or `asciidoc`
-present, then a man page is generated from ripgrep's argv parser. After
-compiling ripgrep, you can find the man page like so from the root of the
-repository:
+Yes. If you installed ripgrep through a package manager on a Unix system, then
+it would have ideally been installed for you in the proper location. In which
+case, `man rg` should just work.
+
+Otherwise, you can ask ripgrep to generate the man page:
 
 ```
-$ find ./target -name rg.1 -print0 | xargs -0 ls -t | head -n1
-./target/debug/build/ripgrep-79899d0edd4129ca/out/rg.1
+$ mkdir -p man/man1
+$ rg --generate man > man/man1/rg.1
+$ MANPATH="$PWD/man" man rg
 ```
 
-Running `man -l ./target/debug/build/ripgrep-79899d0edd4129ca/out/rg.1` will
-show the man page in your normal pager.
+Or, if your version of `man` supports the `-l/--local-file` flag, then this
+will suffice:
+
+```
+$ rg --generate man | man -l -
+```
 
 Note that the man page's documentation for options is equivalent to the output
 shown in `rg --help`. To see more condensed documentation (one line per flag),

--- a/ci/build-and-publish-deb
+++ b/ci/build-and-publish-deb
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-set -e
-D="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-
 # This script builds a binary dpkg for Debian based distros. It does not
 # currently run in CI, and is instead run manually and the resulting dpkg is
 # uploaded to GitHub at the end of this script.
@@ -11,6 +8,12 @@ D="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # 'cargo install cargo-deb'.
 #
 # This should be run from the root of the ripgrep repo.
+#
+# TODO: It looks like this script could be pretty easily ported into GitHub
+# Actions?
+
+set -e
+D="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 if ! command -V cargo-deb > /dev/null 2>&1; then
   echo "cargo-deb command missing" >&2

--- a/ci/build-and-publish-m2
+++ b/ci/build-and-publish-m2
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# This script builds a ripgrep release for the aarch64-apple-darwin target.
+# At time of writing (2023-11-21), GitHub Actions does not free Apple silicon
+# runners. Since I have somewhat recently acquired an M2 mac mini, I just use
+# this script to build the release tarball and upload it with `gh`.
+#
+# Once GitHub Actions has proper support for Apple silicon, we should add it
+# to our release workflow and drop this script.
+
 set -e
 
 version="$1"
@@ -13,13 +21,14 @@ if ! grep -q "version = \"$version\"" Cargo.toml; then
   exit 1
 fi
 
-cargo build --release --features pcre2
-BIN=target/release/rg
-NAME=ripgrep-$version-aarch64-apple-darwin
+target=aarch64-apple-darwin
+cargo build --release --features pcre2 --target $target
+BIN=target/$target/release/rg
+NAME=ripgrep-$version-$target
 ARCHIVE="deployment/m2/$NAME"
 
 mkdir -p "$ARCHIVE"/{complete,doc}
-cp target/release/rg "$ARCHIVE"/
+cp "$BIN" "$ARCHIVE"/
 strip "$ARCHIVE/rg"
 cp {README.md,COPYING,UNLICENSE,LICENSE-MIT} "$ARCHIVE"/
 cp {CHANGELOG.md,FAQ.md,GUIDE.md} "$ARCHIVE"/doc/

--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -2,9 +2,8 @@ These are Docker images used for cross compilation in CI builds (or locally)
 via the [Cross](https://github.com/rust-embedded/cross) tool.
 
 The Cross tool actually provides its own Docker images, and all Docker images
-in this directory are derived from one of them. We provide our own in order
-to customize the environment. For example, we need to install some things like
-`asciidoctor` in order to generate man pages. We also install compression tools
+in this directory are derived from one of them. We provide our own in order to
+customize the environment. For example, we need to install compression tools
 like `xz` so that tests for the `-z/--search-zip` flag are run.
 
 If you make a change to a Docker image, then you can re-build it. `cd` into the

--- a/ci/macos-install-packages
+++ b/ci/macos-install-packages
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-brew install asciidoctor

--- a/ci/ubuntu-install-packages
+++ b/ci/ubuntu-install-packages
@@ -11,6 +11,4 @@ if ! command -V sudo; then
 fi
 sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
-  asciidoctor \
-  zsh xz-utils liblz4-tool musl-tools \
-  brotli zstd
+  zsh xz-utils liblz4-tool musl-tools brotli zstd

--- a/crates/core/flags/complete/rg.zsh
+++ b/crates/core/flags/complete/rg.zsh
@@ -192,7 +192,7 @@ _rg() {
     $no"--no-max-columns-preview[don't show preview for long lines (with -M)]"
 
     + '(max-depth)' # Directory-depth options
-    '--max-depth=[specify max number of directories to descend]:number of directories'
+    {-d,--max-depth}'[specify max number of directories to descend]:number of directories'
     '--maxdepth=[alias for --max-depth]:number of directories'
     '!--maxdepth=:number of directories'
 

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -3829,6 +3829,9 @@ impl Flag for MaxDepth {
     fn is_switch(&self) -> bool {
         false
     }
+    fn name_short(&self) -> Option<u8> {
+        Some(b'd')
+    }
     fn name_long(&self) -> &'static str {
         "max-depth"
     }
@@ -3871,6 +3874,9 @@ fn test_max_depth() {
     assert_eq!(None, args.max_depth);
 
     let args = parse_low_raw(["--max-depth", "5"]).unwrap();
+    assert_eq!(Some(5), args.max_depth);
+
+    let args = parse_low_raw(["-d", "5"]).unwrap();
     assert_eq!(Some(5), args.max_depth);
 
     let args = parse_low_raw(["--max-depth", "5", "--max-depth=10"]).unwrap();

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -1279,7 +1279,7 @@ impl WalkParallel {
         }
         // Create the workers and then wait for them to finish.
         let quit_now = Arc::new(AtomicBool::new(false));
-        let num_pending = Arc::new(AtomicUsize::new(stack.len()));
+        let active_workers = Arc::new(AtomicUsize::new(threads));
         let stacks = Stack::new_for_each_thread(threads, stack);
         std::thread::scope(|s| {
             let handles: Vec<_> = stacks
@@ -1288,7 +1288,7 @@ impl WalkParallel {
                     visitor: builder.build(),
                     stack,
                     quit_now: quit_now.clone(),
-                    num_pending: num_pending.clone(),
+                    active_workers: active_workers.clone(),
                     max_depth: self.max_depth,
                     max_filesize: self.max_filesize,
                     follow_links: self.follow_links,
@@ -1471,8 +1471,8 @@ struct Worker<'s> {
     /// that we need this because we don't want other `Work` to be done after
     /// we quit. We wouldn't need this if have a priority channel.
     quit_now: Arc<AtomicBool>,
-    /// The number of outstanding work items.
-    num_pending: Arc<AtomicUsize>,
+    /// The number of currently active workers.
+    active_workers: Arc<AtomicUsize>,
     /// The maximum depth of directories to descend. A value of `0` means no
     /// descension at all.
     max_depth: Option<usize>,
@@ -1500,7 +1500,6 @@ impl<'s> Worker<'s> {
             if let WalkState::Quit = self.run_one(work) {
                 self.quit_now();
             }
-            self.work_done();
         }
     }
 
@@ -1682,23 +1681,20 @@ impl<'s> Worker<'s> {
                     return None;
                 }
                 None => {
-                    // Once num_pending reaches 0, it is impossible for it to
-                    // ever increase again. Namely, it only reaches 0 once
-                    // all jobs have run such that no jobs have produced more
-                    // work. We have this guarantee because num_pending is
-                    // always incremented before each job is submitted and only
-                    // decremented once each job is completely finished.
-                    // Therefore, if this reaches zero, then there can be no
-                    // other job running.
-                    if self.num_pending() == 0 {
-                        // Every other thread is blocked at the next recv().
-                        // Send the initial quit message and quit.
+                    if self.deactivate_worker() == 0 {
+                        // If deactivate_worker() returns 0, every worker thread
+                        // is currently within the critical section between the
+                        // acquire in deactivate_worker() and the release in
+                        // activate_worker() below.  For this to happen, every
+                        // worker's local deque must be simultaneously empty,
+                        // meaning there is no more work left at all.
                         self.send_quit();
                         return None;
                     }
                     // Wait for next `Work` or `Quit` message.
                     loop {
                         if let Some(v) = self.recv() {
+                            self.activate_worker();
                             value = Some(v);
                             break;
                         }
@@ -1724,14 +1720,8 @@ impl<'s> Worker<'s> {
         self.quit_now.load(AtomicOrdering::SeqCst)
     }
 
-    /// Returns the number of pending jobs.
-    fn num_pending(&self) -> usize {
-        self.num_pending.load(AtomicOrdering::SeqCst)
-    }
-
     /// Send work.
     fn send(&self, work: Work) {
-        self.num_pending.fetch_add(1, AtomicOrdering::SeqCst);
         self.stack.push(Message::Work(work));
     }
 
@@ -1745,9 +1735,14 @@ impl<'s> Worker<'s> {
         self.stack.pop()
     }
 
-    /// Signal that work has been finished.
-    fn work_done(&self) {
-        self.num_pending.fetch_sub(1, AtomicOrdering::SeqCst);
+    /// Deactivates a worker and returns the number of currently active workers.
+    fn deactivate_worker(&self) -> usize {
+        self.active_workers.fetch_sub(1, AtomicOrdering::Acquire) - 1
+    }
+
+    /// Reactivates a worker.
+    fn activate_worker(&self) {
+        self.active_workers.fetch_add(1, AtomicOrdering::Release);
     }
 }
 

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 
 [features]
 default = ["serde"]
-serde = ["dep:base64", "dep:serde", "dep:serde_derive", "dep:serde_json"]
+serde = ["dep:base64", "dep:serde", "dep:serde_json"]
 
 [dependencies]
 base64 = { version = "0.21.4", optional = true }
@@ -26,7 +26,6 @@ grep-searcher = { version = "0.1.11", path = "../searcher" }
 log = "0.4.5"
 termcolor = "1.3.0"
 serde = { version = "1.0.193", optional = true }
-serde_derive = { version = "1.0.193", optional = true }
 serde_json = { version = "1.0.107", optional = true }
 
 [dev-dependencies]

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -16,10 +16,9 @@ edition = "2021"
 
 [features]
 default = ["serde"]
-serde = ["dep:base64", "dep:serde", "dep:serde_json"]
+serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
-base64 = { version = "0.21.4", optional = true }
 bstr = "1.6.2"
 grep-matcher = { version = "0.1.6", path = "../matcher" }
 grep-searcher = { version = "0.1.11", path = "../searcher" }

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 
 [features]
 default = ["serde"]
-serde = ["dep:base64", "dep:serde", "dep:serde_json"]
+serde = ["dep:base64", "dep:serde", "dep:serde_derive", "dep:serde_json"]
 
 [dependencies]
 base64 = { version = "0.21.4", optional = true }
@@ -25,7 +25,8 @@ grep-matcher = { version = "0.1.6", path = "../matcher" }
 grep-searcher = { version = "0.1.11", path = "../searcher" }
 log = "0.4.5"
 termcolor = "1.3.0"
-serde = { version = "1.0.188", optional = true, features = ["derive"] }
+serde = { version = "1.0.193", optional = true }
+serde_derive = { version = "1.0.193", optional = true }
 serde_json = { version = "1.0.107", optional = true }
 
 [dev-dependencies]

--- a/crates/printer/src/jsont.rs
+++ b/crates/printer/src/jsont.rs
@@ -8,10 +8,7 @@
 
 use std::{borrow::Cow, path::Path};
 
-use {
-    base64,
-    serde::{Serialize, Serializer},
-};
+use {base64, serde::Serializer, serde_derive::Serialize};
 
 use crate::stats::Stats;
 
@@ -132,6 +129,7 @@ where
     T: AsRef<[u8]>,
     S: Serializer,
 {
+    use serde::Serialize;
     Data::from_bytes(bytes.as_ref()).serialize(ser)
 }
 
@@ -140,5 +138,6 @@ where
     P: AsRef<Path>,
     S: Serializer,
 {
+    use serde::Serialize;
     path.as_ref().map(|p| Data::from_path(p.as_ref())).serialize(ser)
 }

--- a/crates/printer/src/jsont.rs
+++ b/crates/printer/src/jsont.rs
@@ -8,13 +8,6 @@
 
 use std::{borrow::Cow, path::Path};
 
-use {base64, serde::Serializer, serde_derive::Serialize};
-
-use crate::stats::Stats;
-
-#[derive(Serialize)]
-#[serde(tag = "type", content = "data")]
-#[serde(rename_all = "snake_case")]
 pub(crate) enum Message<'a> {
     Begin(Begin<'a>),
     End(End<'a>),
@@ -22,49 +15,143 @@ pub(crate) enum Message<'a> {
     Context(Context<'a>),
 }
 
-#[derive(Serialize)]
+impl<'a> serde::Serialize for Message<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct("Message", 2)?;
+        match *self {
+            Message::Begin(ref msg) => {
+                state.serialize_field("type", &"begin")?;
+                state.serialize_field("data", msg)?;
+            }
+            Message::End(ref msg) => {
+                state.serialize_field("type", &"end")?;
+                state.serialize_field("data", msg)?;
+            }
+            Message::Match(ref msg) => {
+                state.serialize_field("type", &"match")?;
+                state.serialize_field("data", msg)?;
+            }
+            Message::Context(ref msg) => {
+                state.serialize_field("type", &"context")?;
+                state.serialize_field("data", msg)?;
+            }
+        }
+        state.end()
+    }
+}
+
 pub(crate) struct Begin<'a> {
-    #[serde(serialize_with = "ser_path")]
     pub(crate) path: Option<&'a Path>,
 }
 
-#[derive(Serialize)]
+impl<'a> serde::Serialize for Begin<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct("Begin", 1)?;
+        state.serialize_field("path", &self.path.map(Data::from_path))?;
+        state.end()
+    }
+}
+
 pub(crate) struct End<'a> {
-    #[serde(serialize_with = "ser_path")]
     pub(crate) path: Option<&'a Path>,
     pub(crate) binary_offset: Option<u64>,
-    pub(crate) stats: Stats,
+    pub(crate) stats: crate::stats::Stats,
 }
 
-#[derive(Serialize)]
+impl<'a> serde::Serialize for End<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct("End", 3)?;
+        state.serialize_field("path", &self.path.map(Data::from_path))?;
+        state.serialize_field("binary_offset", &self.binary_offset)?;
+        state.serialize_field("stats", &self.stats)?;
+        state.end()
+    }
+}
+
 pub(crate) struct Match<'a> {
-    #[serde(serialize_with = "ser_path")]
     pub(crate) path: Option<&'a Path>,
-    #[serde(serialize_with = "ser_bytes")]
     pub(crate) lines: &'a [u8],
     pub(crate) line_number: Option<u64>,
     pub(crate) absolute_offset: u64,
     pub(crate) submatches: &'a [SubMatch<'a>],
 }
 
-#[derive(Serialize)]
+impl<'a> serde::Serialize for Match<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct("Match", 5)?;
+        state.serialize_field("path", &self.path.map(Data::from_path))?;
+        state.serialize_field("lines", &Data::from_bytes(self.lines))?;
+        state.serialize_field("line_number", &self.line_number)?;
+        state.serialize_field("absolute_offset", &self.absolute_offset)?;
+        state.serialize_field("submatches", &self.submatches)?;
+        state.end()
+    }
+}
+
 pub(crate) struct Context<'a> {
-    #[serde(serialize_with = "ser_path")]
     pub(crate) path: Option<&'a Path>,
-    #[serde(serialize_with = "ser_bytes")]
     pub(crate) lines: &'a [u8],
     pub(crate) line_number: Option<u64>,
     pub(crate) absolute_offset: u64,
     pub(crate) submatches: &'a [SubMatch<'a>],
 }
 
-#[derive(Serialize)]
+impl<'a> serde::Serialize for Context<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct("Context", 5)?;
+        state.serialize_field("path", &self.path.map(Data::from_path))?;
+        state.serialize_field("lines", &Data::from_bytes(self.lines))?;
+        state.serialize_field("line_number", &self.line_number)?;
+        state.serialize_field("absolute_offset", &self.absolute_offset)?;
+        state.serialize_field("submatches", &self.submatches)?;
+        state.end()
+    }
+}
+
 pub(crate) struct SubMatch<'a> {
-    #[serde(rename = "match")]
-    #[serde(serialize_with = "ser_bytes")]
     pub(crate) m: &'a [u8],
     pub(crate) start: usize,
     pub(crate) end: usize,
+}
+
+impl<'a> serde::Serialize for SubMatch<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct("SubMatch", 3)?;
+        state.serialize_field("match", &Data::from_bytes(self.m))?;
+        state.serialize_field("start", &self.start)?;
+        state.serialize_field("end", &self.end)?;
+        state.end()
+    }
 }
 
 /// Data represents things that look like strings, but may actually not be
@@ -74,16 +161,10 @@ pub(crate) struct SubMatch<'a> {
 /// The happy path is valid UTF-8, which streams right through as-is, since
 /// it is natively supported by JSON. When invalid UTF-8 is found, then it is
 /// represented as arbitrary bytes and base64 encoded.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize)]
-#[serde(untagged)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 enum Data<'a> {
-    Text {
-        text: Cow<'a, str>,
-    },
-    Bytes {
-        #[serde(serialize_with = "to_base64")]
-        bytes: &'a [u8],
-    },
+    Text { text: Cow<'a, str> },
+    Bytes { bytes: &'a [u8] },
 }
 
 impl<'a> Data<'a> {
@@ -115,29 +196,22 @@ impl<'a> Data<'a> {
     }
 }
 
-fn to_base64<T, S>(bytes: T, ser: S) -> Result<S::Ok, S::Error>
-where
-    T: AsRef<[u8]>,
-    S: Serializer,
-{
-    use base64::engine::{general_purpose::STANDARD, Engine};
-    ser.serialize_str(&STANDARD.encode(&bytes))
-}
+impl<'a> serde::Serialize for Data<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
 
-fn ser_bytes<T, S>(bytes: T, ser: S) -> Result<S::Ok, S::Error>
-where
-    T: AsRef<[u8]>,
-    S: Serializer,
-{
-    use serde::Serialize;
-    Data::from_bytes(bytes.as_ref()).serialize(ser)
-}
-
-fn ser_path<P, S>(path: &Option<P>, ser: S) -> Result<S::Ok, S::Error>
-where
-    P: AsRef<Path>,
-    S: Serializer,
-{
-    use serde::Serialize;
-    path.as_ref().map(|p| Data::from_path(p.as_ref())).serialize(ser)
+        let mut state = s.serialize_struct("Data", 1)?;
+        match *self {
+            Data::Text { ref text } => state.serialize_field("text", text)?,
+            Data::Bytes { bytes } => {
+                use base64::engine::{general_purpose::STANDARD, Engine};
+                let encoded = STANDARD.encode(bytes);
+                state.serialize_field("bytes", &encoded)?;
+            }
+        }
+        state.end()
+    }
 }

--- a/crates/printer/src/stats.rs
+++ b/crates/printer/src/stats.rs
@@ -10,7 +10,7 @@ use crate::util::NiceDuration;
 /// When statistics are reported by a printer, they correspond to all searches
 /// executed with that printer.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde_derive::Serialize))]
 pub struct Stats {
     elapsed: NiceDuration,
     searches: u64,

--- a/crates/printer/src/stats.rs
+++ b/crates/printer/src/stats.rs
@@ -10,7 +10,6 @@ use crate::util::NiceDuration;
 /// When statistics are reported by a printer, they correspond to all searches
 /// executed with that printer.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde_derive::Serialize))]
 pub struct Stats {
     elapsed: NiceDuration,
     searches: u64,
@@ -19,49 +18,6 @@ pub struct Stats {
     bytes_printed: u64,
     matched_lines: u64,
     matches: u64,
-}
-
-impl Add for Stats {
-    type Output = Stats;
-
-    fn add(self, rhs: Stats) -> Stats {
-        self + &rhs
-    }
-}
-
-impl<'a> Add<&'a Stats> for Stats {
-    type Output = Stats;
-
-    fn add(self, rhs: &'a Stats) -> Stats {
-        Stats {
-            elapsed: NiceDuration(self.elapsed.0 + rhs.elapsed.0),
-            searches: self.searches + rhs.searches,
-            searches_with_match: self.searches_with_match
-                + rhs.searches_with_match,
-            bytes_searched: self.bytes_searched + rhs.bytes_searched,
-            bytes_printed: self.bytes_printed + rhs.bytes_printed,
-            matched_lines: self.matched_lines + rhs.matched_lines,
-            matches: self.matches + rhs.matches,
-        }
-    }
-}
-
-impl AddAssign for Stats {
-    fn add_assign(&mut self, rhs: Stats) {
-        *self += &rhs;
-    }
-}
-
-impl<'a> AddAssign<&'a Stats> for Stats {
-    fn add_assign(&mut self, rhs: &'a Stats) {
-        self.elapsed.0 += rhs.elapsed.0;
-        self.searches += rhs.searches;
-        self.searches_with_match += rhs.searches_with_match;
-        self.bytes_searched += rhs.bytes_searched;
-        self.bytes_printed += rhs.bytes_printed;
-        self.matched_lines += rhs.matched_lines;
-        self.matches += rhs.matches;
-    }
 }
 
 impl Stats {
@@ -145,5 +101,71 @@ impl Stats {
     /// Add to the total number of matches.
     pub fn add_matches(&mut self, n: u64) {
         self.matches += n;
+    }
+}
+
+impl Add for Stats {
+    type Output = Stats;
+
+    fn add(self, rhs: Stats) -> Stats {
+        self + &rhs
+    }
+}
+
+impl<'a> Add<&'a Stats> for Stats {
+    type Output = Stats;
+
+    fn add(self, rhs: &'a Stats) -> Stats {
+        Stats {
+            elapsed: NiceDuration(self.elapsed.0 + rhs.elapsed.0),
+            searches: self.searches + rhs.searches,
+            searches_with_match: self.searches_with_match
+                + rhs.searches_with_match,
+            bytes_searched: self.bytes_searched + rhs.bytes_searched,
+            bytes_printed: self.bytes_printed + rhs.bytes_printed,
+            matched_lines: self.matched_lines + rhs.matched_lines,
+            matches: self.matches + rhs.matches,
+        }
+    }
+}
+
+impl AddAssign for Stats {
+    fn add_assign(&mut self, rhs: Stats) {
+        *self += &rhs;
+    }
+}
+
+impl<'a> AddAssign<&'a Stats> for Stats {
+    fn add_assign(&mut self, rhs: &'a Stats) {
+        self.elapsed.0 += rhs.elapsed.0;
+        self.searches += rhs.searches;
+        self.searches_with_match += rhs.searches_with_match;
+        self.bytes_searched += rhs.bytes_searched;
+        self.bytes_printed += rhs.bytes_printed;
+        self.matched_lines += rhs.matched_lines;
+        self.matches += rhs.matches;
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Stats {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct("Stats", 7)?;
+        state.serialize_field("elapsed", &self.elapsed)?;
+        state.serialize_field("searches", &self.searches)?;
+        state.serialize_field(
+            "searches_with_match",
+            &self.searches_with_match,
+        )?;
+        state.serialize_field("bytes_searched", &self.bytes_searched)?;
+        state.serialize_field("bytes_printed", &self.bytes_printed)?;
+        state.serialize_field("matched_lines", &self.matched_lines)?;
+        state.serialize_field("matches", &self.matches)?;
+        state.end()
     }
 }

--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -8,9 +8,6 @@ use {
     },
 };
 
-#[cfg(feature = "serde")]
-use serde::{Serialize, Serializer};
-
 use crate::{hyperlink::HyperlinkPath, MAX_LOOK_AHEAD};
 
 /// A type for handling replacements while amortizing allocation.
@@ -385,11 +382,14 @@ impl NiceDuration {
 }
 
 #[cfg(feature = "serde")]
-impl Serialize for NiceDuration {
-    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+impl serde::Serialize for NiceDuration {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        ser: S,
+    ) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;
 
-        let mut state = ser.serialize_struct("Duration", 2)?;
+        let mut state = ser.serialize_struct("Duration", 3)?;
         state.serialize_field("secs", &self.0.as_secs())?;
         state.serialize_field("nanos", &self.0.subsec_nanos())?;
         state.serialize_field("human", &format!("{}", self))?;


### PR DESCRIPTION
Most of this PR is focused on dropping dependencies that are probably not carrying their weight. This gets us back down to the size of the dependency tree in `ripgrep 0.3.2`, but the compile times are still a couple seconds slower for a clean release build (without PCRE2).

At this point, `cargo build --release --timings` on a clean build suggests that the biggest contributor to compile time is `regex-automata`. That's no surprise.