### PR TITLE
Fix fish completion syntax for negated options

### DIFF
--- a/crates/core/flags/complete/fish.rs
+++ b/crates/core/flags/complete/fish.rs
@@ -35,10 +35,11 @@ pub(crate) fn generate() -> String {
                 .replace("!DOC!", &doc),
         );
         if let Some(negated) = flag.name_negated() {
+            let long = format!("-l '{}'", negated.replace("'", "\\'"));
             out.push_str(
                 &template
                     .replace("!SHORT!", "")
-                    .replace("!LONG!", &negated)
+                    .replace("!LONG!", &long)
                     .replace("!DOC!", &doc),
             );
         }

--- a/crates/core/flags/complete/fish.rs
+++ b/crates/core/flags/complete/fish.rs
@@ -37,7 +37,7 @@ pub(crate) fn generate() -> String {
         if let Some(negated) = flag.name_negated() {
             let long = format!("-l '{}'", negated.replace("'", "\\'"));
             out.push_str(
-                &template
+                &TEMPLATE
                     .replace("!SHORT!", "")
                     .replace("!LONG!", &long)
                     .replace("!DOC!", &doc),


### PR DESCRIPTION
The fish completion generator currently forgets to add `-l` to negation options, leading to a list of these errors:
```
complete: too many arguments

~/.config/fish/completions/rg.fish (line 146):
complete -c rg -n '__fish_use_subcommand'  no-sort-files -d '(DEPRECATED) Sort results by file path.'
^
from sourcing file ~/.config/fish/completions/rg.fish

(Type 'help complete' for related documentation)
```
(To reproduce: `fish -c 'rg --generate=complete-fish | source'`)

It also potentially suggests a list of choices for negation options, even though those never take arguments. That case doesn't occur with any of the current options but it's an easy fix.

Fixes #2659.