### PR TITLE
ignore: meson: add meson.options

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -172,7 +172,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         "*.mdx",
     ]),
     (&["matlab"], &["*.m"]),
-    (&["meson"], &["meson.build", "meson_options.txt"]),
+    (&["meson"], &["meson.build", "meson_options.txt", "meson.options"]),
     (&["minified"], &["*.min.html", "*.min.css", "*.min.js"]),
     (&["mint"], &["*.mint"]),
     (&["mk"], &["mkfile"]),


### PR DESCRIPTION
Starting with meson 1.1, there is a preference for using meson.options
instead of meson_options.txt.  Add the new filename to the meson set.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
