### PR TITLE
Fix Guix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ If you're a **Guix** user, you can install ripgrep from the official
 package collection:
 
 ```
-$ sudo guix install ripgrep
+$ guix install ripgrep
 ```
 
 If you're a **Debian** user (or a user of a Debian derivative like **Ubuntu**),


### PR DESCRIPTION
`guix install` should not be run using `sudo`, as per <https://packages.guix.gnu.org/packages/ripgrep/>.

Guix is more like Nix in that users install packages without root privileges.