### PR TITLE
ignore crate: Fix reference cycle for compiled matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 ============
 This is a minor release with a few small new features and bug fixes.
 
+Bug fixes:
+
+* [BUG #2664](https://github.com/BurntSushi/ripgrep/issues/2690):
+  Fix unbounded memory growth in the `ignore` crate.
+
 Feature enhancements:
 
 * [FEATURE #2684](https://github.com/BurntSushi/ripgrep/issues/2684):


### PR DESCRIPTION
This attempts to fix the issue around unbounded memory growth in the ignore crate when ignore flags are enabled, see https://github.com/BurntSushi/ripgrep/issues/2690

I don't have full understanding of the ignore crate codebase but it looks like there is a reference cycle caused by the compiled matchers (compiled HashMap holds ref to Ignore and Ignore holds ref to HashMap). Using weak refs fixes issue #2690 in my test project. Also confirmed via before and after when profiling the code, see the attached screenshots.

![CleanShot 2023-12-20 at 16 30 56@2x](https://github.com/BurntSushi/ripgrep/assets/213498/05e3bb27-7670-483a-ac34-32f38b00c7e7)
![CleanShot 2023-12-20 at 16 26 02@2x](https://github.com/BurntSushi/ripgrep/assets/213498/50928023-7d9c-4a83-8d27-7f26cfd8c939)
