### PR TITLE
Fine-tune the Ordering for the atomic usages

### DIFF
--- a/crates/core/messages.rs
+++ b/crates/core/messages.rs
@@ -99,19 +99,19 @@ macro_rules! ignore_message {
 
 /// Returns true if and only if messages should be shown.
 pub(crate) fn messages() -> bool {
-    MESSAGES.load(Ordering::SeqCst)
+    MESSAGES.load(Ordering::Relaxed)
 }
 
 /// Set whether messages should be shown or not.
 ///
 /// By default, they are not shown.
 pub(crate) fn set_messages(yes: bool) {
-    MESSAGES.store(yes, Ordering::SeqCst)
+    MESSAGES.store(yes, Ordering::Relaxed)
 }
 
 /// Returns true if and only if "ignore" related messages should be shown.
 pub(crate) fn ignore_messages() -> bool {
-    IGNORE_MESSAGES.load(Ordering::SeqCst)
+    IGNORE_MESSAGES.load(Ordering::Relaxed)
 }
 
 /// Set whether "ignore" related messages should be shown or not.
@@ -122,12 +122,12 @@ pub(crate) fn ignore_messages() -> bool {
 /// `messages` is disabled, then "ignore" messages are never shown, regardless
 /// of this setting.
 pub(crate) fn set_ignore_messages(yes: bool) {
-    IGNORE_MESSAGES.store(yes, Ordering::SeqCst)
+    IGNORE_MESSAGES.store(yes, Ordering::Relaxed)
 }
 
 /// Returns true if and only if ripgrep came across a non-fatal error.
 pub(crate) fn errored() -> bool {
-    ERRORED.load(Ordering::SeqCst)
+    ERRORED.load(Ordering::Relaxed)
 }
 
 /// Indicate that ripgrep has come across a non-fatal error.
@@ -135,5 +135,5 @@ pub(crate) fn errored() -> bool {
 /// Callers should not use this directly. Instead, it is called automatically
 /// via the `err_message` macro.
 pub(crate) fn set_errored() {
-    ERRORED.store(true, Ordering::SeqCst);
+    ERRORED.store(true, Ordering::Relaxed);
 }

--- a/crates/ignore/src/lib.rs
+++ b/crates/ignore/src/lib.rs
@@ -527,7 +527,7 @@ mod tests {
 
             let tmpdir = env::temp_dir();
             for _ in 0..TRIES {
-                let count = COUNTER.fetch_add(1, Ordering::SeqCst);
+                let count = COUNTER.fetch_add(1, Ordering::Relaxed);
                 let path = tmpdir.join("rust-ignore").join(count.to_string());
                 if path.is_dir() {
                     continue;

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -1712,12 +1712,12 @@ impl<'s> Worker<'s> {
 
     /// Indicates that all workers should quit immediately.
     fn quit_now(&self) {
-        self.quit_now.store(true, AtomicOrdering::SeqCst);
+        self.quit_now.store(true, AtomicOrdering::Release);
     }
 
     /// Returns true if this worker should quit immediately.
     fn is_quit_now(&self) -> bool {
-        self.quit_now.load(AtomicOrdering::SeqCst)
+        self.quit_now.load(AtomicOrdering::Acquire)
     }
 
     /// Send work.

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -68,7 +68,7 @@ impl Dir {
     /// does not need to be distinct for each invocation, but should correspond
     /// to a logical grouping of tests.
     pub fn new(name: &str) -> Dir {
-        let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
         let root = env::current_exe()
             .unwrap()
             .parent()


### PR DESCRIPTION
`SeqCst` is overly restrictive. I believe that the ordering can be appropriately modified.

In `messages` model, I believe that `MESSAGES`, `IGNORE_MESSAGES`, and `ERRORED` are merely signals for multithreading purposes and do not synchronize with other locals. Therefore, using `Relaxed` ordering should suffice.

In `lib` and `utils` models, `COUNTER` and `NEXT_ID` are used for multithreading counting purposes, so using `Relaxed` ordering is sufficient.

In `walk` model, the `load` and `store` of `quit_now` should use `Acquire`/`Release` to ensure that the `stack` is up-to-date.