### PR TITLE
Fix: strip standalone "." directory path

### DIFF
--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -462,9 +462,13 @@ impl Ignore {
                 // it does fix a nasty bug. It should do fine until we overhaul
                 // this crate.
                 let dirpath = self.0.dir.as_path();
-                let path_prefix = match strip_prefix("./", dirpath) {
-                    None => dirpath,
-                    Some(stripped_dot_slash) => stripped_dot_slash,
+                let path_prefix = if dirpath == Path::new(".") {
+                    Path::new("")
+                } else {
+                    match strip_prefix("./", dirpath) {
+                        None => dirpath,
+                        Some(stripped_dot_slash) => stripped_dot_slash,
+                    }
                 };
                 let path = match strip_prefix(path_prefix, path) {
                     None => abs_parent_path.join(path),


### PR DESCRIPTION
The problem is that in Ignore::matched, the perfix "./" is stripped from files. In Ignore::matched_ignore, the directory path is then stripped from file paths. Now imagine we have a hidden file "./.foo" and pass "." as the search path. "./.foo" gets first stripped to ".foo" and then it would have been stripped to "foo".

I am not completely sure though whether this is the best way to fix it. One could also check earlier whether the directory path is "." and then change it to "./". I don't know which is the best way regarding performance; the current fix is just at the place where it breaks. What do you think?

The implications of this problem (at least the ones I noticed) are that when grepping (including hidden files and passing `.` as search directory) in a subdirectory `a/b` of `a`, and `b` has a hidden file `.foo`, which is ignored in a ignore file in `a`, the contents of `.foo` are shown.
I put in https://github.com/taeruh/debug_file_paths a minimal debugging example to show that.

Issue #829 is similar, but I am not sure about how much it is related.