### PR TITLE
Get help for a single flag

### DIFF
--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -2687,6 +2687,9 @@ long flag, \fB\-\-help\fP, is different. The short flag will show a condensed
 help output while the long flag will show a verbose help output. The verbose
 help output has complete documentation, where as the condensed help output will
 show only a single line for every flag.
+.sp
+This flag may also be used with a single other flag or flag name, and when
+found it will show the verbose help output for that flag only.
 "
     }
 
@@ -2711,11 +2714,23 @@ fn test_help() {
     let args = parse_low_raw(["--help"]).unwrap();
     assert_eq!(Some(SpecialMode::HelpLong), args.special);
 
-    let args = parse_low_raw(["-h", "--help"]).unwrap();
+    let args = parse_low_raw(["-h", "--help", "anything"]).unwrap();
     assert_eq!(Some(SpecialMode::HelpLong), args.special);
 
-    let args = parse_low_raw(["--help", "-h"]).unwrap();
+    let args = parse_low_raw(["--help", "-h", "anything"]).unwrap();
     assert_eq!(Some(SpecialMode::HelpShort), args.special);
+
+    let args = parse_low_raw(["-h", "--help"]).unwrap();
+    assert_eq!(Some(SpecialMode::HelpFlag("help")), args.special);
+
+    let args = parse_low_raw(["--help", "-h"]).unwrap();
+    assert_eq!(Some(SpecialMode::HelpFlag("help")), args.special);
+
+    let args = parse_low_raw(["-h", "--encoding"]).unwrap();
+    assert_eq!(Some(SpecialMode::HelpFlag("encoding")), args.special);
+
+    let args = parse_low_raw(["--no-encoding", "--help"]).unwrap();
+    assert_eq!(Some(SpecialMode::HelpFlag("encoding")), args.special);
 }
 
 /// -./--hidden

--- a/crates/core/flags/doc/help.rs
+++ b/crates/core/flags/doc/help.rs
@@ -12,6 +12,7 @@ use crate::flags::{defs::FLAGS, doc::version, Category, Flag};
 
 const TEMPLATE_SHORT: &'static str = include_str!("template.short.help");
 const TEMPLATE_LONG: &'static str = include_str!("template.long.help");
+const TEMPLATE_FLAG: &'static str = include_str!("template.flag.help");
 
 /// Wraps `std::write!` and asserts there is no failure.
 ///
@@ -115,7 +116,7 @@ pub(crate) fn generate_long() -> String {
         if !cat.is_empty() {
             write!(cat, "\n\n");
         }
-        generate_long_flag(flag, &mut cat);
+        append_long_flag_content(flag, true, &mut cat);
     }
 
     let mut out =
@@ -127,17 +128,37 @@ pub(crate) fn generate_long() -> String {
     out
 }
 
+/// Generate long documentation for a single flag, i.e., for `--help`.
+///
+/// `name` should be the long flag name, without the `--`.
+pub(crate) fn generate_long_flag(name: &str) -> String {
+    let content =
+        if let Some(&flag) = FLAGS.iter().find(|&f| f.name_long() == name) {
+            let mut content = String::new();
+            append_long_flag_content(flag, false, &mut content);
+            content
+        } else {
+            format!("flag not found: --{}", name)
+        };
+
+    TEMPLATE_FLAG
+        .replace("!!VERSION!!", &version::generate_digits())
+        .replace("!!flag!!", &content)
+}
+
 /// Write generated documentation for `flag` to `out`.
-fn generate_long_flag(flag: &dyn Flag, out: &mut String) {
+fn append_long_flag_content(flag: &dyn Flag, indent: bool, out: &mut String) {
+    let indent_str = " ".repeat(if indent { 4 } else { 0 });
     if let Some(byte) = flag.name_short() {
         let name = char::from(byte);
-        write!(out, r"    -{name}");
+        write!(out, r"{}", &indent_str);
+        write!(out, r"-{name}");
         if let Some(var) = flag.doc_variable() {
             write!(out, r" {var}");
         }
         write!(out, r", ");
     } else {
-        write!(out, r"    ");
+        write!(out, r"{}", &indent_str);
     }
 
     let name = flag.name_long();
@@ -183,7 +204,7 @@ fn generate_long_flag(flag: &dyn Flag, out: &mut String) {
             write!(cleaned, "\n\nThis flag can be disabled with --{negated}.");
         }
     }
-    let indent = " ".repeat(8);
+    let indent_str = " ".repeat(if indent { 8 } else { 4 });
     let wrapopts = textwrap::Options::new(71)
         // Normally I'd be fine with breaking at hyphens, but ripgrep's docs
         // includes a lot of flag names, and they in turn contain hyphens.
@@ -197,11 +218,11 @@ fn generate_long_flag(flag: &dyn Flag, out: &mut String) {
         if paragraph.lines().all(|line| line.starts_with("    ")) {
             // Re-indent but don't refill so as to preserve line breaks
             // in code/shell example snippets.
-            new = textwrap::indent(&new, &indent);
+            new = textwrap::indent(&new, &indent_str);
         } else {
             new = new.replace("\n", " ");
             new = textwrap::refill(&new, &wrapopts);
-            new = textwrap::indent(&new, &indent);
+            new = textwrap::indent(&new, &indent_str);
         }
         write!(out, "{}", new.trim_end());
     }

--- a/crates/core/flags/doc/template.flag.help
+++ b/crates/core/flags/doc/template.flag.help
@@ -1,0 +1,4 @@
+ripgrep !!VERSION!!
+Andrew Gallant <jamslam@gmail.com>
+
+!!flag!!

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -127,6 +127,10 @@ pub(crate) enum SpecialMode {
     /// Shows a very verbose version of the "help" output. The docs for some
     /// flags will be paragraphs long. This corresponds to the `--help` flag.
     HelpLong,
+    /// Shows a very verbose version of the "help" output for a single flag.
+    /// This corresponds to the `-h` or `--help` flag with a single other
+    /// argument. The value is the long name of the flag.
+    HelpFlag(&'static str),
     /// Show condensed version information. e.g., `ripgrep x.y.z`.
     VersionShort,
     /// Show verbose version information. Includes "short" information as well

--- a/crates/core/flags/mod.rs
+++ b/crates/core/flags/mod.rs
@@ -25,6 +25,7 @@ pub(crate) use crate::flags::{
     doc::{
         help::{
             generate_long as generate_help_long,
+            generate_long_flag as generate_help_flag,
             generate_short as generate_help_short,
         },
         man::generate as generate_man_page,

--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -387,6 +387,7 @@ fn special(mode: crate::flags::SpecialMode) -> anyhow::Result<ExitCode> {
     let output = match mode {
         SpecialMode::HelpShort => flags::generate_help_short(),
         SpecialMode::HelpLong => flags::generate_help_long(),
+        SpecialMode::HelpFlag(name) => flags::generate_help_flag(name),
         SpecialMode::VersionShort => flags::generate_version_short(),
         SpecialMode::VersionLong => flags::generate_version_long(),
         // --pcre2-version is a little special because it emits an error


### PR DESCRIPTION
This is a little QoL feature I wanted to have for some time.

ripgrep's `--help` output is long, *really* long. It's inconvenient to look for a flag docs in that huge blob of text. This PR adds a feature which lets you output the verbose help of a single flag.

We may discuss about the details, but I had to make a few choices, and I hope the behavior I ended up with is fine. I'll be happy to improve it though if needed.

Specifically, now you can use `-h` or `--help` along with a *single* other argument, such as `E`, `-E`, `encoding`, `--encoding`, `no-encoding`, `--no-encoding`, you get the idea. Any two combinations in these two sets will get you the same result: `E -h` is the same as `--help --encoding`. Note that `-h` still gets you the *verbose* help of the flag, as it didn't seem useful to me to output the short help of a single flag.

The idea is that I can start with:

```
$ rg -h
```

Read the short help, then press the <kbd>up</kbd> key and just add a `p` (for instance) to the previous line:

```
$ rg -h p
```

Which outputs:

```
ripgrep 14.1.0 (rev 648a65f197)
Andrew Gallant <jamslam@gmail.com>

-p, --pretty
    This is a convenience alias for --color=always --heading --line-number.
    This flag is useful when you still want pretty output even if you're
    piping ripgrep to another program or file. For example: rg -p foo |
    less -R.
```

Also note that currently, if you add a non-existing flag name to `-h`/`--help`, it will behave as before and print the whole help. Would you rather have it print an error message instead?