### PR TITLE
feat: add vuejs as a default type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -302,6 +302,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["vimscript"], &[
         "*.vim", ".vimrc", ".gvimrc", "vimrc", "gvimrc", "_vimrc", "_gvimrc",
     ]),
+    (&["vue"], &["*.vue"]),
     (&["webidl"], &["*.idl", "*.webidl", "*.widl"]),
     (&["wiki"], &["*.mediawiki", "*.wiki"]),
     (&["xml"], &[


### PR DESCRIPTION
Just adding `vue` as a valid flag to pass to `-t`.

Using `rg -tvue <pattern>` now works.