### PR TITLE
Detect WORKSPACE.bzlmod for bazel file type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -27,7 +27,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["bat", "batch"], &["*.bat"]),
     (&["bazel"], &[
         "*.bazel", "*.bzl", "*.BUILD", "*.bazelrc", "BUILD", "MODULE.bazel",
-        "WORKSPACE", "WORKSPACE.bazel",
+        "WORKSPACE", "WORKSPACE.bazel", "WORKSPACE.bzlmod",
     ]),
     (&["bitbake"], &["*.bb", "*.bbappend", "*.bbclass", "*.conf", "*.inc"]),
     (&["brotli"], &["*.br"]),


### PR DESCRIPTION
This file came alongside MODULE.bazel and I should have added it here previously