### PR TITLE
bump memchr = "2.7.1"

### DIFF
--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -22,7 +22,7 @@ bench = false
 crossbeam-deque = "0.8.3"
 globset = { version = "0.4.14", path = "../globset" }
 log = "0.4.20"
-memchr = "2.6.3"
+memchr = "2.7.1"
 same-file = "1.0.6"
 walkdir = "2.4.0"
 

--- a/crates/matcher/Cargo.toml
+++ b/crates/matcher/Cargo.toml
@@ -15,7 +15,7 @@ autotests = false
 edition = "2021"
 
 [dependencies]
-memchr = "2.6.3"
+memchr = "2.7.1"
 
 [dev-dependencies]
 regex = "1.9.5"

--- a/crates/searcher/Cargo.toml
+++ b/crates/searcher/Cargo.toml
@@ -19,7 +19,7 @@ encoding_rs = "0.8.33"
 encoding_rs_io = "0.1.7"
 grep-matcher = { version = "0.1.7", path = "../matcher" }
 log = "0.4.20"
-memchr = "2.6.3"
+memchr = "2.7.1"
 memmap = { package = "memmap2", version = "0.9.0" }
 
 [dev-dependencies]


### PR DESCRIPTION
Currently I cannot use `ignore` create with the latest ruff crates. Hence the bump in versions.

Test plan: CI