### PR TITLE
cargo: nuke 'simd-accel' from orbit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ TBD
 ===
 Unreleased changes. Release notes have not yet been written.
 
+Miscellaneous:
+
+* [MISC #2748](https://github.com/BurntSushi/ripgrep/issues/2748):
+  Remove ripgrep's `simd-accel` feature because it was frequently broken.
+
 
 14.1.0 (2024-01-06)
 ===================

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bstr"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,7 +85,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
- "packed_simd",
 ]
 
 [[package]]
@@ -270,12 +263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
-name = "libm"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,26 +281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
-dependencies = [
- "autocfg",
- "libm",
-]
-
-[[package]]
-name = "packed_simd"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9f08af0c877571712e2e3e686ad79efad9657dbf0f7c3c8ba943ff6c38932d"
-dependencies = [
- "cfg-if",
- "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ serde_derive = "1.0.77"
 walkdir = "2"
 
 [features]
-simd-accel = ["grep/simd-accel"]
 pcre2 = ["grep/pcre2"]
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -432,18 +432,13 @@ $ ./target/release/rg --version
 0.1.3
 ```
 
-If you have a Rust nightly compiler and a recent Intel CPU, then you can enable
-additional optional SIMD acceleration like so:
-
-```
-RUSTFLAGS="-C target-cpu=native" cargo build --release --features 'simd-accel'
-```
-
-The `simd-accel` feature enables SIMD support in certain ripgrep dependencies
-(responsible for transcoding). They are not necessary to get SIMD optimizations
-for search; those are enabled automatically. Hopefully, some day, the
-`simd-accel` feature will similarly become unnecessary. **WARNING:** Currently,
-enabling this option can increase compilation times dramatically.
+**NOTE:** In the past, ripgrep supported a `simd-accel` Cargo feature when
+using a Rust nightly compiler. This only benefited UTF-16 transcoding.
+Since it required unstable features, this build mode was prone to breakage.
+Because of that, support for it has been removed. If you want SIMD
+optimizations for UTF-16 transcoding, then you'll have to petition the
+[`encoding_rs`](https://github.com/hsivonen/encoding_rs) project to use stable
+APIs.
 
 Finally, optional PCRE2 support can be built with ripgrep by enabling the
 `pcre2` feature:
@@ -451,9 +446,6 @@ Finally, optional PCRE2 support can be built with ripgrep by enabling the
 ```
 $ cargo build --release --features 'pcre2'
 ```
-
-(Tip: use `--features 'pcre2 simd-accel'` to also include compile time SIMD
-optimizations, which will only work with a nightly compiler.)
 
 Enabling the PCRE2 feature works with a stable Rust compiler and will
 attempt to automatically find and link with your system's PCRE2 library via

--- a/crates/core/flags/doc/version.rs
+++ b/crates/core/flags/doc/version.rs
@@ -161,9 +161,6 @@ fn compile_cpu_features() -> Vec<String> {
 fn features() -> Vec<String> {
     let mut features = vec![];
 
-    let simd_accel = cfg!(feature = "simd-accel");
-    features.push(format!("{sign}simd-accel", sign = sign(simd_accel)));
-
     let pcre2 = cfg!(feature = "pcre2");
     features.push(format!("{sign}pcre2", sign = sign(pcre2)));
 

--- a/crates/grep/Cargo.toml
+++ b/crates/grep/Cargo.toml
@@ -26,8 +26,8 @@ termcolor = "1.0.4"
 walkdir = "2.2.7"
 
 [features]
-simd-accel = ["grep-searcher/simd-accel"]
 pcre2 = ["grep-pcre2"]
 
-# This feature is DEPRECATED. Runtime dispatch is used for SIMD now.
+# These features are DEPRECATED. Runtime dispatch is used for SIMD now.
+simd-accel = []
 avx-accel = []

--- a/crates/searcher/Cargo.toml
+++ b/crates/searcher/Cargo.toml
@@ -27,7 +27,6 @@ grep-regex = { version = "0.1.12", path = "../regex" }
 regex = "1.9.5"
 
 [features]
-simd-accel = ["encoding_rs/simd-accel"]
-
-# This feature is DEPRECATED. Runtime dispatch is used for SIMD now.
+# These features are DEPRECATED. Runtime dispatch is used for SIMD now.
+simd-accel = []
 avx-accel = []


### PR DESCRIPTION
This feature causes nothing but problems and is frequently broken. The
only optimization it was enabling were SIMD optimizations for
transcoding. In particular, for UTF-16 transcoding. This is performed by
the [`encoding_rs`](https://github.com/hsivonen/encoding_rs) crate,
which specifically uses unstable portable SIMD APIs instead of the
stable non-portable SIMD APIs.

SIMD optimizations that apply to search have long been making use of
stable APIs, and are automatically enabled when your target supports
them. This is, IMO, the correct user experience and one that
`encoding_rs` refuses to support. I'm done dealing with it, so
transcoding will only use scalar code until the SIMD optimizations in
`encoding_rs` work on stable. (This doesn't mean that `encoding_rs` has
to change. This could also be fixed by stabilizing `std::simd`.)

Fixes #2748
