### PR TITLE
Add option to ignore nested git repositories

### DIFF
--- a/crates/core/flags/complete/rg.zsh
+++ b/crates/core/flags/complete/rg.zsh
@@ -146,6 +146,10 @@ _rg() {
     '--ignore-file-case-insensitive[process ignore files case insensitively]'
     $no'--no-ignore-file-case-insensitive[process ignore files case sensitively]'
 
+    + '(ignore-nested-git)' # Ignore nested git repository option
+    '--ignore-nested-git[ignore nested git repositories]'
+    $no"--no-ignore-nested-git[don't ignore nested git repositories]"
+
     + '(ignore-exclude)' # Local exclude (ignore)-file options
     "--no-ignore-exclude[don't respect local exclude (ignore) files]"
     $no'--ignore-exclude[respect local exclude (ignore) files]'

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -83,6 +83,7 @@ pub(super) const FLAGS: &[&dyn Flag] = &[
     &IgnoreCase,
     &IgnoreFile,
     &IgnoreFileCaseInsensitive,
+    &IgnoreNestedGit,
     &IncludeZero,
     &InvertMatch,
     &JSON,
@@ -3236,6 +3237,62 @@ fn test_ignore_file_case_insensitive() {
     ])
     .unwrap();
     assert_eq!(true, args.ignore_file_case_insensitive);
+}
+
+/// --ignore-nested-git
+#[derive(Debug)]
+struct IgnoreNestedGit;
+
+impl Flag for IgnoreNestedGit {
+    fn is_switch(&self) -> bool {
+        true
+    }
+    fn name_long(&self) -> &'static str {
+        "ignore-nested-git"
+    }
+    fn name_negated(&self) -> Option<&'static str> {
+        Some("no-ignore-nested-git")
+    }
+    fn doc_category(&self) -> Category {
+        Category::Filter
+    }
+    fn doc_short(&self) -> &'static str {
+        r"Ignore nested git repositories."
+    }
+    fn doc_long(&self) -> &'static str {
+        r"
+Ignore any nested directory containing a \fB.git\fP file or directory.
+This will prevent ripgrep from recursing into any git worktrees, submodules,
+or regular repositories.
+.sp
+Note that this does not affect top-level directories.
+"
+    }
+
+    fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
+        args.ignore_nested_git = v.unwrap_switch();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_ignore_nested_git() {
+    let args = parse_low_raw(None::<&str>).unwrap();
+    assert_eq!(false, args.ignore_nested_git);
+
+    let args = parse_low_raw(["--ignore-nested-git"]).unwrap();
+    assert_eq!(true, args.ignore_nested_git);
+
+    let args =
+        parse_low_raw(["--ignore-nested-git", "--no-ignore-nested-git"])
+            .unwrap();
+    assert_eq!(false, args.ignore_nested_git);
+
+    let args =
+        parse_low_raw(["--no-ignore-nested-git", "--ignore-nested-git"])
+            .unwrap();
+    assert_eq!(true, args.ignore_nested_git);
 }
 
 /// --include-zero

--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -59,6 +59,7 @@ pub(crate) struct HiArgs {
     hyperlink_config: grep::printer::HyperlinkConfig,
     ignore_file_case_insensitive: bool,
     ignore_file: Vec<PathBuf>,
+    ignore_nested_git: bool,
     include_zero: bool,
     invert_match: bool,
     is_terminal_stdout: bool,
@@ -275,6 +276,7 @@ impl HiArgs {
             hyperlink_config,
             ignore_file: low.ignore_file,
             ignore_file_case_insensitive: low.ignore_file_case_insensitive,
+            ignore_nested_git: low.ignore_nested_git,
             include_zero: low.include_zero,
             invert_match: low.invert_match,
             is_terminal_stdout: state.is_terminal_stdout,
@@ -893,7 +895,8 @@ impl HiArgs {
             .git_ignore(!self.no_ignore_vcs)
             .git_exclude(!self.no_ignore_vcs && !self.no_ignore_exclude)
             .require_git(!self.no_require_git)
-            .ignore_case_insensitive(self.ignore_file_case_insensitive);
+            .ignore_case_insensitive(self.ignore_file_case_insensitive)
+            .ignore_nested_git_repo(self.ignore_nested_git);
         if !self.no_ignore_dot {
             builder.add_custom_ignore_filename(".rgignore");
         }

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -64,6 +64,7 @@ pub(crate) struct LowArgs {
     pub(crate) iglobs: Vec<String>,
     pub(crate) ignore_file: Vec<PathBuf>,
     pub(crate) ignore_file_case_insensitive: bool,
+    pub(crate) ignore_nested_git: bool,
     pub(crate) include_zero: bool,
     pub(crate) invert_match: bool,
     pub(crate) line_number: Option<bool>,

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -811,6 +811,14 @@ impl WalkBuilder {
         self
     }
 
+    /// Enables ignoring nested git repositories, including submodules.
+    ///
+    /// This is disabled by default.
+    pub fn ignore_nested_git_repo(&mut self, yes: bool) -> &mut WalkBuilder {
+        self.ig_builder.ignore_nested_git_repo(yes);
+        self
+    }
+
     /// Set a function for sorting directory entries by their path.
     ///
     /// If a compare function is set, the resulting iterator will return all


### PR DESCRIPTION
This implements the suggestion made in #23 to provide an option to ignore nested git repositories.

A nested git repository is identified by the presence of a .git file or directory. It's a directory in the regular case, but it's a file for git worktrees and git submodules.

This option is disabled by default.

I'm open to suggestions for better names for things. In particular I'm not sure about the name `ignore_nested_git_repo` used in `IgnoreOptions` and `IgnoreBuilder` because the concept of 'nesting' is outside of that layer; it has no knowledge of the level of a `DirEntry` and relies on the calling code to make sure that the level 0 directory is never ignored.