### PR TITLE
feat: add svelte file types as default filetype

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -265,6 +265,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["sql"], &["*.sql", "*.psql"]),
     (&["stylus"], &["*.styl"]),
     (&["sv"], &["*.v", "*.vg", "*.sv", "*.svh", "*.h"]),
+    (&["svelte"], &["*.svelte"]),
     (&["svg"], &["*.svg"]),
     (&["swift"], &["*.swift"]),
     (&["swig"], &["*.def", "*.i"]),


### PR DESCRIPTION
Added svelte filetype as default filetype, ran `cargo test -all` to confirm tests worked Ran `rg --type-list` to convert svelte showed up