### PR TITLE
ignore/walk: correct build_parallel() documentation

### DIFF
--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -591,7 +591,7 @@ impl WalkBuilder {
     ///
     /// Note that this *doesn't* return something that implements `Iterator`.
     /// Instead, the returned value must be run with a closure. e.g.,
-    /// `builder.build_parallel().run(|| |path| println!("{:?}", path))`.
+    /// `builder.build_parallel().run(|| |path| { println!("{path:?}"); WalkState::Continue })`.
     pub fn build_parallel(&self) -> WalkParallel {
         WalkParallel {
             paths: self.paths.clone().into_iter(),


### PR DESCRIPTION
The returned closure should return `WalkState`, not `()`.

Closes: #2767