### PR TITLE
ignore/types: add WGSL to the default file types

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -305,6 +305,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     ]),
     (&["vue"], &["*.vue"]),
     (&["webidl"], &["*.idl", "*.webidl", "*.widl"]),
+    (&["wgsl"], &["*.wgsl"]),
     (&["wiki"], &["*.mediawiki", "*.wiki"]),
     (&["xml"], &[
         "*.xml", "*.xml.dist", "*.dtd", "*.xsl", "*.xslt", "*.xsd", "*.xjb",


### PR DESCRIPTION
[WGSL][1] is a shading language for WebGPU. As defined in [Appendix A][2], the file extension is `.wgsl`.

This PR adds a file type support for WGSL to ripgrep.

[1]: https://www.w3.org/TR/WGSL/
[2]: https://www.w3.org/TR/WGSL/#text-wgsl-media-type