### PR TITLE
ignore/gitignore: Skip BOM at start of ignore file

### DIFF
--- a/crates/ignore/src/gitignore.rs
+++ b/crates/ignore/src/gitignore.rs
@@ -401,6 +401,12 @@ impl GitignoreBuilder {
                     break;
                 }
             };
+
+            // Match Git's handling of .gitignore files that begin with the Unicode BOM
+            const UTF8_BOM: &str = "\u{feff}";
+            let line =
+                if i == 0 { line.trim_start_matches(UTF8_BOM) } else { &line };
+
             if let Err(err) = self.add_line(Some(path.to_path_buf()), &line) {
                 errs.push(err.tagged(path, lineno));
             }

--- a/crates/ignore/tests/gitignore_skip_bom.gitignore
+++ b/crates/ignore/tests/gitignore_skip_bom.gitignore
@@ -1,0 +1,2 @@
+﻿ignore/this/path
+# This file begins with a BOM (U+FEFF)

--- a/crates/ignore/tests/gitignore_skip_bom.rs
+++ b/crates/ignore/tests/gitignore_skip_bom.rs
@@ -1,0 +1,14 @@
+use ignore::gitignore::GitignoreBuilder;
+
+const IGNORE_FILE: &'static str = "tests/gitignore_skip_bom.gitignore";
+
+/// Skip a Byte-Order Mark (BOM) at the beginning of the file, matching Git's behavior.
+#[test]
+fn gitignore_skip_bom() {
+    let mut builder = GitignoreBuilder::new("ROOT");
+    let error = builder.add(IGNORE_FILE);
+    assert!(error.is_none(), "failed to open gitignore file");
+    let g = builder.build().unwrap();
+
+    assert!(g.matched("ignore/this/path", false).is_ignore());
+}


### PR DESCRIPTION
Match Git's behavior.
Fixes #2177.