### PR TITLE
strip dollar signs from the commands readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,112 +242,112 @@ mentioned below are advised to download one of these archives.
 If you're a **macOS Homebrew** or a **Linuxbrew** user, then you can install
 ripgrep from homebrew-core:
 
-```
-$ brew install ripgrep
+```bash
+ brew install ripgrep
 ```
 
 If you're a **MacPorts** user, then you can install ripgrep from the
 [official ports](https://www.macports.org/ports.php?by=name&substr=ripgrep):
 
-```
-$ sudo port install ripgrep
+```bash
+ sudo port install ripgrep
 ```
 
 If you're a **Windows Chocolatey** user, then you can install ripgrep from the
 [official repo](https://chocolatey.org/packages/ripgrep):
 
-```
-$ choco install ripgrep
+```bash
+ choco install ripgrep
 ```
 
 If you're a **Windows Scoop** user, then you can install ripgrep from the
 [official bucket](https://github.com/ScoopInstaller/Main/blob/master/bucket/ripgrep.json):
 
-```
-$ scoop install ripgrep
+```bash
+ scoop install ripgrep
 ```
 
 If you're a **Windows Winget** user, then you can install ripgrep from the
 [winget-pkgs](https://github.com/microsoft/winget-pkgs/tree/master/manifests/b/BurntSushi/ripgrep)
 repository:
 
-```
-$ winget install BurntSushi.ripgrep.MSVC
+```bash
+ winget install BurntSushi.ripgrep.MSVC
 ```
 
 If you're an **Arch Linux** user, then you can install ripgrep from the official repos:
 
-```
-$ sudo pacman -S ripgrep
+```bash
+ sudo pacman -S ripgrep
 ```
 
 If you're a **Gentoo** user, you can install ripgrep from the
 [official repo](https://packages.gentoo.org/packages/sys-apps/ripgrep):
 
-```
-$ sudo emerge sys-apps/ripgrep
+```bash
+ sudo emerge sys-apps/ripgrep
 ```
 
 If you're a **Fedora** user, you can install ripgrep from official
 repositories.
 
-```
-$ sudo dnf install ripgrep
+```bash
+ sudo dnf install ripgrep
 ```
 
 If you're an **openSUSE** user, ripgrep is included in **openSUSE Tumbleweed**
 and **openSUSE Leap** since 15.1.
 
-```
-$ sudo zypper install ripgrep
+```bash
+ sudo zypper install ripgrep
 ```
 
 If you're a **RHEL/CentOS 7/8** user, you can install ripgrep from
 [copr](https://copr.fedorainfracloud.org/coprs/carlwgeorge/ripgrep/):
 
-```
-$ sudo yum install -y yum-utils
-$ sudo yum-config-manager --add-repo=https://copr.fedorainfracloud.org/coprs/carlwgeorge/ripgrep/repo/epel-7/carlwgeorge-ripgrep-epel-7.repo
-$ sudo yum install ripgrep
+```bash
+ sudo yum install -y yum-utils
+ sudo yum-config-manager --add-repo=https://copr.fedorainfracloud.org/coprs/carlwgeorge/ripgrep/repo/epel-7/carlwgeorge-ripgrep-epel-7.repo
+ sudo yum install ripgrep
 ```
 
 If you're a **Nix** user, you can install ripgrep from
 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/text/ripgrep/default.nix):
 
-```
-$ nix-env --install ripgrep
+```bash
+ nix-env --install ripgrep
 ```
 
 If you're a **Guix** user, you can install ripgrep from the official
 package collection:
 
-```
-$ guix install ripgrep
+```bash
+ guix install ripgrep
 ```
 
 If you're a **Debian** user (or a user of a Debian derivative like **Ubuntu**),
 then ripgrep can be installed using a binary `.deb` file provided in each
 [ripgrep release](https://github.com/BurntSushi/ripgrep/releases).
 
-```
-$ curl -LO https://github.com/BurntSushi/ripgrep/releases/download/13.0.0/ripgrep_13.0.0_amd64.deb
-$ sudo dpkg -i ripgrep_13.0.0_amd64.deb
+```bash
+ curl -LO https://github.com/BurntSushi/ripgrep/releases/download/13.0.0/ripgrep_13.0.0_amd64.deb
+ sudo dpkg -i ripgrep_13.0.0_amd64.deb
 ```
 
 If you run Debian stable, ripgrep is [officially maintained by
 Debian](https://tracker.debian.org/pkg/rust-ripgrep), although its version may
 be older than the `deb` package available in the previous step.
 
-```
-$ sudo apt-get install ripgrep
+```bash
+ sudo apt-get install ripgrep
 ```
 
 If you're an **Ubuntu Cosmic (18.10)** (or newer) user, ripgrep is
 [available](https://launchpad.net/ubuntu/+source/rust-ripgrep) using the same
 packaging as Debian:
 
-```
-$ sudo apt-get install ripgrep
+```bash
+ sudo apt-get install ripgrep
 ```
 
 (N.B. Various snaps for ripgrep on Ubuntu are also available, but none of them
@@ -358,50 +358,50 @@ longer a recommended installation option.)
 If you're an **ALT** user, you can install ripgrep from the
 [official repo](https://packages.altlinux.org/en/search?name=ripgrep):
 
-```
-$ sudo apt-get install ripgrep
+```bash
+ sudo apt-get install ripgrep
 ```
 
 If you're a **FreeBSD** user, then you can install ripgrep from the
 [official ports](https://www.freshports.org/textproc/ripgrep/):
 
-```
-$ sudo pkg install ripgrep
+```bash
+ sudo pkg install ripgrep
 ```
 
 If you're an **OpenBSD** user, then you can install ripgrep from the
 [official ports](https://openports.se/textproc/ripgrep):
 
-```
-$ doas pkg_add ripgrep
+```bash
+ doas pkg_add ripgrep
 ```
 
 If you're a **NetBSD** user, then you can install ripgrep from
 [pkgsrc](https://pkgsrc.se/textproc/ripgrep):
 
-```
-$ sudo pkgin install ripgrep
+```bash
+ sudo pkgin install ripgrep
 ```
 
 If you're a **Haiku x86_64** user, then you can install ripgrep from the
 [official ports](https://github.com/haikuports/haikuports/tree/master/sys-apps/ripgrep):
 
-```
-$ sudo pkgman install ripgrep
+```bash
+ sudo pkgman install ripgrep
 ```
 
 If you're a **Haiku x86_gcc2** user, then you can install ripgrep from the
 same port as Haiku x86_64 using the x86 secondary architecture build:
 
-```
-$ sudo pkgman install ripgrep_x86
+```bash
+ sudo pkgman install ripgrep_x86
 ```
 
 If you're a **Void Linux** user, then you can install ripgrep from the
 [official repository](https://voidlinux.org/packages/?arch=x86_64&q=ripgrep):
 
-```
-$ sudo xbps-install -Syv ripgrep
+```bash
+ sudo xbps-install -Syv ripgrep
 ```
 
 If you're a **Rust programmer**, ripgrep can be installed with `cargo`.
@@ -412,16 +412,16 @@ If you're a **Rust programmer**, ripgrep can be installed with `cargo`.
   symbols. This is intentional. To remove debug symbols and therefore reduce
   the file size, run `strip` on the binary.
 
-```
-$ cargo install ripgrep
+```bash
+ cargo install ripgrep
 ```
 
 Alternatively, one can use [`cargo
 binstall`](https://github.com/cargo-bins/cargo-binstall) to install a ripgrep
 binary directly from GitHub:
 
-```
-$ cargo binstall ripgrep
+```bash
+ cargo binstall ripgrep
 ```
 
 
@@ -434,11 +434,11 @@ the latest stable release of the Rust compiler.
 
 To build ripgrep:
 
-```
-$ git clone https://github.com/BurntSushi/ripgrep
-$ cd ripgrep
-$ cargo build --release
-$ ./target/release/rg --version
+```bash
+ git clone https://github.com/BurntSushi/ripgrep
+ cd ripgrep
+ cargo build --release
+ ./target/release/rg --version
 0.1.3
 ```
 
@@ -453,8 +453,8 @@ APIs.
 Finally, optional PCRE2 support can be built with ripgrep by enabling the
 `pcre2` feature:
 
-```
-$ cargo build --release --features 'pcre2'
+```bash
+ cargo build --release --features 'pcre2'
 ```
 
 Enabling the PCRE2 feature works with a stable Rust compiler and will
@@ -470,9 +470,9 @@ library on your system (consult your friendly neighborhood package manager).
 Then you just need to add MUSL support to your Rust toolchain and rebuild
 ripgrep, which yields a fully static executable:
 
-```
-$ rustup target add x86_64-unknown-linux-musl
-$ cargo build --release --target x86_64-unknown-linux-musl
+```bash
+ rustup target add x86_64-unknown-linux-musl
+ cargo build --release --target x86_64-unknown-linux-musl
 ```
 
 Applying the `--features` flag from above works as expected. If you want to
@@ -486,8 +486,8 @@ MUSL library, depending on your Linux distribution.
 ripgrep is relatively well-tested, including both unit tests and integration
 tests. To run the full test suite, use:
 
-```
-$ cargo test --all
+```bash
+ cargo test --all
 ```
 
 from the repository root.


### PR DESCRIPTION
People tend to click on the copy to clipboard button then paste it. But it has a leading dollar sign. The command fails. It takes almost no time to remove the dollar sign but it's a bit annoying. Consider merging