### PR TITLE
Set up ripgrep for compilation on non-unix, non-windows platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,21 @@ jobs:
       shell: bash
       run: ${{ env.CARGO }} test --bin rg ${{ env.TARGET_FLAGS }} flags::defs::tests::available_shorts -- --nocapture
 
+     # Setup and compile on the wasm32-wasi target
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    - name: Add wasm32-wasi target
+      run: rustup target add wasm32-wasi
+    - name: Basic build
+      run: cargo build --verbose
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,9 +189,12 @@ jobs:
       shell: bash
       run: ${{ env.CARGO }} test --bin rg ${{ env.TARGET_FLAGS }} flags::defs::tests::available_shorts -- --nocapture
 
-     # Setup and compile on the wasm32-wasi target
+  # Setup and run tests on the wasm32-wasi target via wasmtime.
   wasm:
     runs-on: ubuntu-latest
+    env:
+      # The version of wasmtime to download and install.
+      WASMTIME_VERSION: 15.0.1
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -201,9 +204,19 @@ jobs:
         toolchain: stable
     - name: Add wasm32-wasi target
       run: rustup target add wasm32-wasi
+    - name: Download and install Wasmtime
+      run: |
+        echo "CARGO_BUILD_TARGET=wasm32-wasi" >> $GITHUB_ENV
+        echo "RUSTFLAGS=-Ctarget-feature=+simd128" >> $GITHUB_ENV
+        curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v$WASMTIME_VERSION/wasmtime-v$WASMTIME_VERSION-x86_64-linux.tar.xz
+        tar xvf wasmtime-v$WASMTIME_VERSION-x86_64-linux.tar.xz
+        echo `pwd`/wasmtime-v$WASMTIME_VERSION-x86_64-linux >> $GITHUB_PATH
+        echo "CARGO_TARGET_WASM32_WASI_RUNNER=wasmtime run --wasm simd --" >> $GITHUB_ENV
     - name: Basic build
       run: cargo build --verbose
-
+    - name: Run tests
+      run: cargo test --verbose
+    
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,12 +189,9 @@ jobs:
       shell: bash
       run: ${{ env.CARGO }} test --bin rg ${{ env.TARGET_FLAGS }} flags::defs::tests::available_shorts -- --nocapture
 
-  # Setup and run tests on the wasm32-wasi target via wasmtime.
+     # Setup and compile on the wasm32-wasi target
   wasm:
     runs-on: ubuntu-latest
-    env:
-      # The version of wasmtime to download and install.
-      WASMTIME_VERSION: 15.0.1
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -204,19 +201,9 @@ jobs:
         toolchain: stable
     - name: Add wasm32-wasi target
       run: rustup target add wasm32-wasi
-    - name: Download and install Wasmtime
-      run: |
-        echo "CARGO_BUILD_TARGET=wasm32-wasi" >> $GITHUB_ENV
-        echo "RUSTFLAGS=-Ctarget-feature=+simd128" >> $GITHUB_ENV
-        curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v$WASMTIME_VERSION/wasmtime-v$WASMTIME_VERSION-x86_64-linux.tar.xz
-        tar xvf wasmtime-v$WASMTIME_VERSION-x86_64-linux.tar.xz
-        echo `pwd`/wasmtime-v$WASMTIME_VERSION-x86_64-linux >> $GITHUB_PATH
-        echo "CARGO_TARGET_WASM32_WASI_RUNNER=wasmtime run --wasm simd --" >> $GITHUB_ENV
     - name: Basic build
       run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/crates/cli/src/hostname.rs
+++ b/crates/cli/src/hostname.rs
@@ -25,10 +25,8 @@ pub fn hostname() -> io::Result<OsString> {
     }
     #[cfg(not(any(windows, unix)))]
     {
-        io::Error::new(
-            io::ErrorKind::Other,
-            "hostname could not be found on unsupported platform",
-        )
+        // backup solution for systems that do not have gethostname():
+        Ok(OsString::from("localhost"))
     }
 }
 

--- a/crates/cli/src/hostname.rs
+++ b/crates/cli/src/hostname.rs
@@ -25,8 +25,10 @@ pub fn hostname() -> io::Result<OsString> {
     }
     #[cfg(not(any(windows, unix)))]
     {
-        // backup solution for systems that do not have gethostname():
-        Ok(OsString::from("localhost"))
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "hostname could not be found on unsupported platform",
+        ))
     }
 }
 

--- a/crates/printer/src/hyperlink.rs
+++ b/crates/printer/src/hyperlink.rs
@@ -853,56 +853,12 @@ impl HyperlinkPath {
         }
         HyperlinkPath(result)
     }
-    #[cfg(target_os = "wasi")]
-    pub(crate) fn from_path(original_path: &Path) -> Option<HyperlinkPath> {
-        use std::os::wasi::ffi::OsStrExt;
 
-        // We canonicalize the path in order to get an absolute version of it
-        // without any `.` or `..` or superfluous separators. Unfortunately,
-        // this does also remove symlinks, and in theory, it would be nice to
-        // retain them. Perhaps even simpler, we could just join the current
-        // working directory with the path and be done with it. There was
-        // some discussion about this on PR#2483, and there generally appears
-        // to be some uncertainty about the extent to which hyperlinks with
-        // things like `..` in them actually work. So for now, we do the safest
-        // thing possible even though I think it can result in worse user
-        // experience. (Because it means the path you click on and the actual
-        // path that gets followed are different, even though they ostensibly
-        // refer to the same file.)
-        //
-        // There's also the potential issue that path canonicalization is
-        // expensive since it can touch the file system. That is probably
-        // less of an issue since hyperlinks are only created when they're
-        // supported, i.e., when writing to a tty.
-        //
-        // [1]: https://github.com/BurntSushi/ripgrep/pull/2483
-        let path = match original_path.canonicalize() {
-            Ok(path) => path,
-            Err(err) => {
-                log::debug!(
-                    "hyperlink creation for {:?} failed, error occurred \
-                     during path canonicalization: {}",
-                    original_path,
-                    err,
-                );
-                return None;
-            }
-        };
-        let bytes = path.as_os_str().as_bytes();
-        // This should not be possible since one imagines that canonicalization
-        // should always return an absolute path. But it doesn't actually
-        // appear guaranteed by POSIX, so we check whether it's true or not and
-        // refuse to create a hyperlink from a relative path if it isn't.
-        if !bytes.starts_with(b"/") {
-            log::debug!(
-                "hyperlink creation for {:?} failed, canonicalization \
-                 returned {:?}, which does not start with a slash",
-                original_path,
-                path,
-            );
-            return None;
-        }
-        Some(HyperlinkPath::encode(bytes))
+    // For other platforms (not windows, not unix), return None and log a debug message.
+    #[cfg(not(any(windows, unix)))]
+    pub(crate) fn from_path(original_path: &Path) -> Option<HyperlinkPath> {
+        log::debug!("Hyperlinks are not supported on this platform");
+        None
     }
 }
 

--- a/crates/printer/src/hyperlink.rs
+++ b/crates/printer/src/hyperlink.rs
@@ -811,6 +811,13 @@ impl HyperlinkPath {
         Some(HyperlinkPath::encode(with_slash.as_bytes()))
     }
 
+    /// For other platforms (not windows, not unix), return None and log a debug message.
+    #[cfg(not(any(windows, unix)))]
+    pub(crate) fn from_path(original_path: &Path) -> Option<HyperlinkPath> {
+        log::debug!("hyperlinks are not supported on this platform");
+        None
+    }
+
     /// Percent-encodes a path.
     ///
     /// The alphanumeric ASCII characters and "-", ".", "_", "~" are unreserved
@@ -852,13 +859,6 @@ impl HyperlinkPath {
             }
         }
         HyperlinkPath(result)
-    }
-
-    // For other platforms (not windows, not unix), return None and log a debug message.
-    #[cfg(not(any(windows, unix)))]
-    pub(crate) fn from_path(original_path: &Path) -> Option<HyperlinkPath> {
-        log::debug!("Hyperlinks are not supported on this platform");
-        None
     }
 }
 


### PR DESCRIPTION
The code of ripgrep compiles on almost any kind of architecture, including WebAssembly, except in two tiny places related to hyperlinks: 
- when it searches for the local hostname in `hostname.rs`, 
- when it does path canonalization in `hyperlink.rs`.

In both cases, there is a path with `#[cfg(unix)]` and a path with `#[cfg(windows)]`. WebAssembly being neither unix nor windows, compilation fails. This PR adds a third path:
- for localhost, it returns "localhost" instead of calling `gethostname()`, for all environments that are neither unix nor windows.
- for path canonalization, it uses `std::os::wasi::ffi::OsStrExt` instead of `std::os::unix::ffi::OsStrExt`, which is not available; this part is specific for wasm32-wasi. It could be possible to deactivate path canonalization entirely for architectures that are neither unix nor windows, but I aimed for the smallest working change.

With these two changes, it's possible to compile ripgrep with `cargo build --target wasm32-wasi` (and, more importantly, it works in wasm32-wasi environments). 