### PR TITLE
stats fixup

### DIFF
--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -468,7 +468,7 @@ fn print_stats<W: Write>(
 {bytes_printed} bytes printed
 {bytes_searched} bytes searched
 {search_time:0.6} seconds spent searching
-{process_time:0.6} seconds
+{process_time:0.6} seconds spent processing
 ",
             matches = stats.matches(),
             lines = stats.matched_lines(),

--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -468,7 +468,7 @@ fn print_stats<W: Write>(
 {bytes_printed} bytes printed
 {bytes_searched} bytes searched
 {search_time:0.6} seconds spent searching
-{process_time:0.6} seconds spent processing
+{process_time:0.6} seconds total
 ",
             matches = stats.matches(),
             lines = stats.matched_lines(),


### PR DESCRIPTION
Tiny change, looks like the text for seconds spent processing for `--stats` was missing.