### PR TITLE
fix: typo in vimgrep help message

### DIFF
--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -7261,7 +7261,7 @@ impl Flag for Vimgrep {
         Category::Output
     }
     fn doc_short(&self) -> &'static str {
-        r"Print results im a vim compatible format."
+        r"Print results in a vim compatible format."
     }
     fn doc_long(&self) -> &'static str {
         r"


### PR DESCRIPTION
I found a very small typo in the help message and I thought might as well fix it