### PR TITLE
Add Flox as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ If you're a **Nix** user, you can install ripgrep from
 $ nix-env --install ripgrep
 ```
 
+If you're a **Flox** user, you can install ripgrep as follows:
+
+```
+$ flox install ripgrep
+```
+
 If you're a **Guix** user, you can install ripgrep from the official
 package collection:
 


### PR DESCRIPTION
`ripgrep` is available to install through the [Flox CLI](https://flox.dev/docs/), and seems to be working today.
Since Nix, and Guix, are also listed as installation option, I thought Flox might make sense as well.