### PR TITLE
Add `*.tfvars` to list of Terraform filetypes

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -280,9 +280,9 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["texinfo"], &["*.texi"]),
     (&["textile"], &["*.textile"]),
     (&["tf"], &[
-        "*.tf", "*.auto.tfvars", "terraform.tfvars", "*.tf.json",
+        "*.tf", "*.auto.tfvars", "terraform.tfvars", "*.tfvars", "*.tf.json",
         "*.auto.tfvars.json", "terraform.tfvars.json", "*.terraformrc",
-        "terraform.rc", "*.tfrc", "*.terraform.lock.hcl",
+        "terraform.rc", "*.tfrc", "*.terraform.lock.hcl"
     ]),
     (&["thrift"], &["*.thrift"]),
     (&["toml"], &["*.toml", "Cargo.lock"]),

--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -282,7 +282,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["tf"], &[
         "*.tf", "*.auto.tfvars", "terraform.tfvars", "*.tfvars", "*.tf.json",
         "*.auto.tfvars.json", "terraform.tfvars.json", "*.terraformrc",
-        "terraform.rc", "*.tfrc", "*.terraform.lock.hcl"
+        "terraform.rc", "*.tfrc", "*.terraform.lock.hcl",
     ]),
     (&["thrift"], &["*.thrift"]),
     (&["toml"], &["*.toml", "Cargo.lock"]),


### PR DESCRIPTION
Hello,
I'd like to propose adding `*.tfvars` to the list of terraform filetypes. In setups with multiple workspaces, we have different configuration for say `staging.tfvars` and `production.tfvars`. This might override `terraform.tfvars`, so not sure if that should be removed.

Thank you 🙂 