### PR TITLE
Add italic to style attributes

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -248,7 +248,7 @@ The `--colors` flag is a bit more complicated. The general format is:
   to bold the output or not).
 * `{value}` is determined by the value of `{attribute}`. If
   `{attribute}` is `style`, then `{value}` should be one of `nobold`,
-  `bold`, `nointense`, `intense`, `nounderline` or `underline`. If
+  `bold`, `nointense`, `intense`, `nounderline`, `underline`, `noitalic`, or `italic`. If
   `{attribute}` is `fg` or `bg`, then `{value}` should be a color.
 
 A color is specified by either one of eight of English names, a single 256-bit

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -835,7 +835,7 @@ provided multiple times. Settings are applied iteratively. Pre-existing color
 labels are limited to one of eight choices: \fBred\fP, \fBblue\fP, \fBgreen\fP,
 \fBcyan\fP, \fBmagenta\fP, \fByellow\fP, \fBwhite\fP and \fBblack\fP. Styles
 are limited to \fBnobold\fP, \fBbold\fP, \fBnointense\fP, \fBintense\fP,
-\fBnounderline\fP or \fBunderline\fP.
+\fBnounderline\fP, \fBunderline\fP, \fBnoitalic\fP, or \fBitalic\fP, .
 .sp
 The format of the flag is
 \fB{\fP\fItype\fP\fB}:{\fP\fIattribute\fP\fB}:{\fP\fIvalue\fP\fB}\fP.

--- a/crates/printer/src/color.rs
+++ b/crates/printer/src/color.rs
@@ -65,7 +65,7 @@ impl std::fmt::Display for ColorError {
                 f,
                 "unrecognized style attribute '{}'. Choose from: \
                  nobold, bold, nointense, intense, nounderline, \
-                 underline.",
+                 underline, noitalic, italic.",
                 name,
             ),
             ColorError::InvalidFormat(ref original) => write!(
@@ -121,7 +121,7 @@ pub struct ColorSpecs {
 /// `0x`.
 ///
 /// Valid style instructions are `nobold`, `bold`, `intense`, `nointense`,
-/// `underline`, `nounderline`.
+/// `underline`, `nounderline`, `italic`, `noitalic`.
 ///
 /// ## Example
 ///
@@ -201,6 +201,8 @@ enum Style {
     NoIntense,
     Underline,
     NoUnderline,
+    Italic,
+    NoItalic,
 }
 
 impl ColorSpecs {
@@ -286,6 +288,12 @@ impl SpecValue {
                 Style::NoUnderline => {
                     cspec.set_underline(false);
                 }
+                Style::Italic => {
+                    cspec.set_italic(true);
+                }
+                Style::NoItalic => {
+                    cspec.set_italic(false);
+                }
             },
         }
     }
@@ -370,6 +378,8 @@ impl std::str::FromStr for Style {
             "nointense" => Ok(Style::NoIntense),
             "underline" => Ok(Style::Underline),
             "nounderline" => Ok(Style::NoUnderline),
+            "italic" => Ok(Style::Italic),
+            "noitalic" => Ok(Style::NoItalic),
             _ => Err(ColorError::UnrecognizedStyle(s.to_string())),
         }
     }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -404,7 +404,7 @@ rgtest!(r428_unrecognized_style, |dir: Dir, mut cmd: TestCommand| {
     let expected = "\
 rg: error parsing flag --colors: \
 unrecognized style attribute ''. Choose from: nobold, bold, nointense, \
-intense, nounderline, underline.
+intense, nounderline, underline, noitalic, italic.
 ";
     eqnice!(expected, stderr);
 });


### PR DESCRIPTION
See example:

![image](https://github.com/BurntSushi/ripgrep/assets/49597791/44f0c2c9-8d05-40de-a749-f7107c5940f6)

I like italics and termcolor already supports it, just a matter of wiring it up 😁 