### PR TITLE
add Makefile.inc to "make" type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -159,6 +159,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         "[Gg][Nn][Uu]makefile", "[Mm]akefile",
         "[Gg][Nn][Uu]makefile.am", "[Mm]akefile.am",
         "[Gg][Nn][Uu]makefile.in", "[Mm]akefile.in",
+        "[Mm]akefile.inc",
         "*.mk", "*.mak"
     ]),
     (&["mako"], &["*.mako", "*.mao"]),


### PR DESCRIPTION
The *BSD build systems make use of "Makefile.inc" a lot.  Make the "make" type recognize this file by default.