### PR TITLE
chore: Adjust `WalkParallel` heuristic for multithreading

### DIFF
--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -1305,7 +1305,7 @@ impl WalkParallel {
 
     fn threads(&self) -> usize {
         if self.threads == 0 {
-            2
+            std::thread::available_parallelism().map_or(1, |n| n.get()).min(12)
         } else {
             self.threads
         }


### PR DESCRIPTION
See also https://github.com/BurntSushi/ripgrep/blob/71d71d2d98964653cdfcfa315802f518664759d7/crates/core/flags/hiargs.rs#L172

Closes #2854
