### PR TITLE
Use `std::path::absolute` for hyperlinks on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.74.0
+          rust: 1.79.0
         - build: stable
           os: ubuntu-latest
           rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 build = "build.rs"
 autotests = false
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.79"
 
 [[bin]]
 bench = false

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ $ sudo xbps-install -Syv ripgrep
 
 If you're a **Rust programmer**, ripgrep can be installed with `cargo`.
 
-* Note that the minimum supported version of Rust for ripgrep is **1.72.0**,
+* Note that the minimum supported version of Rust for ripgrep is **1.79.0**,
   although ripgrep may work with older versions.
 * Note that the binary may be bigger than expected because it contains debug
   symbols. This is intentional. To remove debug symbols and therefore reduce
@@ -435,7 +435,7 @@ $ cargo binstall ripgrep
 
 ripgrep is written in Rust, so you'll need to grab a
 [Rust installation](https://www.rust-lang.org/) in order to compile it.
-ripgrep compiles with Rust 1.72.0 (stable) or newer. In general, ripgrep tracks
+ripgrep compiles with Rust 1.79.0 (stable) or newer. In general, ripgrep tracks
 the latest stable release of the Rust compiler.
 
 To build ripgrep:


### PR DESCRIPTION
Now that `std::path::absolute` is stable, this PR uses it instead of canonicalization for hyperlinks on Windows, the main goal being to avoid unnecessary access to the file system. It bumps the MSRV to 1.79.

I ran a couple benchmarks: ripgrep is a bit faster in the usual case, but the gains can be much higher when generating hyperlinks for many files, such as when using `--files`.

## Usual case

Here's a simple usage example: looking for `hello` in the ripgrep source code:

```powershell
hyperfine --warmup 3 --export-markdown bench.md `
    -n Baseline 'rg hello C:\Dev\GitHub\ripgrep --no-config --hyperlink-format=vscode --color=always' `
    -n PR 'C:\Dev\GitHub\ripgrep\target\release\rg.exe hello C:\Dev\GitHub\ripgrep --no-config --hyperlink-format=vscode --color=always'
```

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `Baseline` | 26.1 ± 1.7 | 22.1 | 32.4 | 1.11 ± 0.09 |
| `PR` | 23.6 ± 1.2 | 21.4 | 28.3 | 1.00 |

## Using `--files`

And here's a more extreme example: using `--files` on a [big repo](https://github.com/dotnet/runtime):

```powershell
hyperfine --warmup 3 --export-markdown bench.md `
    -n Baseline 'rg --files C:\Dev\dotnet\runtime --no-config --hyperlink-format=vscode --color=always' `
    -n PR 'C:\Dev\GitHub\ripgrep\target\release\rg.exe --files C:\Dev\dotnet\runtime --no-config --hyperlink-format=vscode --color=always'
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `Baseline` | 1.625 ± 0.004 | 1.619 | 1.633 | 10.73 ± 0.17 |
| `PR` | 0.151 ± 0.002 | 0.148 | 0.156 | 1.00 |

What's worth noting here is that this PR reduces the system time (certainly spent on accessing the file system for canonicalization):

```
Benchmark 1: Baseline
  Time (mean ± σ):      1.625 s ±  0.004 s    [User: 0.092 s, System: 0.511 s]
  Range (min … max):    1.619 s …  1.633 s    10 runs

Benchmark 2: PR
  Time (mean ± σ):     151.4 ms ±   2.3 ms    [User: 58.4 ms, System: 129.9 ms]
  Range (min … max):   147.8 ms … 156.0 ms    19 runs

Summary
  PR ran
   10.73 ± 0.17 times faster than Baseline
```

> [!NOTE]
> The baseline and PR binaries have been compiled with the same Rust v1.80.

