### PR TITLE
Update default_types.rs to include msbuild solution filters

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -181,7 +181,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["motoko"], &["*.mo"]),
     (&["msbuild"], &[
         "*.csproj", "*.fsproj", "*.vcxproj", "*.proj", "*.props", "*.targets",
-        "*.sln",
+        "*.sln", "*.slnf"
     ]),
     (&["nim"], &["*.nim", "*.nimf", "*.nimble", "*.nims"]),
     (&["nix"], &["*.nix"]),


### PR DESCRIPTION
Update `msbuild` definition to include [solution filter files](https://learn.microsoft.com/en-us/visualstudio/msbuild/solution-filters?view=vs-2022) that were added in MSBuild 16.7. 