### PR TITLE
Add replacement into json output

### DIFF
--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -589,6 +589,7 @@ impl HiArgs {
             .pretty(false)
             .max_matches(self.max_count)
             .always_begin_end(false)
+            .replacement(self.replace.clone().map(|r| r.into()))
             .build(wtr)
     }
 

--- a/crates/printer/src/json.rs
+++ b/crates/printer/src/json.rs
@@ -270,7 +270,6 @@ impl JSONBuilder {
 ///   present. If no file path is available, then this field is `null`.
 /// * **lines** - An
 ///   [arbitrary data object](#object-arbitrary-data)
-// TODO (sbadragan): add note about replacement
 ///   representing one or more lines contained in this match.
 /// * **line_number** - If the searcher has been configured to report line
 ///   numbers, then this corresponds to the line number of the first line
@@ -283,7 +282,8 @@ impl JSONBuilder {
 ///   encoded, then the byte offsets correspond to the data after base64
 ///   decoding.) The `submatch` objects are guaranteed to be sorted by their
 ///   starting offsets. Note that it is possible for this array to be empty,
-///   for example, when searching reports inverted matches.
+///   for example, when searching reports inverted matches. If a replace value
+///   has been configured, the resulting replacement text is also present.
 ///
 /// #### Message: **context**
 ///
@@ -313,7 +313,8 @@ impl JSONBuilder {
 ///   decoding.) The `submatch` objects are guaranteed to be sorted by
 ///   their starting offsets. Note that it is possible for this array to be
 ///   non-empty, for example, when searching reports inverted matches such that
-///   the original matcher could match things in the contextual lines.
+///   the original matcher could match things in the contextual lines. If a replace
+///   value has been configured, the resulting replacement text is also present.
 ///
 /// #### Object: **submatch**
 ///
@@ -673,7 +674,6 @@ impl<'p, 's, M: Matcher, W: io::Write> JSONSink<'p, 's, M, W> {
         Ok(())
     }
 
-    // TODO (sbadragan): do we need to clone bytes?
     /// If the configuration specifies a replacement, then this executes the
     /// replacement, lazily allocating memory if necessary.
     ///
@@ -916,8 +916,6 @@ impl<'a> SubMatches<'a> {
             for (i, &mat) in matches.iter().enumerate() {
                 match_ranges.push(jsont::SubMatch {
                     m: &bytes[mat],
-                    // TODO (sbadragan): remove
-                    // stephan stephan
                     replacement: replacement
                         .map(|(rbuf, rmatches)| &rbuf[rmatches[i]]),
                     start: mat.start(),

--- a/crates/printer/src/jsont.rs
+++ b/crates/printer/src/jsont.rs
@@ -135,6 +135,7 @@ impl<'a> serde::Serialize for Context<'a> {
 
 pub(crate) struct SubMatch<'a> {
     pub(crate) m: &'a [u8],
+    pub(crate) replacement: Option<&'a [u8]>,
     pub(crate) start: usize,
     pub(crate) end: usize,
 }
@@ -148,6 +149,9 @@ impl<'a> serde::Serialize for SubMatch<'a> {
 
         let mut state = s.serialize_struct("SubMatch", 3)?;
         state.serialize_field("match", &Data::from_bytes(self.m))?;
+        if let Some(r) = self.replacement {
+            state.serialize_field("replacement", &Data::from_bytes(r))?;
+        }
         state.serialize_field("start", &self.start)?;
         state.serialize_field("end", &self.end)?;
         state.end()


### PR DESCRIPTION
fixes https://github.com/BurntSushi/ripgrep/issues/1872

Hi, I am new to this repo so feel free to let me know if there is any way I can improve this PR. As detailed in the liked issue, this functionality is useful for quite a few cases where search/replace type tooling is built around ripgrep. My own neovim plugin is an example of a tool built on top of your great work 😄 : https://github.com/MagicDuck/grug-far.nvim 
This change would allow me to show diffs, a much requested feature.

Example:

Given the text:
```text
For the Doctor Watsons of this world, as opposed to the Sherlock
Holmeses, success in the province of detective work must always
```

Searching for `Watson` with a replacement parameter of `Moriarity`, here's what a match type item would looks like:
```json
{
  "type": "match",
  "data": {
    "path": {"text": "/home/andrew/sherlock"},
    "lines": {"text": "For the Doctor Watsons of this world, as opposed to the Sherlock\n"},
    "line_number": 1,
    "absolute_offset": 0,
    "submatches": [
      {"match": {"text": "Watson"}, "replacement": {"text": "Moriarity"}, "start": 15, "end": 21}
    ]
  }
}
```

