### PR TITLE
docs(install): add x-cmd method to install rg

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,14 @@ If you're a **Flox** user, you can install ripgrep as follows:
 $ flox install ripgrep
 ```
 
+If you're a **X-CMD** user, you can install ripgrep as follows:
+
+```
+$ x env use rg
+$ # or
+$ x rg
+```
+
 If you're a **Guix** user, you can install ripgrep from the official
 package collection:
 


### PR DESCRIPTION
- Hi, [x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk. It helps you download rg release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the rg installation.md?**[The installation method for the x command](https://www.x-cmd.com/start/).
  ```sh
  x env use rg
  # or
  x rg
  ```

- We wrote a [rg introduction article](https://www.x-cmd.com/pkg/rg) and a [demo](https://www.x-cmd.com/1min/rg)
