### PR TITLE
Add `.svelte.ts` file extension to Svelte glob

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -265,7 +265,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["sql"], &["*.sql", "*.psql"]),
     (&["stylus"], &["*.styl"]),
     (&["sv"], &["*.v", "*.vg", "*.sv", "*.svh", "*.h"]),
-    (&["svelte"], &["*.svelte"]),
+    (&["svelte"], &["*.svelte", "*.svelte.ts"]),
     (&["svg"], &["*.svg"]),
     (&["swift"], &["*.swift"]),
     (&["swig"], &["*.def", "*.i"]),


### PR DESCRIPTION
Closes #2874.

While the `.ts` extension is for TypeScript, it is useful to see `.svelte.ts` files as part of the Svelte glob.