### PR TITLE
Add typst as language and match on *.typ glob

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -290,6 +290,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["twig"], &["*.twig"]),
     (&["txt"], &["*.txt"]),
     (&["typoscript"], &["*.typoscript", "*.ts"]),
+    (&["typst"], &["*.typ"]),
     (&["usd"], &["*.usd", "*.usda", "*.usdc"]),
     (&["v"], &["*.v", "*.vsh"]),
     (&["vala"], &["*.vala"]),


### PR DESCRIPTION
Include Typst programming language in default_types to search for `*.typ`.