### PR TITLE
Add --histogram=NUM argument

### DIFF
--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -59,6 +59,7 @@ pub(super) const FLAGS: &[&dyn Flag] = &[
     &ContextSeparator,
     &Count,
     &CountMatches,
+    &Histogram,
     &Crlf,
     &Debug,
     &DfaSizeLimit,
@@ -1318,6 +1319,42 @@ given.
     fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
         assert!(v.unwrap_switch(), "--count-matches can only be enabled");
         args.mode.update(Mode::Search(SearchMode::CountMatches));
+        Ok(())
+    }
+}
+
+/// --histogram
+#[derive(Debug)]
+struct Histogram;
+
+impl Flag for Histogram {
+    fn is_switch(&self) -> bool {
+        false
+    }
+    fn name_short(&self) -> Option<u8> {
+        None
+    }
+    fn name_long(&self) -> &'static str {
+        "histogram"
+    }
+    fn doc_variable(&self) -> Option<&'static str> {
+        Some("NUM")
+    }
+    fn doc_category(&self) -> Category {
+        Category::OutputModes
+    }
+    fn doc_short(&self) -> &'static str {
+        r"Print a histogram of the matches"
+    }
+    fn doc_long(&self) -> &'static str {
+        r"
+--histogram NUM means that the bins of the histograms are NUM characters wide. In the output the numbers are the counts in these bins.
+            "
+    }
+
+    fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
+        let binsize = convert::usize(&v.unwrap_value())?;
+        args.histogram = if binsize == 0 { None } else { Some(binsize) };
         Ok(())
     }
 }

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -1353,8 +1353,8 @@ impl Flag for Histogram {
     }
 
     fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
-        let binsize = convert::usize(&v.unwrap_value())?;
-        args.histogram = binsize;
+        let binsize = convert::u64(&v.unwrap_value())?;
+        args.histogram_bin_size = Some(binsize);
         args.mode.update(Mode::Search(SearchMode::Histogram));
         Ok(())
     }

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -1347,9 +1347,10 @@ impl Flag for Histogram {
         r"Print a histogram of the matches"
     }
     fn doc_long(&self) -> &'static str {
-        r"
---histogram NUM means that the bins of the histograms are NUM characters wide. In the output the numbers are the counts in these bins.
-            "
+        r" 
+The offset of the match and the specified bin size
+(NUM) of this argument are used to determine which bin gets
+incremented for every match."
     }
 
     fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -1354,7 +1354,8 @@ impl Flag for Histogram {
 
     fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
         let binsize = convert::usize(&v.unwrap_value())?;
-        args.histogram = if binsize == 0 { None } else { Some(binsize) };
+        args.histogram = binsize;
+        args.mode.update(Mode::Search(SearchMode::Histogram));
         Ok(())
     }
 }

--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -573,7 +573,7 @@ impl HiArgs {
                 SearchMode::Histogram => SummaryKind::Histogram,
                 SearchMode::JSON => {
                     return Printer::JSON(self.printer_json(wtr))
-                },
+                }
                 SearchMode::Standard => {
                     return Printer::Standard(self.printer_standard(wtr))
                 }

--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -55,6 +55,7 @@ pub(crate) struct HiArgs {
     follow: bool,
     globs: ignore::overrides::Override,
     heading: bool,
+    histogram_bin_size: Option<u64>,
     hidden: bool,
     hyperlink_config: grep::printer::HyperlinkConfig,
     ignore_file_case_insensitive: bool,
@@ -273,6 +274,7 @@ impl HiArgs {
             follow: low.follow,
             heading,
             hidden: low.hidden,
+            histogram_bin_size: low.histogram_bin_size,
             hyperlink_config,
             ignore_file: low.ignore_file,
             ignore_file_case_insensitive: low.ignore_file_case_insensitive,
@@ -570,7 +572,10 @@ impl HiArgs {
                 SearchMode::FilesWithoutMatch => SummaryKind::PathWithoutMatch,
                 SearchMode::Count => SummaryKind::Count,
                 SearchMode::CountMatches => SummaryKind::CountMatches,
-                SearchMode::Histogram => SummaryKind::Histogram,
+                SearchMode::Histogram => SummaryKind::Histogram(
+                    self.histogram_bin_size
+                        .expect("Histogram bin size must be specified"),
+                ),
                 SearchMode::JSON => {
                     return Printer::JSON(self.printer_json(wtr))
                 }

--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -203,6 +203,7 @@ impl HiArgs {
                 SearchMode::FilesWithMatches
                 | SearchMode::FilesWithoutMatch
                 | SearchMode::Count
+                | SearchMode::Histogram
                 | SearchMode::CountMatches => return false,
                 SearchMode::JSON => return true,
                 SearchMode::Standard => {
@@ -569,9 +570,10 @@ impl HiArgs {
                 SearchMode::FilesWithoutMatch => SummaryKind::PathWithoutMatch,
                 SearchMode::Count => SummaryKind::Count,
                 SearchMode::CountMatches => SummaryKind::CountMatches,
+                SearchMode::Histogram => SummaryKind::Histogram,
                 SearchMode::JSON => {
                     return Printer::JSON(self.printer_json(wtr))
-                }
+                },
                 SearchMode::Standard => {
                     return Printer::Standard(self.printer_standard(wtr))
                 }

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -59,6 +59,7 @@ pub(crate) struct LowArgs {
     pub(crate) globs: Vec<String>,
     pub(crate) heading: Option<bool>,
     pub(crate) hidden: bool,
+    pub(crate) histogram: Option<usize>,
     pub(crate) hostname_bin: Option<PathBuf>,
     pub(crate) hyperlink_format: HyperlinkFormat,
     pub(crate) iglobs: Vec<String>,

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -59,7 +59,7 @@ pub(crate) struct LowArgs {
     pub(crate) globs: Vec<String>,
     pub(crate) heading: Option<bool>,
     pub(crate) hidden: bool,
-    pub(crate) histogram: usize,
+    pub(crate) histogram_bin_size: Option<u64>,
     pub(crate) hostname_bin: Option<PathBuf>,
     pub(crate) hyperlink_format: HyperlinkFormat,
     pub(crate) iglobs: Vec<String>,

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -59,7 +59,7 @@ pub(crate) struct LowArgs {
     pub(crate) globs: Vec<String>,
     pub(crate) heading: Option<bool>,
     pub(crate) hidden: bool,
-    pub(crate) histogram: Option<usize>,
+    pub(crate) histogram: usize,
     pub(crate) hostname_bin: Option<PathBuf>,
     pub(crate) hyperlink_format: HyperlinkFormat,
     pub(crate) iglobs: Vec<String>,
@@ -210,6 +210,8 @@ pub(crate) enum SearchMode {
     /// Show files containing at least one match and the total number of
     /// matches.
     CountMatches,
+    /// Show a histogram of the matches
+    Histogram,
     /// Print matches in a JSON lines format.
     JSON,
 }

--- a/crates/printer/src/summary.rs
+++ b/crates/printer/src/summary.rs
@@ -71,6 +71,8 @@ pub enum SummaryKind {
     /// If the `path` setting is enabled, then the count is prefixed by the
     /// corresponding file path.
     CountMatches,
+    /// Show a histogram of the matches
+    Histogram,
     /// Show only the file path if and only if a match was found.
     ///
     /// This ignores the `path` setting and always shows the file path. If no
@@ -101,7 +103,7 @@ impl SummaryKind {
 
         match *self {
             PathWithMatch | PathWithoutMatch => true,
-            Count | CountMatches | Quiet => false,
+            Count | CountMatches | Histogram | Quiet => false,
         }
     }
 
@@ -111,7 +113,7 @@ impl SummaryKind {
         use self::SummaryKind::*;
 
         match *self {
-            CountMatches => true,
+            Histogram |CountMatches => true,
             Count | PathWithMatch | PathWithoutMatch | Quiet => false,
         }
     }
@@ -123,7 +125,7 @@ impl SummaryKind {
 
         match *self {
             PathWithMatch | Quiet => true,
-            Count | CountMatches | PathWithoutMatch => false,
+            Count | CountMatches | Histogram | PathWithoutMatch => false,
         }
     }
 }
@@ -788,6 +790,9 @@ impl<'p, 's, M: Matcher, W: WriteColor> Sink for SummarySink<'p, 's, M, W> {
                     self.write_line_term(searcher)?;
                 }
             }
+            SummaryKind::Histogram => {
+                self.write(b"hello")?;
+            },
             SummaryKind::PathWithMatch => {
                 if self.match_count > 0 {
                     self.write_path_line(searcher)?;

--- a/crates/printer/src/summary.rs
+++ b/crates/printer/src/summary.rs
@@ -822,8 +822,6 @@ impl<'p, 's, M: Matcher, W: WriteColor> Sink for SummarySink<'p, 's, M, W> {
                     self.write_line_term(searcher)?;
                     self.write(&terminal_str)?;
                     self.write_line_term(searcher)?;
-                    self.write(b"---")?;
-                    self.write_line_term(searcher)?;
                 }
             }
             SummaryKind::PathWithMatch => {

--- a/crates/printer/src/summary.rs
+++ b/crates/printer/src/summary.rs
@@ -804,8 +804,7 @@ impl<'p, 's, M: Matcher, W: WriteColor> Sink for SummarySink<'p, 's, M, W> {
                     .stats
                     .as_ref()
                     .expect("Histogram should enable stats tracking");
-                let total: u64 = stats.histogram().values().sum();
-                if total > 0 {
+                if self.match_count > 0 {
                     let bin_iter = 0..=(stats.bytes_searched() / bin_size);
                     let terminal_str = bin_iter
                         .map(|i| {
@@ -818,8 +817,10 @@ impl<'p, 's, M: Matcher, W: WriteColor> Sink for SummarySink<'p, 's, M, W> {
                         })
                         .collect::<Vec<Vec<u8>>>()
                         .join(searcher.line_terminator().as_bytes());
-                    self.write_path_field()?;
-                    self.write_line_term(searcher)?;
+                    if self.path.is_some() {
+                        self.write_path_field()?;
+                        self.write_line_term(searcher)?;
+                    }
                     self.write(&terminal_str)?;
                     self.write_line_term(searcher)?;
                 }


### PR DESCRIPTION
With this output mode, `rg` will print a histogram of the number of matches within certain ranges of byte offsets. The width of the ranges is the bin size which is specified in the argument.