### PR TITLE
Add `*.rake` extension to list of Ruby file types

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -227,7 +227,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         // Idiomatic files
         "config.ru", "Gemfile", ".irbrc", "Rakefile",
         // Extensions
-        "*.gemspec", "*.rb", "*.rbw"
+        "*.gemspec", "*.rb", "*.rbw", "*.rake"
     ]),
     (&["rust"], &["*.rs"]),
     (&["sass"], &["*.sass", "*.scss"]),


### PR DESCRIPTION
Hello!

This PR adds the `.rake` extension to the Ruby type. It's a pretty common file extension in Rails apps—in my experience, the `Rakefile` is often pretty empty and only sets some stuff up while most of the code lives in various `.rake` files.

https://ruby.github.io/rake/doc/rakefile_rdoc.html#label-Multiple+Rake+Files