### PR TITLE
ignore/types: add *.dtso to devicetree type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -62,7 +62,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["cython"], &["*.pyx", "*.pxi", "*.pxd"]),
     (&["d"], &["*.d"]),
     (&["dart"], &["*.dart"]),
-    (&["devicetree"], &["*.dts", "*.dtsi"]),
+    (&["devicetree"], &["*.dts", "*.dtsi", "*.dtso"]),
     (&["dhall"], &["*.dhall"]),
     (&["diff"], &["*.patch", "*.diff"]),
     (&["dita"], &["*.dita", "*.ditamap", "*.ditaval"]),


### PR DESCRIPTION
dtso files became recognized as devicetree a couple of years ago with the following commit: https://github.com/torvalds/linux/commit/363547d2191cbc32ca954ba75d72908712398ff2