### PR TITLE
ignore/types: add Kconfig

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -117,6 +117,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["julia"], &["*.jl"]),
     (&["jupyter"], &["*.ipynb", "*.jpynb"]),
     (&["k"], &["*.k"]),
+    (&["kconfig"], &["Kconfig", "Kconfig.*"]),
     (&["kotlin"], &["*.kt", "*.kts"]),
     (&["lean"], &["*.lean"]),
     (&["less"], &["*.less"]),


### PR DESCRIPTION
Kconfig files are used to represent the configuration database of Kbuild build system.
Kbuild is developed as part of the Linux kernel.
There are numerous other users including OpenWrt and U-Boot.

Ref: https://docs.kernel.org/kbuild/index.html