### PR TITLE
feat(completion): support sourcing zsh completion dynamically

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -115,10 +115,16 @@ $ rg --generate complete-fish > "$dir/rg.fish"
 
 For **zsh**:
 
-```
+```zsh
 $ dir="$HOME/.zsh-complete"
 $ mkdir -p "$dir"
 $ rg --generate complete-zsh > "$dir/_rg"
+```
+
+or add the following to your `.zshrc`:
+
+```zsh
+$ source <(rg --generate complete-zsh) # note: this is about 4ms slower than the previous method
 ```
 
 For **PowerShell**, create the completions:

--- a/FAQ.md
+++ b/FAQ.md
@@ -94,7 +94,7 @@ Does ripgrep have support for shell auto-completion?
 
 Yes! If you installed ripgrep through a package manager on a Unix system, then
 the shell completion files included in the release archive should have been
-installed for you automatically. If not, you can generate completes using
+installed for you automatically. If not, you can generate completions using
 ripgrep's command line interface.
 
 For **bash**:
@@ -113,7 +113,7 @@ $ mkdir -p "$dir"
 $ rg --generate complete-fish > "$dir/rg.fish"
 ```
 
-For **zsh**:
+For **zsh**, the recommended approach is:
 
 ```zsh
 $ dir="$HOME/.zsh-complete"
@@ -121,11 +121,22 @@ $ mkdir -p "$dir"
 $ rg --generate complete-zsh > "$dir/_rg"
 ```
 
-or add the following to your `.zshrc`:
+And then add `$HOME/.zsh-complete` to your `fpath` in, e.g., your
+`$HOME/.zshrc` file:
 
 ```zsh
-$ source <(rg --generate complete-zsh) # note: this is about 4ms slower than the previous method
+fpath=($HOME/.zsh-complete $fpath)
 ```
+
+Or if you'd prefer to load and generate completions at the same time, you can
+add the following to your `$HOME/.zshrc` file:
+
+```zsh
+$ source <(rg --generate complete-zsh)
+```
+
+Note though that while this approach is easier to setup, is generally slower
+than the previous method, and will add more time to loading your shell prompt.
 
 For **PowerShell**, create the completions:
 

--- a/crates/core/flags/complete/rg.zsh
+++ b/crates/core/flags/complete/rg.zsh
@@ -434,7 +434,12 @@ _rg_types() {
   fi
 }
 
-_rg "$@"
+# don't run the completion function when being sourced by itself. See #2956
+if [[ $funcstack[1] == _rg ]] || (( ! $+functions[compdef] )); then
+  _rg "$@"
+else
+    compdef _rg rg
+fi
 
 ################################################################################
 # ZSH COMPLETION REFERENCE

--- a/crates/core/flags/complete/rg.zsh
+++ b/crates/core/flags/complete/rg.zsh
@@ -434,11 +434,14 @@ _rg_types() {
   fi
 }
 
-# don't run the completion function when being sourced by itself. See #2956
+# Don't run the completion function when being sourced by itself.
+#
+# See https://github.com/BurntSushi/ripgrep/issues/2956
+# See https://github.com/BurntSushi/ripgrep/pull/2957
 if [[ $funcstack[1] == _rg ]] || (( ! $+functions[compdef] )); then
   _rg "$@"
 else
-    compdef _rg rg
+  compdef _rg rg
 fi
 
 ################################################################################


### PR DESCRIPTION
Summary:
Previously, you needed to save the completion script to a file and then
source it.  Now, you can dynamically source completions in zsh by
running

```zsh
$ source <(rg --generate complete-zsh)
```

Test plan:
1. Run `source <(rg --generate complete-zsh)`
2. Run `rg --generate=complete-zs<TAB>`

Before this commit, you would get an error after step 1.
After this commit, it should work as expected.

Closes #2956
