### PR TITLE
Fix the CI workflow broken by WASI compilation target rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
       shell: bash
       run: ${{ env.CARGO }} test --bin rg ${{ env.TARGET_FLAGS }} flags::defs::tests::available_shorts -- --nocapture
 
-     # Setup and compile on the wasm32-wasi target
+     # Setup and compile on the wasm32-wasip1 target
   wasm:
     runs-on: ubuntu-latest
     steps:
@@ -199,8 +199,8 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-    - name: Add wasm32-wasi target
-      run: rustup target add wasm32-wasi
+    - name: Add wasm32-wasip1 target
+      run: rustup target add wasm32-wasip1
     - name: Basic build
       run: cargo build --verbose
 


### PR DESCRIPTION
For more info visit the official rust [blog](https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html).