### PR TITLE
Adding the .rake extension to default Ruby file types

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -227,7 +227,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         // Idiomatic files
         "config.ru", "Gemfile", ".irbrc", "Rakefile",
         // Extensions
-        "*.gemspec", "*.rb", "*.rbw"
+        "*.gemspec", "*.rake", "*.rb", "*.rbw"
     ]),
     (&["rust"], &["*.rs"]),
     (&["sass"], &["*.sass", "*.scss"]),


### PR DESCRIPTION
Rake can read from [multiple `.rake` files](https://github.com/ruby/rake/blob/master/doc/rakefile.rdoc#label-Multiple+Rake+Files) other than the `Rakefile` (already listed). And they are widely used in Ruby projects.

Let's also include the `.rake` extension for completeness.