### PR TITLE
docs: fix nixpkgs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ $ sudo yum install ripgrep
 ```
 
 If you're a **Nix** user, you can install ripgrep from
-[nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/text/ripgrep/default.nix):
+[nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ri/ripgrep/package.nix):
 
 ```
 $ nix-env --install ripgrep


### PR DESCRIPTION
Hi,

love ripgrep and just saw that the nixpkgs link is outdated. There has been some refactoring in nixpkgs a while ago that moved the packages around.

You don't need the link for installing ripgrep via Nix, but I thought a link leading nowhere gives off a bad impression for newcomers to Nix.