### PR TITLE
ignore/types: Add scdoc

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -232,6 +232,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["rust"], &["*.rs"]),
     (&["sass"], &["*.sass", "*.scss"]),
     (&["scala"], &["*.scala", "*.sbt"]),
+    (&["scdoc"], &["*.scd", "*.scdoc"]),
     (&["sh"], &[
         // Portable/misc. init files
         ".login", ".logout", ".profile", "profile",


### PR DESCRIPTION
Homepage: https://sr.ht/~sircmpwn/scdoc/

It's reasonably popular especially among freedesktop/wayland projects, [a github search for `*.scd` files has 48k results](https://github.com/search?q=path%3A*.scd&type=code) (which is an underestimate since these many projects in these communities are hosted on freedesktop gitlab, codeberg, sourcehut, etc.).
Not sure how much `*.scdoc` actually gets used, for comparison it only has [83 github results](https://github.com/search?q=path%3A*.scdoc&type=code), the format name is short enough that its natural to use it as an extension so it seems worth including. 