### PR TITLE
ignore: gracefully quit worker threads upon panic in ParallelVisitor

### DIFF
--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -2221,6 +2221,18 @@ mod tests {
         assert!(!dents[0].path_is_symlink());
     }
 
+    #[test]
+    #[should_panic(expected = "oops!")]
+    fn panic_in_parallel() {
+        let td = tmpdir();
+        wfile(td.path().join("foo.txt"), "");
+
+        WalkBuilder::new(td.path())
+            .threads(40)
+            .build_parallel()
+            .run(|| Box::new(|_| panic!("oops!")));
+    }
+
     #[cfg(unix)] // because symlinks on windows are weird
     #[test]
     fn symlink_loop() {


### PR DESCRIPTION
*Fixes #3009.*

# Problem
`WalkParallel::visit()` will nondeterministically hang if the `ParallelVisitor::visit()` implementation panics. This also occurs when providing a closure to `WalkParallel::run()`. Minimal repro is provided in #3009:

```rust
        WalkBuilder::new(path)
            .build_parallel()
            .run(|| Box::new(|_| panic!("oops!")));
```

The above code will nondeterministically hang, because of an infinite loop when no new work is available: https://github.com/BurntSushi/ripgrep/blob/de4baa10024f2cb62d438596274b9b710e01c59b/crates/ignore/src/walk.rs#L1695-L1707

# Solution
1. Check the `quit_now` flag in our wait loop.
2. Catch any panic in the `run()` method and set `quit_now` before propagating the panic.

**Breaking change:** In order to ensure soundness, we also enforce that the filter method provided to `WalkBuilder#filter_entry()` is `UnwindSafe`. Users can circumvent this by wrapping in `AssertUnwindSafe` as needed.

# Result
The added test `panic_in_parallel()` always succeeds instead of hanging.