### PR TITLE
Fix glob pattern to correctly ignore directories with only dots

### DIFF
--- a/crates/globset/src/pathutil.rs
+++ b/crates/globset/src/pathutil.rs
@@ -7,7 +7,7 @@ use bstr::{ByteSlice, ByteVec};
 /// If the path terminates in `.`, `..`, or consists solely of a root of
 /// prefix, file_name will return None.
 pub(crate) fn file_name<'a>(path: &Cow<'a, [u8]>) -> Option<Cow<'a, [u8]>> {
-    if path.last_byte().map_or(true, |b| b == b'.') {
+    if path.iter().all(|&b| b == b'.') {
         return None;
     }
     let last_slash = path.rfind_byte(b'/').map(|i| i + 1).unwrap_or(0);


### PR DESCRIPTION
This PR addresses [issue #2990](https://github.com/BurntSushi/ripgrep/issues/2990), where `ripgrep` did not properly ignore directories named only with dots (e.g., `.`, `..`, `...`) when using negated glob patterns (`-g '!dir'`).  

Previously, the `file_name` function in `globset` only checked if the last byte was a dot (`.`), which led to incorrect behavior. This caused:  
- `rg --files -g '!asdf.'` still listing `asdf./foo`  
- But `rg --files -g '!asdf'` correctly ignoring `asdf/foo`  

### Fix  
The function now ensures that entire filenames made only of dots are ignored by using:  
```rust
if path.iter().all(|&b| b == b'.') {
    return None;
}
