### PR TITLE
Implement `IntoIterator` for `GlobSetBuilder`

### DIFF
--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -514,6 +514,16 @@ impl GlobSetBuilder {
     }
 }
 
+impl<'a> IntoIterator for &'a GlobSetBuilder {
+    type Item = &'a Glob;
+    type IntoIter = std::slice::Iter<'a, Glob>;
+
+    /// Returns an iterator over the globs in this set.
+    fn into_iter(self) -> Self::IntoIter {
+        self.pats.iter()
+    }
+}
+
 /// A candidate path for matching.
 ///
 /// All glob matching in this crate operates on `Candidate` values.
@@ -1031,5 +1041,22 @@ mod tests {
 
         let matches = set.matches("nada");
         assert_eq!(0, matches.len());
+    }
+
+    #[test]
+    fn set_builder_can_be_iterated() {
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("src/**/*.rs").unwrap());
+        builder.add(Glob::new("*.c").unwrap());
+        builder.add(Glob::new("src/lib.rs").unwrap());
+
+        assert_eq!(
+            builder.into_iter().collect::<Vec<_>>(),
+            &[
+                &Glob::new("src/**/*.rs").unwrap(),
+                &Glob::new("*.c").unwrap(),
+                &Glob::new("src/lib.rs").unwrap(),
+            ]
+        );
     }
 }


### PR DESCRIPTION
Originally reported here: https://github.com/BurntSushi/globset/issues/8

This PR fixes the linked issue. See below:

---

The `Debug` implementation of `GlobSetBuilder` is quite noisy. For better introspectability in consuming packages, it would be perfect if one of two things could be implemented, so the `Debug` implementation can be adjusted (favorite) or is more readable:

1. An `IntoIterator<Item = &Glob>` implementation for `&GlobSetBuilder`, so we can use the `Display` implementation of `Glob` where applicable. This would be a non-invasive addition, as the consumer can decide what style they want.
2. A `Debug` implementation for `GlobSetBuilder` that does 1., i.e., prints `Glob` via `Display`.

I'm happy to send a PR for either of which, if this is a good match.

### Example

``` rust 
#[cfg(test)]
mod tests {
    use globset::{Glob, GlobSetBuilder};

    #[test]
    fn test() -> Result<(), Box<dyn std::error::Error>> {
        let mut builder = GlobSetBuilder::new();
        builder.add(Glob::new("src/**/*.rs")?);
        builder.add(Glob::new("*.txt")?);
        builder.add(Glob::new("docs/**/*.md")?);
        println!("{:#?}", builder);
        Ok(())
    }
}
```

### Current Result

``` rust
GlobSetBuilder {
    pats: [
        Glob {
            glob: "src/**/*.rs",
            re: "(?-u)^src(?:/|/.*/).*\\.rs$",
            opts: GlobOptions {
                case_insensitive: false,
                literal_separator: false,
                backslash_escape: true,
            },
            tokens: Tokens(
                [
                    Literal(
                        's',
                    ),
                    Literal(
                        'r',
                    ),
                    Literal(
                        'c',
                    ),
                    RecursiveZeroOrMore,
                    ZeroOrMore,
                    Literal(
                        '.',
                    ),
                    Literal(
                        'r',
                    ),
                    Literal(
                        's',
                    ),
                ],
            ),
        },
        Glob {
            glob: "*.txt",
            re: "(?-u)^.*\\.txt$",
            opts: GlobOptions {
                case_insensitive: false,
                literal_separator: false,
                backslash_escape: true,
            },
            tokens: Tokens(
                [
                    ZeroOrMore,
                    Literal(
                        '.',
                    ),
                    Literal(
                        't',
                    ),
                    Literal(
                        'x',
                    ),
                    Literal(
                        't',
                    ),
                ],
            ),
        },
        Glob {
            glob: "docs/**/*.md",
            re: "(?-u)^docs(?:/|/.*/).*\\.md$",
            opts: GlobOptions {
                case_insensitive: false,
                literal_separator: false,
                backslash_escape: true,
            },
            tokens: Tokens(
                [
                    Literal(
                        'd',
                    ),
                    Literal(
                        'o',
                    ),
                    Literal(
                        'c',
                    ),
                    Literal(
                        's',
                    ),
                    RecursiveZeroOrMore,
                    ZeroOrMore,
                    Literal(
                        '.',
                    ),
                    Literal(
                        'm',
                    ),
                    Literal(
                        'd',
                    ),
                ],
            ),
        },
    ],
}
```

### Ideal Result:

``` rust
GlobSetBuilder {
    pats: [
        "src/**/*.rs",
        "*.txt",
        "docs/**/*.md",
    ]
}
```

Oh and thanks for this library, it is awesome!