### PR TITLE
build: emit warning if git is missing during build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -37,10 +37,22 @@ fn set_git_revision_hash() {
     use std::process::Command;
 
     let args = &["rev-parse", "--short=10", "HEAD"];
-    let Ok(output) = Command::new("git").args(args).output() else { return };
-    let rev = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if rev.is_empty() {
-        return;
+    let output = Command::new("git").args(args).output();
+    match output {
+        Ok(output) => {
+            let rev =
+                String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if rev.is_empty() {
+                return;
+            }
+            println!("cargo:rustc-env=RIPGREP_BUILD_GIT_HASH={}", rev);
+        }
+        Err(e) => {
+            eprintln!(
+                "cargo:warning=git not found, skipping commit hash embed (error: {}).",
+                e
+            );
+            return;
+        }
     }
-    println!("cargo:rustc-env=RIPGREP_BUILD_GIT_HASH={}", rev);
 }


### PR DESCRIPTION
Adds a cargo:warning if git is not available during build.
This makes it easier to understand why RIPGREP_BUILD_GIT_HASH might be missing, without breaking the build.