### PR TITLE
ignore/types: add .env to sh type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -235,7 +235,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["seed7"], &["*.sd7", "*.s7i"]),
     (&["sh"], &[
         // Portable/misc. init files
-        ".login", ".logout", ".profile", "profile",
+        ".env", ".login", ".logout", ".profile", "profile",
         // bash-specific init files
         ".bash_login", "bash_login",
         ".bash_logout", "bash_logout",
@@ -254,7 +254,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         ".zprofile", "zprofile",
         ".zshrc", "zshrc",
         // Extensions
-        "*.bash", "*.csh", "*.ksh", "*.sh", "*.tcsh", "*.zsh",
+        "*.bash", "*.csh", "*.env", "*.ksh", "*.sh", "*.tcsh", "*.zsh",
     ]),
     (&["slim"], &["*.skim", "*.slim", "*.slime"]),
     (&["smarty"], &["*.tpl"]),


### PR DESCRIPTION
`.env` or "dotenv" is used quite often in cross-compilation/embedded development environments to load environment variables, define shell functions or even to execute shell commands.
Just like `.zshenv` in this list, I think `.env` should also be added here.