### PR TITLE
fix(globset): make GlobSet::new public

### DIFF
--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -410,7 +410,9 @@ impl GlobSet {
         into.dedup();
     }
 
-    fn new(pats: &[Glob]) -> Result<GlobSet, Error> {
+    /// Builds a new matcher from a collection of Glob patterns.
+    pub fn new(pats: impl AsRef<[Glob]>) -> Result<GlobSet, Error> {
+        let pats = pats.as_ref();
         if pats.is_empty() {
             return Ok(GlobSet { len: 0, strats: vec![] });
         }


### PR DESCRIPTION
Currently, `GlobSet::new` is private and can only be accessed via the `GlobSetBuilder`.

However, `GlobSetBuilder` simply creates a `Vec<Glob>` and then invokes `GlobSet::new`. For users of `globset` who already have a `Vec<Glob>` (or similar), this design requires them to iterate over their `Vec<Glob>`, calling `GlobSetBuilder::add` for each `Glob`, thus constructing a new `Vec<Glob>` internal to the `GlobSetBuilder`.

This makes the consuming code unnecessarily verbose to and may result in some performance impact (not tested).