### PR TITLE
fix(tests): Increase sleep duration for sort file metadata tests on Windows AArch64

### DIFF
--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1092,16 +1092,22 @@ rgtest!(type_list, |_: Dir, mut cmd: TestCommand| {
 // This order is important when sorting them by system time-stamps.
 fn sort_setup(dir: Dir) {
     use std::{thread::sleep, time::Duration};
-
+    // As reported in https://github.com/BurntSushi/ripgrep/issues/3071
+    // this test fails if sufficient delay is not given on Windows/Aarch64.
+    let delay = if cfg!(all(windows, target_arch = "aarch64")) {
+        Duration::from_millis(1000)
+    } else {
+        Duration::from_millis(100)
+    };
     let sub_dir = dir.path().join("dir");
     dir.create("a", "test");
-    sleep(Duration::from_millis(100));
+    sleep(delay);
     dir.create_dir(&sub_dir);
-    sleep(Duration::from_millis(100));
+    sleep(delay);
     dir.create(sub_dir.join("c"), "test");
-    sleep(Duration::from_millis(100));
+    sleep(delay);
     dir.create("b", "test");
-    sleep(Duration::from_millis(100));
+    sleep(delay);
     dir.create(sub_dir.join("d"), "test");
 }
 


### PR DESCRIPTION
Use cfg! to assign a 1000ms delay only on Windows Aarch64 targets. As it is a compile time conditional, there should be no runtime overhead.

Closes #3071