### PR TITLE
ignore/types: add LLVM to default types

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -149,6 +149,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     ]),
     (&["lilypond"], &["*.ly", "*.ily"]),
     (&["lisp"], &["*.el", "*.jl", "*.lisp", "*.lsp", "*.sc", "*.scm"]),
+    (&["llvm"], &["*.ll"]),
     (&["lock"], &["*.lock", "package-lock.json"]),
     (&["log"], &["*.log"]),
     (&["lua"], &["*.lua"]),


### PR DESCRIPTION
Hello ripgrep maintainers and community,

This PR adds `llvm` to the list of default types, matching files with extension `ll` which is used widely for the textual form of [LLVM's Intermediate Representation](https://llvm.org/docs/LangRef.html).

Let me know what you think.

Finally, I would like to thank you for this great tool, it has been extremely useful to me over many years.

