### PR TITLE
add complection for built-in `--hyperlink-format`s

### DIFF
--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -2953,6 +2953,21 @@ https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
 "#
     }
 
+    fn doc_choices(&self) -> &'static [&'static str] {
+        &[
+            "default",
+            "none",
+            "file",
+            "grep+",
+            "kitty",
+            "macvim",
+            "textmate",
+            "vscode",
+            "vscode-insiders",
+            "vscodium",
+        ]
+    }
+
     fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
         let v = v.unwrap_value();
         let string = convert::str(&v)?;
@@ -7665,9 +7680,10 @@ mod tests {
                 assert!(
                     choice.chars().all(|c| c.is_ascii_alphanumeric()
                         || c == '-'
-                        || c == ':'),
+                        || c == ':'
+                        || c == '+'),
                     "choice '{choice}' for flag '{long}' does not match \
-                     ^[-:0-9A-Za-z]+$",
+                     ^[-+:0-9A-Za-z]+$",
                 )
             }
         }


### PR DESCRIPTION
The goal is to make the completion for `rg --hyperlink-format v<TAB>` work in the fish shell.

These are not exhaustive (the user can also specify custom formats). If this ever makes a difference, perhaps `fn
doc_choices_are_exhaustive(&self) -> bool` can be added to the `Flags` trait.

The `grep+` value necessitated a change to a test.

I'm not sure whether there's a good way to generate the choices directly from `hyperlink_aliases.rs` as a `&'static [&'static str]`. The simplest would be to reorganize `hyperlink_aliases.rs` to keep the keys and values in separate arrays, but that would be less readable. This would be easy if the return type of `doc_choices` could be changed. OTOH, the values already need to be kept in sync with the long-form description inside the help text, which currently also has to be an `&'static str`.