### PR TITLE
complete/zsh: improve --hyperlink-format completion

### DIFF
--- a/crates/core/flags/complete/rg.zsh
+++ b/crates/core/flags/complete/rg.zsh
@@ -319,7 +319,7 @@ _rg() {
     '--field-context-separator[set string to delimit fields in context lines]'
     '--field-match-separator[set string to delimit fields in matching lines]'
     '--hostname-bin=[executable for getting system hostname]:hostname executable:_command_names -e'
-    '--hyperlink-format=[specify pattern for hyperlinks]:pattern'
+    '--hyperlink-format=[specify pattern for hyperlinks]: :_rg_hyperlink_formats'
     '--trace[show more verbose debug messages]'
     '--dfa-size-limit=[specify upper size limit of generated DFA]:DFA size (bytes)'
     "(1 stats)--files[show each file that would be searched (but don't search)]"
@@ -409,6 +409,7 @@ _rg() {
 }
 
 # Complete encodings
+(( $+functions[_rg_encodings] )) ||
 _rg_encodings() {
   local -a expl
   local -aU _encodings
@@ -421,6 +422,7 @@ _rg_encodings() {
 }
 
 # Complete file types
+(( $+functions[_rg_types] )) ||
 _rg_types() {
   local -a expl
   local -aU _types
@@ -432,6 +434,58 @@ _rg_types() {
   else
     _wanted types expl 'file type' compadd "$@" - ${(@)_types%%:*}
   fi
+}
+
+# Complete hyperlink format-string aliases
+(( $+functions[_rg_hyperlink_format_aliases] )) ||
+_rg_hyperlink_format_aliases() {
+  _describe -t format-aliases 'hyperlink format alias' '(
+    none:"disable hyperlinks"
+    default:"RFC 8089 scheme (file://) (platform-aware)"
+    file:"RFC 8089 scheme (file://) with host"
+    grep+:"grep+ scheme (grep+://)"
+    kitty:"kitty-style RFC 8089 scheme (file://) with line number"
+    macvim:"MacVim scheme (mvim://)"
+    textmate:"TextMate scheme (txmt://)"
+    vscode:"VS Code scheme (vscode://)"
+    vscode-insiders:"VS Code Insiders scheme (vscode-insiders://)"
+    vscodium:"VSCodium scheme (vscodium://)"
+  )'
+}
+
+# Complete custom hyperlink format strings
+(( $+functions[_rg_hyperlink_format_strings] )) ||
+_rg_hyperlink_format_strings() {
+  local op='{' ed='}'
+  local -a pfx sfx rmv
+
+  compquote op ed
+
+  sfx=( -S $ed )
+  rmv=( -r ${(q)ed[1]} )
+
+  compset -S "$op*"
+  compset -S "$ed*" && sfx=( -S '' )
+  compset -P "*$ed"
+  compset -p ${#PREFIX%$op*}
+  compset -P $op || pfx=( -P $op )
+
+  WSL_DISTRO_NAME=${WSL_DISTRO_NAME:-\$WSL_DISTRO_NAME} \
+  _describe -t format-variables 'hyperlink format variable' '(
+    path:"absolute path to file containing match (required)"
+    host:"system host name or output of --hostname-bin executable"
+    line:"line number of match"
+    column:"column of match (requires {line})"
+    wslprefix:"\"wsl$/$WSL_DISTRO_NAME\" (for WSL share)"
+  )' "${(@)pfx}" "${(@)sfx}" "${(@)rmv}"
+}
+
+# Complete hyperlink formats
+(( $+functions[_rg_hyperlink_formats] )) ||
+_rg_hyperlink_formats() {
+  _alternative \
+    'format-string-aliases: :_rg_hyperlink_format_aliases' \
+    'format-strings: :_rg_hyperlink_format_strings'
 }
 
 # Don't run the completion function when being sourced by itself.


### PR DESCRIPTION
here's better completion for `--hyperlink-format`

three known annoyances:

* zsh doesn't perform brace expansion on single words, so users might be inclined to leave the variable braces unquoted, as in `--hyperlink-format=foo://{path}`. but i guess it generally assumes that it might and handles it at an earlier stage, which means our function doesn't even know the `{` is there. this causes unexpected behaviour. there is also a bug (i assume zsh's rather than mine but idk) where it re-inserts the `{` in a weird place, e.g. `\{ho{st\}`

* zsh converts the the argument in `--opt=arg` style options to the `\`-escaped (rather than quoted) form when completing it, which is not pleasant with the syntax used here and exacerbates the above issue

* if you have like `--hyperlink-format '{}`, press tab between the `{}`, and then press `}` after adding one of the matches, it won't swallow the extra `}`

off the top of my head idk if there's anything to be done about the first two. the last one can probably be fixed with `compadd -R` or sth. but tbh i got bored of the problem

if these limitations bother you i can simplify it so it only tries to complete the aliases i guess

i also made it so helper functions aren't re-defined if they exist. this is a convention of many completion functions that allows end-users to more easily define their own helpers if they want them to behave differently. i just forgot to do it before