### PR TITLE
Add line highlighting support for matching lines

### DIFF
--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -751,7 +751,8 @@ the \flag{colors} flag to manually set all color styles to \fBnone\fP:
     \-\-colors 'path:none' \\
     \-\-colors 'line:none' \\
     \-\-colors 'column:none' \\
-    \-\-colors 'match:none'
+    \-\-colors 'match:none' \\
+    \-\-colors 'highlight:none'
 .EE
 .sp
 "
@@ -839,7 +840,7 @@ are limited to \fBnobold\fP, \fBbold\fP, \fBnointense\fP, \fBintense\fP,
 .sp
 The format of the flag is
 \fB{\fP\fItype\fP\fB}:{\fP\fIattribute\fP\fB}:{\fP\fIvalue\fP\fB}\fP.
-\fItype\fP should be one of \fBpath\fP, \fBline\fP, \fBcolumn\fP or
+\fItype\fP should be one of \fBpath\fP, \fBline\fP, \fBcolumn\fP, \fBhighlight\fP or
 \fBmatch\fP. \fIattribute\fP can be \fBfg\fP, \fBbg\fP or \fBstyle\fP.
 \fIvalue\fP is either a color (for \fBfg\fP and \fBbg\fP) or a text style. A
 special format, \fB{\fP\fItype\fP\fB}:none\fP, will clear all color settings
@@ -906,6 +907,24 @@ fn test_colors() {
         vec![
             "match:fg:magenta".parse().unwrap(),
             "line:bg:yellow".parse().unwrap()
+        ]
+    );
+
+    let args = parse_low_raw(["--colors", "highlight:bg:240"]).unwrap();
+    assert_eq!(args.colors, vec!["highlight:bg:240".parse().unwrap()]);
+
+    let args = parse_low_raw([
+        "--colors",
+        "match:fg:magenta",
+        "--colors",
+        "highlight:bg:blue",
+    ])
+    .unwrap();
+    assert_eq!(
+        args.colors,
+        vec![
+            "match:fg:magenta".parse().unwrap(),
+            "highlight:bg:blue".parse().unwrap()
         ]
     );
 }

--- a/crates/printer/src/color.rs
+++ b/crates/printer/src/color.rs
@@ -51,7 +51,7 @@ impl std::fmt::Display for ColorError {
             ColorError::UnrecognizedOutType(ref name) => write!(
                 f,
                 "unrecognized output type '{}'. Choose from: \
-                 path, line, column, match.",
+                path, line, column, match, highlight.",
                 name,
             ),
             ColorError::UnrecognizedSpecType(ref name) => write!(
@@ -64,14 +64,14 @@ impl std::fmt::Display for ColorError {
             ColorError::UnrecognizedStyle(ref name) => write!(
                 f,
                 "unrecognized style attribute '{}'. Choose from: \
-                 nobold, bold, nointense, intense, nounderline, \
-                 underline.",
+                nobold, bold, nointense, intense, nounderline, \
+                underline.",
                 name,
             ),
             ColorError::InvalidFormat(ref original) => write!(
                 f,
                 "invalid color spec format: '{}'. Valid format \
-                 is '(path|line|column|match):(fg|bg|style):(value)'.",
+                is '(path|line|column|match|highlight):(fg|bg|style):(value)'.",
                 original,
             ),
         }
@@ -90,6 +90,7 @@ pub struct ColorSpecs {
     line: ColorSpec,
     column: ColorSpec,
     matched: ColorSpec,
+    highlight: ColorSpec,
 }
 
 /// A single color specification provided by the user.
@@ -99,7 +100,7 @@ pub struct ColorSpecs {
 /// The format of a `Spec` is a triple: `{type}:{attribute}:{value}`. Each
 /// component is defined as follows:
 ///
-/// * `{type}` can be one of `path`, `line`, `column` or `match`.
+/// * `{type}` can be one of `path`, `line`, `column`, `match` or `highlight`.
 /// * `{attribute}` can be one of `fg`, `bg` or `style`. `{attribute}` may also
 ///   be the special value `none`, in which case, `{value}` can be omitted.
 /// * `{value}` is either a color name (for `fg`/`bg`) or a style instruction.
@@ -181,6 +182,7 @@ enum OutType {
     Line,
     Column,
     Match,
+    Highlight,
 }
 
 /// The specification type.
@@ -214,6 +216,7 @@ impl ColorSpecs {
                 OutType::Line => spec.merge_into(&mut merged.line),
                 OutType::Column => spec.merge_into(&mut merged.column),
                 OutType::Match => spec.merge_into(&mut merged.matched),
+                OutType::Highlight => spec.merge_into(&mut merged.highlight),
             }
         }
         merged
@@ -246,6 +249,11 @@ impl ColorSpecs {
     /// Return the color specification for coloring matched text.
     pub fn matched(&self) -> &ColorSpec {
         &self.matched
+    }
+
+    /// Return the color specification for coloring entire line if there is a matched text.
+    pub fn highlight(&self) -> &ColorSpec {
+        &self.highlight
     }
 }
 
@@ -340,6 +348,7 @@ impl std::str::FromStr for OutType {
             "line" => Ok(OutType::Line),
             "column" => Ok(OutType::Column),
             "match" => Ok(OutType::Match),
+            "highlight" => Ok(OutType::Highlight),
             _ => Err(ColorError::UnrecognizedOutType(s.to_string())),
         }
     }


### PR DESCRIPTION
Implement a new "highlight" feature for the '--colors' flag that allows users to highlight entire matching lines with background color.

 It is important to note that this feature gets disabled if '--colors' flag is used with 'match:none' as it depends on matching detection.

Documentation in crates/core/flags/defs.rs is updated.

Fixes #3024