### PR TITLE
msrv: bump to Rust 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.74.0
+          rust: 1.88.0
         - build: stable
           os: ubuntu-latest
           rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 build = "build.rs"
 autotests = false
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.88"
 
 [[bin]]
 bench = false

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ $ sudo xbps-install -Syv ripgrep
 
 If you're a **Rust programmer**, ripgrep can be installed with `cargo`.
 
-* Note that the minimum supported version of Rust for ripgrep is **1.72.0**,
+* Note that the minimum supported version of Rust for ripgrep is **1.88.0**,
   although ripgrep may work with older versions.
 * Note that the binary may be bigger than expected because it contains debug
   symbols. This is intentional. To remove debug symbols and therefore reduce
@@ -435,7 +435,7 @@ $ cargo binstall ripgrep
 
 ripgrep is written in Rust, so you'll need to grab a
 [Rust installation](https://www.rust-lang.org/) in order to compile it.
-ripgrep compiles with Rust 1.72.0 (stable) or newer. In general, ripgrep tracks
+ripgrep compiles with Rust 1.88.0 (stable) or newer. In general, ripgrep tracks
 the latest stable release of the Rust compiler.
 
 To build ripgrep:


### PR DESCRIPTION
This is to prep for the next release. I don't know if the requirement
will actually be for Rust 1.88, but it is intended to support the latest
version of stable Rust.
