### PR TITLE
ignore: look for .gitignore's in Jujutsu repos

### DIFF
--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -212,7 +212,7 @@ impl Ignore {
             igtmp.absolute_base = Some(absolute_base.clone());
             igtmp.has_git =
                 if self.0.opts.require_git && self.0.opts.git_ignore {
-                    parent.join(".git").exists()
+                    parent.join(".git").exists() || parent.join(".jj").exists()
                 } else {
                     false
                 };
@@ -247,7 +247,11 @@ impl Ignore {
         let git_type = if self.0.opts.require_git
             && (self.0.opts.git_ignore || self.0.opts.git_exclude)
         {
-            dir.join(".git").metadata().ok().map(|md| md.file_type())
+            dir.join(".git")
+                .metadata()
+                .or_else(|_| dir.join(".jj").metadata())
+                .ok()
+                .map(|md| md.file_type())
         } else {
             None
         };

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -2076,6 +2076,43 @@ mod tests {
     }
 
     #[test]
+    fn gitignore_in_jj() {
+        let td = tmpdir();
+        mkdirp(td.path().join(".jj"));
+        mkdirp(td.path().join("a"));
+        wfile(td.path().join(".gitignore"), "foo");
+        wfile(td.path().join("foo"), "");
+        wfile(td.path().join("a/foo"), "");
+        wfile(td.path().join("bar"), "");
+        wfile(td.path().join("a/bar"), "");
+
+        assert_paths(
+            td.path(),
+            &WalkBuilder::new(td.path()),
+            &["bar", "a", "a/bar"],
+        );
+    }
+
+    #[test]
+    fn gitignore_in_jj_child() {
+        let td = tmpdir();
+        mkdirp(td.path().join(".jj"));
+        mkdirp(td.path().join("a"));
+        wfile(td.path().join(".gitignore"), "foo");
+        wfile(td.path().join("foo"), "");
+        wfile(td.path().join("a/foo"), "");
+        wfile(td.path().join("bar"), "");
+        wfile(td.path().join("a/bar"), "");
+
+        let child_path = td.path().join("a");
+        assert_paths(
+            &child_path,
+            &WalkBuilder::new(child_path.clone()),
+            &["bar"],
+        );
+    }
+
+    #[test]
     fn explicit_ignore() {
         let td = tmpdir();
         let igpath = td.path().join(".not-an-ignore");


### PR DESCRIPTION
In the context of a non-colocated Jujutsu (jj) repository, .gitignore's retain their meaning, but .git directories aren't present. This commit amends ignore to look for jj repos when deciding whether or not to also acknowledge a .gitignore.

I've of course tested this patch and everything that I can see works fine, but do let me know if I've missed anything. Thanks a ton!