### PR TITLE
globset: allow nested alternatives

### DIFF
--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -81,7 +81,6 @@ Standard Unix-style glob syntax is supported:
   the pattern, then it matches zero or more directories. Using `**` anywhere
   else is illegal (N.B. the glob `**` is allowed and means "match everything").
 * `{a,b}` matches `a` or `b` where `a` and `b` are arbitrary glob patterns.
-  (N.B. Nesting `{...}` is not currently allowed.)
 * `[ab]` matches `a` or `b` where `a` and `b` are characters. Use
   `[!ab]` to match any character except for `a` and `b`.
 * Metacharacters such as `*` and `?` can be escaped with character class
@@ -169,8 +168,10 @@ pub enum ErrorKind {
     UnopenedAlternates,
     /// Occurs when a `{` is found without a matching `}`.
     UnclosedAlternates,
-    /// Occurs when an alternating group is nested inside another alternating
-    /// group, e.g., `{{a,b},{c,d}}`.
+    /// **DEPRECATED**
+    ///
+    /// This error used to occur when an alternating group is nested inside
+    /// another alternating group, e.g., `{{a,b},{c,d}}`. This is now allowed.
     NestedAlternates,
     /// Occurs when an unescaped '\' is found at the end of a glob.
     DanglingEscape,


### PR DESCRIPTION
Hello. I have a use case where it would be great if nested alternatives were supported in globset. Namely, the [Helix editor](github.com/helix-editor/helix) uses globset for [Editorconfig](https://spec.editorconfig.org/), which allows nested alternatives. It is used in the real world by the Linux kernel (see the [Linux editorconfig](https://github.com/torvalds/linux/blob/master/.editorconfig#L5) with nested alternatives).

Unix shells like Bash and Fish support this kind of syntax and the documentation of globset states that "Nesting `{...}` is not **currently** allowed" (emphasis mine)

So I assume this feature is in-scope for the globset crate. I'm happy to improve the implementation if there is any feedback. Thank you for taking a look!