### PR TITLE
--cursor-ignore ripgrep option

### DIFF
--- a/crates/core/flags/complete/rg.zsh
+++ b/crates/core/flags/complete/rg.zsh
@@ -324,6 +324,7 @@ _rg() {
     '--dfa-size-limit=[specify upper size limit of generated DFA]:DFA size (bytes)'
     "(1 stats)--files[show each file that would be searched (but don't search)]"
     '*--ignore-file=[specify additional ignore file]:ignore file:_files'
+    '*--cursor-ignore=[specify high-precedence ignore file]:ignore file:_files'
     '(-v --invert-match)'{-v,--invert-match}'[invert matching]'
     $no"--no-invert-match[do not invert matching]"
     '(-M --max-columns)'{-M+,--max-columns=}'[specify max length of lines to print]:number of bytes'

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -82,6 +82,7 @@ pub(super) const FLAGS: &[&dyn Flag] = &[
     &IGlob,
     &IgnoreCase,
     &IgnoreFile,
+    &CursorIgnore,
     &IgnoreFileCaseInsensitive,
     &IncludeZero,
     &InvertMatch,
@@ -3159,6 +3160,36 @@ directly on the command line, then use \flag{glob} instead.
     fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
         let path = PathBuf::from(v.unwrap_value());
         args.ignore_file.push(path);
+        Ok(())
+    }
+}
+
+/// --cursor-ignore
+#[derive(Debug)]
+struct CursorIgnore;
+
+impl Flag for CursorIgnore {
+    fn is_switch(&self) -> bool { false }
+    fn name_long(&self) -> &'static str { "cursor-ignore" }
+    fn doc_variable(&self) -> Option<&'static str> { Some("PATH") }
+    fn doc_category(&self) -> Category { Category::Filter }
+    fn doc_short(&self) -> &'static str {
+        r"Specify high-precedence ignore files (applied before -g/--glob)."
+    }
+    fn doc_long(&self) -> &'static str {
+        r"
+Specifies a path to one or more gitignore-formatted rules files that are
+applied with higher precedence than -g/--glob overrides. These rules can
+exclude files even when a glob would otherwise include them. Multiple files
+may be specified by repeating this flag; later files have higher precedence.
+.sp
+This behaves like \flag{ignore-file} except for its higher precedence.
+"
+    }
+    fn completion_type(&self) -> CompletionType { CompletionType::Filename }
+    fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
+        let path = PathBuf::from(v.unwrap_value());
+        args.cursor_ignore.push(path);
         Ok(())
     }
 }

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -3169,10 +3169,18 @@ directly on the command line, then use \flag{glob} instead.
 struct CursorIgnore;
 
 impl Flag for CursorIgnore {
-    fn is_switch(&self) -> bool { false }
-    fn name_long(&self) -> &'static str { "cursor-ignore" }
-    fn doc_variable(&self) -> Option<&'static str> { Some("PATH") }
-    fn doc_category(&self) -> Category { Category::Filter }
+    fn is_switch(&self) -> bool {
+        false
+    }
+    fn name_long(&self) -> &'static str {
+        "cursor-ignore"
+    }
+    fn doc_variable(&self) -> Option<&'static str> {
+        Some("PATH")
+    }
+    fn doc_category(&self) -> Category {
+        Category::Filter
+    }
     fn doc_short(&self) -> &'static str {
         r"Specify high-precedence ignore files (applied before -g/--glob)."
     }
@@ -3186,7 +3194,9 @@ may be specified by repeating this flag; later files have higher precedence.
 This behaves like \flag{ignore-file} except for its higher precedence.
 "
     }
-    fn completion_type(&self) -> CompletionType { CompletionType::Filename }
+    fn completion_type(&self) -> CompletionType {
+        CompletionType::Filename
+    }
     fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
         let path = PathBuf::from(v.unwrap_value());
         args.cursor_ignore.push(path);

--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -59,6 +59,8 @@ pub(crate) struct HiArgs {
     hyperlink_config: grep::printer::HyperlinkConfig,
     ignore_file_case_insensitive: bool,
     ignore_file: Vec<PathBuf>,
+    /// Additional high-precedence ignore files (see --cursor-ignore)
+    cursor_ignore: Vec<PathBuf>,
     include_zero: bool,
     invert_match: bool,
     is_terminal_stdout: bool,
@@ -274,6 +276,7 @@ impl HiArgs {
             hidden: low.hidden,
             hyperlink_config,
             ignore_file: low.ignore_file,
+            cursor_ignore: low.cursor_ignore,
             ignore_file_case_insensitive: low.ignore_file_case_insensitive,
             include_zero: low.include_zero,
             invert_match: low.invert_match,
@@ -873,6 +876,12 @@ impl HiArgs {
         if !self.no_ignore_files {
             for path in self.ignore_file.iter() {
                 if let Some(err) = builder.add_ignore(path) {
+                    ignore_message!("{err}");
+                }
+            }
+            // Apply high-precedence cursor ignore files
+            for path in self.cursor_ignore.iter() {
+                if let Some(err) = builder.add_cursor_ignore(path) {
                     ignore_message!("{err}");
                 }
             }

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -63,6 +63,8 @@ pub(crate) struct LowArgs {
     pub(crate) hyperlink_format: HyperlinkFormat,
     pub(crate) iglobs: Vec<String>,
     pub(crate) ignore_file: Vec<PathBuf>,
+    /// Additional high-precedence ignore files (see --cursor-ignore)
+    pub(crate) cursor_ignore: Vec<PathBuf>,
     pub(crate) ignore_file_case_insensitive: bool,
     pub(crate) include_zero: bool,
     pub(crate) invert_match: bool,

--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -383,8 +383,11 @@ impl Ignore {
         if !self.0.cursor_ignores.is_empty() {
             let mut m_cursor = Match::None;
             for gi in self.0.cursor_ignores.iter().rev() {
-                if !m_cursor.is_none() { break; }
-                m_cursor = gi.matched(path, is_dir).map(IgnoreMatch::gitignore);
+                if !m_cursor.is_none() {
+                    break;
+                }
+                m_cursor =
+                    gi.matched(path, is_dir).map(IgnoreMatch::gitignore);
             }
             if m_cursor.is_ignore() {
                 return m_cursor;

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -670,6 +670,28 @@ impl WalkBuilder {
         errs.into_error_option()
     }
 
+    /// Add a high-precedence cursor ignore file to the matcher.
+    ///
+    /// These rules are applied before override globs from `-g/--glob` and
+    /// therefore can filter entries even when a glob would otherwise match.
+    pub fn add_cursor_ignore<P: AsRef<Path>>(
+        &mut self,
+        path: P,
+    ) -> Option<Error> {
+        let mut builder = GitignoreBuilder::new("");
+        let mut errs = PartialErrorBuilder::default();
+        errs.maybe_push(builder.add(path));
+        match builder.build() {
+            Ok(gi) => {
+                self.ig_builder.add_cursor_ignore(gi);
+            }
+            Err(err) => {
+                errs.push(err);
+            }
+        }
+        errs.into_error_option()
+    }
+
     /// Add a custom ignore file name
     ///
     /// These ignore files have higher precedence than all other ignore files.


### PR DESCRIPTION
Adds a --cursor-ignore option for ripgrep. It behaves the same as --ignore-file, except it acts as a strict filter.

--ignore-file is lower precedence than --glob, so glob matches can match contents that are normally .gitignored.

The --cursor-ignore option blocks .cursorignore options even if a --glob arg would match them.