### PR TITLE
Include missing files for the Terraform type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -281,9 +281,8 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["texinfo"], &["*.texi"]),
     (&["textile"], &["*.textile"]),
     (&["tf"], &[
-        "*.tf", "*.auto.tfvars", "terraform.tfvars", "*.tf.json",
-        "*.auto.tfvars.json", "terraform.tfvars.json", "*.terraformrc",
-        "terraform.rc", "*.tfrc", "*.terraform.lock.hcl",
+        "*.tf", "*.tf.json", "*.tfvars", "*.tfvars.json",
+        "*.terraformrc", "terraform.rc", "*.tfrc", "*.terraform.lock.hcl",
     ]),
     (&["thrift"], &["*.thrift"]),
     (&["toml"], &["*.toml", "Cargo.lock"]),


### PR DESCRIPTION
Existing matches were too restrictives, so we simplify those to every type of tfvars file we can encounter.