### PR TITLE
fix: exit code for -q --files-without-match combination

### DIFF
--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -561,7 +561,7 @@ impl HiArgs {
         search_mode: SearchMode,
         wtr: W,
     ) -> Printer<W> {
-        let summary_kind = if self.quiet {
+        let summary_kind = if self.quiet && !matches!(search_mode, SearchMode::FilesWithoutMatch) {
             SummaryKind::Quiet
         } else {
             match search_mode {


### PR DESCRIPTION
This is to resolve issue #3108 

Exit codes were inverted when using -q with --files-without-match. Quiet mode was overriding the search mode logic.

Before:
```
echo "no match" | rg -q --files-without-match pattern  # returned 1 ❌
echo "has match" | rg -q --files-without-match pattern # returned 0 ❌
```

After:
```
echo "no match" | rg -q --files-without-match pattern  # returns 0 ✅
echo "has match" | rg -q --files-without-match pattern # returns 1 ✅
```

Fix: Don't let quiet mode override FilesWithoutMatch summary kind.

One line change in hiargs.rs printer logic.