### PR TITLE
Fix broken command in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,8 @@ then ripgrep can be installed using a binary `.deb` file provided in each
 [ripgrep release](https://github.com/BurntSushi/ripgrep/releases).
 
 ```
-$ curl -LO https://github.com/BurntSushi/ripgrep/releases/download/14.1.0/ripgrep_14.1.1-1_amd64.deb
-$ sudo dpkg -i ripgrep_14.1.1-1_amd64.deb
+$ curl -LO https://github.com/BurntSushi/ripgrep/releases/download/14.1.0/ripgrep_14.1.0-1_amd64.deb
+$ sudo dpkg -i ripgrep_14.1.0-1_amd64.deb
 ```
 
 If you run Debian stable, ripgrep is [officially maintained by


### PR DESCRIPTION
The documentation uses the `ripgrep_14.1.1-1_amd64.deb` file from `https://github.com/BurntSushi/ripgrep/releases/download/14.1.0/ripgrep_14.1.1-1_amd64.deb` URL. But the name of file is `ripgrep_14.1.0-1_amd64` (not 14.1.1-1) as you can see [here](https://github.com/BurntSushi/ripgrep/releases/tag/14.1.0). This PR fixes this [issue](https://github.com/BurntSushi/ripgrep/issues/3083) By correcting name in second command.