### PR TITLE
doc: update CentOS/RHEL instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,13 +302,11 @@ and **openSUSE Leap** since 15.1.
 $ sudo zypper install ripgrep
 ```
 
-If you're a **RHEL/CentOS 7/8** user, you can install ripgrep from
-[copr](https://copr.fedorainfracloud.org/coprs/carlwgeorge/ripgrep/):
+If you're a **CentOS/RHEL** user, you can install ripgrep from the
+[EPEL](https://docs.fedoraproject.org/en-US/epel/getting-started/) repository.
 
 ```
-$ sudo yum install -y yum-utils
-$ sudo yum-config-manager --add-repo=https://copr.fedorainfracloud.org/coprs/carlwgeorge/ripgrep/repo/epel-7/carlwgeorge-ripgrep-epel-7.repo
-$ sudo yum install ripgrep
+$ sudo dnf install ripgrep
 ```
 
 If you're a **Nix** user, you can install ripgrep from


### PR DESCRIPTION
The copr repo is no longer needed as ripgrep has been available from EPEL for several years now.