### PR TITLE
docs: Add installation method with gah

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,12 @@ If you're a **Flox** user, you can install ripgrep as follows:
 $ flox install ripgrep
 ```
 
+If you're a **gah** user, you can install ripgrep as follows:
+
+```
+$ gah install ripgrep
+```
+
 If you're a **Guix** user, you can install ripgrep from the official
 package collection:
 


### PR DESCRIPTION
Hello!
This PR adds to the documentation installation method using [gah](https://github.com/marverix/gah):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.