### PR TITLE
fix example .ripgreprc in GUIDE.md

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -579,7 +579,7 @@ web:*.{html,css,js}*
 
 # or
 --glob
-!.git/*
+!.git/
 
 # Set the colors.
 --colors=line:none


### PR DESCRIPTION
`!.git/*` does not do what the example suggests, i.e. include general hidden files and directories, _except_ `.git/` folder contents. Matches inside `.git/` folders will instead be returned. Without the `*` it works as expected. Verified with `zsh`.