### PR TITLE
Add Qt types for resource files and ui declaration

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -210,6 +210,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["py", "python"], &["*.py", "*.pyi"]),
     (&["qmake"], &["*.pro", "*.pri", "*.prf"]),
     (&["qml"], &["*.qml"]),
+    (&["qrc"], &["*.qrc"]),
     (&["r"], &["*.R", "*.r", "*.Rmd", "*.Rnw"]),
     (&["racket"], &["*.rkt"]),
     (&["raku"], &[
@@ -291,6 +292,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["twig"], &["*.twig"]),
     (&["txt"], &["*.txt"]),
     (&["typoscript"], &["*.typoscript", "*.ts"]),
+    (&["ui"], &["*.ui"]),
     (&["usd"], &["*.usd", "*.usda", "*.usdc"]),
     (&["v"], &["*.v", "*.vsh"]),
     (&["vala"], &["*.vala"]),


### PR DESCRIPTION
qrc are the resource files for data related to user interfaces, and ui is the extension that the Qt Designer generates, for Widget based projects.