### PR TITLE
cli: --iglob filter paths in argv

### DIFF
--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -362,7 +362,7 @@ impl Ignore {
     /// ignored or not.
     ///
     /// The match contains information about its origin.
-    fn matched<'a, P: AsRef<Path>>(
+    pub(crate) fn matched<'a, P: AsRef<Path>>(
         &'a self,
         path: P,
         is_dir: bool,


### PR DESCRIPTION
`--{,i}glob` don't filter path in argv

can we add an option to support it or (this pr make it default now):
```sh
$ cargo run -- -e r LICENSE-MIT README.md --iglob '!*.md' --files
LICENSE-MIT
$ cargo run -- -e r LICENSE-MIT README.md --iglob '*.md' --files
README.md
```

For me paths in argv are built from fzf output, then I can use `--iglob` to filter the result in fzf live query again.
