### PR TITLE
fix: clippy errors

### DIFF
--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -177,7 +177,7 @@ impl DecompressionMatcher {
     /// If there are multiple possible commands matching the given path, then
     /// the command added last takes precedence.
     pub fn command<P: AsRef<Path>>(&self, path: P) -> Option<Command> {
-        for i in self.globs.matches(path).into_iter().rev() {
+        if let Some(i) = self.globs.matches(path).into_iter().next_back() {
             let decomp_cmd = &self.commands[i];
             let mut cmd = Command::new(&decomp_cmd.bin);
             cmd.args(&decomp_cmd.args);

--- a/crates/ignore/examples/walk.rs
+++ b/crates/ignore/examples/walk.rs
@@ -18,8 +18,8 @@ fn main() {
     let stdout_thread = std::thread::spawn(move || {
         let mut stdout = std::io::BufWriter::new(std::io::stdout());
         for dent in rx {
-            stdout.write(&*Vec::from_path_lossy(dent.path())).unwrap();
-            stdout.write(b"\n").unwrap();
+            stdout.write_all(&Vec::from_path_lossy(dent.path())).unwrap();
+            stdout.write_all(b"\n").unwrap();
         }
     });
 

--- a/crates/printer/src/json.rs
+++ b/crates/printer/src/json.rs
@@ -571,7 +571,7 @@ impl<W: io::Write> JSON<W> {
         } else {
             json::to_writer(&mut self.wtr, message)?;
         }
-        self.wtr.write(&[b'\n'])?;
+        let _ = self.wtr.write(b"\n")?; // This will always be Ok(1) when successful.
         Ok(())
     }
 }

--- a/crates/printer/src/jsont.rs
+++ b/crates/printer/src/jsont.rs
@@ -190,7 +190,7 @@ impl<'a> Data<'a> {
     }
 
     #[cfg(not(unix))]
-    fn from_path(path: &Path) -> Data {
+    fn from_path(path: &Path) -> Data<'_> {
         // Using lossy conversion means some paths won't round trip precisely,
         // but it's not clear what we should actually do. Serde rejects
         // non-UTF-8 paths, and OsStr's are serialized as a sequence of UTF-16


### PR DESCRIPTION
I opened the project in RustRover on Windows after you merged the rollup branch, and it showed a few Clippy errors. Those were displayed by highlighting a few files in red, which is annoying, so I thought I'd rather get rid of them.

This is basically the equivalent of handling the output of `cargo clippy -- -A warnings` with Rust 1.90 on Windows. (Clippy also shows 72 warnings without `-A warnings`, 60 of whose can be auto-applied, but I thought you wouldn't want a PR like that).

RustRover now only complains about the `#![feature(test)]` in the `globset` bench, but I don't think I can do anything about that without changing the toolchain or using another benching framework.

