### PR TITLE
cargo: set MSRV to 1.85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.88.0
+          rust: 1.85.0
         - build: stable
           os: ubuntu-latest
           rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 build = "build.rs"
 autotests = false
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.85"
 
 [[bin]]
 bench = false

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ $ sudo xbps-install -Syv ripgrep
 
 If you're a **Rust programmer**, ripgrep can be installed with `cargo`.
 
-* Note that the minimum supported version of Rust for ripgrep is **1.88.0**,
+* Note that the minimum supported version of Rust for ripgrep is **1.85.0**,
   although ripgrep may work with older versions.
 * Note that the binary may be bigger than expected because it contains debug
   symbols. This is intentional. To remove debug symbols and therefore reduce
@@ -437,7 +437,7 @@ $ cargo binstall ripgrep
 
 ripgrep is written in Rust, so you'll need to grab a
 [Rust installation](https://www.rust-lang.org/) in order to compile it.
-ripgrep compiles with Rust 1.88.0 (stable) or newer. In general, ripgrep tracks
+ripgrep compiles with Rust 1.85.0 (stable) or newer. In general, ripgrep tracks
 the latest stable release of the Rust compiler.
 
 To build ripgrep:


### PR DESCRIPTION
I believe the current stable version of Debian packages 1.85 rustc. So
if the next release of ripgrep uses a higher MSRV, then I think Debian
won't be able to package it.

It also turned out that I wasn't using anything from beyond Rust 1.85
anyway.

It's likely that I could make use of let-chains in various places, but I
don't think it's worth combing through the code to switch to them at
this point.
