### PR TITLE
printer: hack in a fix for `-l/--files-with-matches` when using `--pcre2 --multiline` with look-around

### DIFF
--- a/crates/printer/src/summary.rs
+++ b/crates/printer/src/summary.rs
@@ -683,7 +683,11 @@ impl<'p, 's, M: Matcher, W: WriteColor> Sink for SummarySink<'p, 's, M, W> {
                     true
                 },
             )?;
-            count
+            // Because of `find_iter_at_in_context` being a giant
+            // kludge internally, it's possible that it won't find
+            // *any* matches even though we clearly know that there is
+            // at least one. So make sure we record at least one here.
+            count.max(1)
         };
         if is_multi_line {
             self.match_count += sink_match_count;


### PR DESCRIPTION
The underlying issue here is #2528, which was introduced by commit
efd9cfb2fc1f0233de9eda4c03416d32ef2c3ce8 which fixed another bug.

For the specific case of "did a file match," we can always assume the
match count is at least 1 here. But this doesn't fix the underlying
problem.

Fixes #3139
