### PR TITLE
printer: finish removal of `max_matches`

### DIFF
--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -596,7 +596,6 @@ impl HiArgs {
     ) -> grep::printer::JSON<W> {
         grep::printer::JSONBuilder::new()
             .pretty(false)
-            .max_matches(self.max_count)
             .always_begin_end(false)
             .replacement(self.replace.clone().map(|r| r.into()))
             .build(wtr)
@@ -656,7 +655,6 @@ impl HiArgs {
             .exclude_zero(!self.include_zero)
             .hyperlink(self.hyperlink_config.clone())
             .kind(kind)
-            .max_matches(self.max_count)
             .path(self.with_filename)
             .path_terminator(self.path_terminator.clone())
             .separator_field(b":".to_vec())


### PR DESCRIPTION
This finishes what I started in commit
a6e0be3c909c5c09e5fb402c907f3beb88cfb4c4.
Specifically, the `max_matches` configuration has been moved to the
`grep-searcher` crate and *removed* from the `grep-printer` crate. The
commit message has the details for why we're doing this, but the short
story is to fix #3076 without other regressions.

Note that this is a breaking change for `grep-printer`, so this will
require a semver incompatible release.
