### PR TITLE
Add interactive CodeCanvas diagram for ripgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ Summarizing, ripgrep is fast because:
 
 Check out this interactive walkthrough of the `ripgrep` codebase on CodeCanvas [here](https://www.code-canvas.com/?session=unauthenticatedGithub&repo=ripgrep&owner=BurntSushi&branch=master&OnboardingTutorial=true).
 
-<img width="1916" alt="CodeCanvas Screenshot" src="https://codecanvas-media-public.s3.amazonaws.com/images/codecanvas-readme-screenshot.png" />
+<img width="2860" height="1338" alt="image" src="https://github.com/user-attachments/assets/c05f25ac-0d68-4bf8-a17e-8ccc56386230" />
+
 
 
 ### Feature comparison

--- a/README.md
+++ b/README.md
@@ -208,6 +208,15 @@ Summarizing, ripgrep is fast because:
   [`ignore`](https://docs.rs/ignore).
 
 
+### How does `ripgrep` work?
+
+Check out this interactive walkthrough of the `ripgrep` codebase on CodeCanvas [here](https://www.code-canvas.com/?session=unauthenticatedGithub&repo=ripgrep&owner=BurntSushi&branch=master&OnboardingTutorial=true).
+
+To update the diagram, follow the quick tutorial [here](https://docs.code-canvas.com/updating-diagram).
+
+<img width="1916" alt="CodeCanvas Screenshot" src="https://codecanvas-media-public.s3.amazonaws.com/images/codecanvas-readme-screenshot.png" />
+
+
 ### Feature comparison
 
 Andy Lester, author of [ack](https://beyondgrep.com/), has published an

--- a/README.md
+++ b/README.md
@@ -208,11 +208,9 @@ Summarizing, ripgrep is fast because:
   [`ignore`](https://docs.rs/ignore).
 
 
-### How does `ripgrep` work?
+### How does `ripgrep` work under the hood?
 
 Check out this interactive walkthrough of the `ripgrep` codebase on CodeCanvas [here](https://www.code-canvas.com/?session=unauthenticatedGithub&repo=ripgrep&owner=BurntSushi&branch=master&OnboardingTutorial=true).
-
-To update the diagram, follow the quick tutorial [here](https://docs.code-canvas.com/updating-diagram).
 
 <img width="1916" alt="CodeCanvas Screenshot" src="https://codecanvas-media-public.s3.amazonaws.com/images/codecanvas-readme-screenshot.png" />
 

--- a/ripgrep.CodeCanvas
+++ b/ripgrep.CodeCanvas
@@ -1,0 +1,6036 @@
+{
+	"drawioXML": "<mxfile>\n  <diagram id=\"lF8P7EKMFVM7NsQc4B7w\" name=\"Page-1\">\n    <mxGraphModel dx=\"14125\" dy=\"7845\" grid=\"0\" gridSize=\"10\" guides=\"1\" tooltips=\"1\" connect=\"0\" arrows=\"1\" fold=\"1\" page=\"0\" pageScale=\"1\" pageWidth=\"850\" pageHeight=\"1100\" math=\"0\" shadow=\"0\">\n      <root>\n        <mxCell id=\"0\" />\n        <mxCell id=\"1\" style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=9;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#fffefe\" parent=\"0\" />\n        <UserObject label=\"crates\" value=\"crates\" id=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=55;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#fffefe\" parent=\"1\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"11535\" height=\"3086.9947244486543\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"core\" value=\"core\" id=\"debf18dd-047e-44e4-9016-2ee07faaf18b\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=55;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f9f3f3\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" vertex=\"1\">\n            <mxGeometry x=\"135\" y=\"120\" width=\"4020\" height=\"2845.994724448655\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"main.rs\" value=\"main.rs\" id=\"0508ecd1-fc1d-499a-8811-8cfff3245a53\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=31;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f4e9e9\" parent=\"debf18dd-047e-44e4-9016-2ee07faaf18b\" vertex=\"1\">\n            <mxGeometry x=\"715\" y=\"2408.380640347422\" width=\"960\" height=\"367.614084101233\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Start Parallel Search - main.rs:L86-90\" value=\"Start Parallel Search - main.rs:L86-90\" id=\"f571f13d-a5b1-4696-810d-016af864988b\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"0508ecd1-fc1d-499a-8811-8cfff3245a53\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"207.614084101233\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Configure Parallel Directory Walker - main.rs:L185-187\" value=\"Configure Parallel Directory Walker - main.rs:L185-187\" id=\"bdea59c2-5355-45cb-babe-67dfd0c2717e\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"0508ecd1-fc1d-499a-8811-8cfff3245a53\" vertex=\"1\">\n            <mxGeometry x=\"390\" y=\"207.614084101233\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Worker Thread Processes a File Entry - main.rs:L193-200\" value=\"Worker Thread Processes a File Entry - main.rs:L193-200\" id=\"2196ff9f-2695-4b8a-8a75-d5702b89371f\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"0508ecd1-fc1d-499a-8811-8cfff3245a53\" vertex=\"1\">\n            <mxGeometry x=\"710\" y=\"167.69656267962813\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Consolidate and Print Buffered Output - main.rs:L204-211\" value=\"Consolidate and Print Buffered Output - main.rs:L204-211\" id=\"f6322f9f-f154-481a-a997-75b09226c146\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"0508ecd1-fc1d-499a-8811-8cfff3245a53\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"77.53878483181295\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Aggregate Final Results - main.rs:L220-228\" value=\"Aggregate Final Results - main.rs:L220-228\" id=\"344c1f2c-d241-4b5f-a686-7c1ea7037c5c\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"0508ecd1-fc1d-499a-8811-8cfff3245a53\" vertex=\"1\">\n            <mxGeometry x=\"390\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"7789b62c-d2f3-4540-aa1a-a737a35b60c8\" value=\"Pass Arguments&#xa;to Parallel&#xa;Search\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=11;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"0508ecd1-fc1d-499a-8811-8cfff3245a53\" source=\"f571f13d-a5b1-4696-810d-016af864988b\" target=\"bdea59c2-5355-45cb-babe-67dfd0c2717e\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\" />\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"590b160d-861c-4b10-a432-28127a3d547b\" value=\"Dispatch Directory&#xa;Entries to&#xa;Worker Threads\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=11;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"0508ecd1-fc1d-499a-8811-8cfff3245a53\" source=\"bdea59c2-5355-45cb-babe-67dfd0c2717e\" target=\"2196ff9f-2695-4b8a-8a75-d5702b89371f\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"610\" y=\"252.614084101233\" />\n              <mxPoint x=\"610\" y=\"212.69656267962816\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"5f9ee588-f79d-40bd-bb72-9ec3368ab21f\" value=\"Return Search&#xa;Result Statistics\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=11;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"0508ecd1-fc1d-499a-8811-8cfff3245a53\" source=\"f6322f9f-f154-481a-a997-75b09226c146\" target=\"344c1f2c-d241-4b5f-a686-7c1ea7037c5c\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"290\" y=\"122.53878483181295\" />\n              <mxPoint x=\"290\" y=\"115\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"search.rs\" value=\"search.rs\" id=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=37;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f4e9e9\" parent=\"debf18dd-047e-44e4-9016-2ee07faaf18b\" vertex=\"1\">\n            <mxGeometry x=\"2485\" y=\"713.1396360390709\" width=\"1360\" height=\"619.9999999999999\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Execute Search with PCRE2 Matcher - search.rs:L341-350\" value=\"Execute Search with PCRE2 Matcher - search.rs:L341-350\" id=\"1c3b00d3-1533-4f77-855a-0a5ae9d0abd1\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"69.99999999999999\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Configure Search Worker for Decompression - search.rs:L127-134\" value=\"Configure Search Worker for Decompression - search.rs:L127-134\" id=\"cadc0775-86e8-4e88-bd26-61f174b086eb\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"459.9999999999999\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Check if Decompression is Needed - search.rs:L275-280\" value=\"Check if Decompression is Needed - search.rs:L275-280\" id=\"36ea22a2-80cb-4c97-b055-b14052750de7\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" vertex=\"1\">\n            <mxGeometry x=\"470\" y=\"374.5461609370479\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"a5c04342-f30c-4b03-88ef-fd5d5cc6dec5\" value=\"Transmit File&#xa;Path for&#xa;Decompression Check\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=12;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" source=\"cadc0775-86e8-4e88-bd26-61f174b086eb\" target=\"36ea22a2-80cb-4c97-b055-b14052750de7\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"370\" y=\"504.9999999999999\" />\n              <mxPoint x=\"370\" y=\"419.5461609370479\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"Configure Search Worker - search.rs:L96-118\" value=\"Configure Search Worker - search.rs:L96-118\" id=\"41c68e49-b2b4-463f-b7e9-444a1f388ede\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"199.99999999999994\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Check if File Matches Preprocessor Globs - search.rs:L285-295\" value=\"Check if File Matches Preprocessor Globs - search.rs:L285-295\" id=\"661242fb-a028-49ef-8a40-665bdc8f8b9a\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" vertex=\"1\">\n            <mxGeometry x=\"470\" y=\"211.27246328596593\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Execute Preprocessor Command - search.rs:L299-321\" value=\"Execute Preprocessor Command - search.rs:L299-321\" id=\"84432abe-73a2-46dd-aa06-178ca2b62ff8\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" vertex=\"1\">\n            <mxGeometry x=\"790\" y=\"211.27246328596593\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Search Preprocessed Stream - search.rs:L349-357\" value=\"Search Preprocessed Stream - search.rs:L349-357\" id=\"fa7bdd21-d61e-497f-9427-eda4d39438cd\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" vertex=\"1\">\n            <mxGeometry x=\"1110\" y=\"211.27246328596593\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"10918ee4-422b-453e-bb5d-05d55fe40fd2\" value=\"Initiate File&#xa;Search\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=11;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" source=\"41c68e49-b2b4-463f-b7e9-444a1f388ede\" target=\"661242fb-a028-49ef-8a40-665bdc8f8b9a\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"370\" y=\"244.99999999999994\" />\n              <mxPoint x=\"370\" y=\"256.27246328596596\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"e6ad1c9e-fb02-48a3-91ce-1920e842ae43\" value=\"Signal for&#xa;Preprocessing\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=11;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" source=\"661242fb-a028-49ef-8a40-665bdc8f8b9a\" target=\"84432abe-73a2-46dd-aa06-178ca2b62ff8\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\" />\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"ed97f725-0d09-4009-8626-5bafe4b0f4bd\" value=\"Stream Preprocessed&#xa;Data\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=11;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" source=\"84432abe-73a2-46dd-aa06-178ca2b62ff8\" target=\"fa7bdd21-d61e-497f-9427-eda4d39438cd\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\" />\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"Execute Search on Filtered Files - search.rs:L245-255\" value=\"Execute Search on Filtered Files - search.rs:L245-255\" id=\"f922a6d3-7cbf-48ac-b204-399522834fe1\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"fbd72afc-9b46-46a0-a2f0-c3757937fd45\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"329.99999999999994\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"flags\" value=\"flags\" id=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=45;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f4e9e9\" parent=\"debf18dd-047e-44e4-9016-2ee07faaf18b\" vertex=\"1\">\n            <mxGeometry x=\"95\" y=\"70\" width=\"2200\" height=\"2298.380640347422\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"defs.rs\" value=\"defs.rs\" id=\"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=25;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" vertex=\"1\">\n            <mxGeometry x=\"685\" y=\"828.380640347422\" width=\"480\" height=\"1400\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Flow 1: Parse &#39;--glob&#39; Flag - defs.rs:L2555-2558\" value=\"Flow 1: Parse &#39;--glob&#39; Flag - defs.rs:L2555-2558\" id=\"cb3a4534-fcff-4d6e-a249-7dc152bd9a32\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"1110\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Flow 2: Parse File Type Flags - defs.rs:L6901-7126\" value=\"Flow 2: Parse File Type Flags - defs.rs:L6901-7126\" id=\"38526dce-9250-40d1-8e4b-b6489562aee3\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"980\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Standard Output Flow: Parse Context and Formatting Flags - defs.rs:L995-1024\" value=\"Standard Output Flow: Parse Context and Formatting Flags - defs.rs:L995-1024\" id=\"8e2b5abc-ba17-4126-8196-2d863574dd03\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"589.9999999999999\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"JSON Output Flow: Parse --json Flag - defs.rs:L3429-3512\" value=\"JSON Output Flow: Parse --json Flag - defs.rs:L3429-3512\" id=\"dc9f30d5-6599-4494-867c-a5f5726f7aa2\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"1240\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Parse PCRE2 Command-Line Flag - defs.rs:L5381-5387\" value=\"Parse PCRE2 Command-Line Flag - defs.rs:L5381-5387\" id=\"6825dcae-96a0-412f-ab1b-8e65b339933d\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Parse &#39;--search-zip&#39; Flag - defs.rs:L6097-6103\" value=\"Parse &#39;--search-zip&#39; Flag - defs.rs:L6097-6103\" id=\"b5bf4086-9be8-40aa-a51f-b67c6f172778\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"459.9999999999999\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Parse Multiline Flag - defs.rs:L4184-4190\" value=\"Parse Multiline Flag - defs.rs:L4184-4190\" id=\"65e6f10c-354e-430e-8920-63ca301b13f6\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"850\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Parse &#39;--replace&#39; Argument - defs.rs:L6029-6032\" value=\"Parse &#39;--replace&#39; Argument - defs.rs:L6029-6032\" id=\"4fd8d6c1-cc49-4bfe-a852-ab24cffcf443\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"720\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Parse Preprocessor CLI Arguments - defs.rs:L5528-5542\" value=\"Parse Preprocessor CLI Arguments - defs.rs:L5528-5542\" id=\"371cba6e-4f3e-43f1-a988-edb4f54e2c44\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"199.9999999999999\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Build High-Level Arguments - defs.rs:L6973-6978\" value=\"Build High-Level Arguments - defs.rs:L6973-6978\" id=\"0cfd7f6c-1a85-422b-9ea8-8c1dcf0467c1\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"329.99999999999983\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"hiargs.rs\" value=\"hiargs.rs\" id=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=28;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" vertex=\"1\">\n            <mxGeometry x=\"1385\" y=\"646.9864916644442\" width=\"720\" height=\"1400\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Flow 1: Build Glob Override Matcher - hiargs.rs:L1205-1225\" value=\"Flow 1: Build Glob Override Matcher - hiargs.rs:L1205-1225\" id=\"fbfa66cf-8419-4584-8997-3dcb1520343c\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"1110.0000000000002\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Flow 2: Build File Type Matcher - hiargs.rs:L1180-1202\" value=\"Flow 2: Build File Type Matcher - hiargs.rs:L1180-1202\" id=\"c6ed14cf-fad1-4551-b5c4-ddfa4af6afe0\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"980.0000000000002\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Standard Output Flow: Configure Searcher and Printer - hiargs.rs:L599-633\" value=\"Standard Output Flow: Configure Searcher and Printer - hiargs.rs:L599-633\" id=\"8a7a07f1-7758-4c90-9a3b-f49dc60d12f1\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"590.0000000000002\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"JSON Output Flow: Select and Build JSON Printer - hiargs.rs:L586-596\" value=\"JSON Output Flow: Select and Build JSON Printer - hiargs.rs:L586-596\" id=\"aedf481e-7a26-4f1a-8f80-e270d31af954\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"1240\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Select PCRE2 Regex Matcher - hiargs.rs:L370-380\" value=\"Select PCRE2 Regex Matcher - hiargs.rs:L370-380\" id=\"019eb844-4613-490c-9b1a-5743aa71aeb4\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Build PCRE2 Matcher - hiargs.rs:L405-454\" value=\"Build PCRE2 Matcher - hiargs.rs:L405-454\" id=\"c2791749-9b9a-4275-990a-a2c2319735f9\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" vertex=\"1\">\n            <mxGeometry x=\"470\" y=\"79.87241739063518\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"85dfd805-df63-4482-a789-93fa055a046c\" value=\"Invoke PCRE2&#xa;Matcher Builder\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=11;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" source=\"019eb844-4613-490c-9b1a-5743aa71aeb4\" target=\"c2791749-9b9a-4275-990a-a2c2319735f9\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"370\" y=\"115\" />\n              <mxPoint x=\"370\" y=\"124.87241739063518\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"Build High-Level Arguments - hiargs.rs:L310\" value=\"Build High-Level Arguments - hiargs.rs:L310\" id=\"3e247a17-fe8e-4353-bc30-5ea6711f2d85\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"460.00000000000017\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Configure Regex Engine - hiargs.rs:L478-482\" value=\"Configure Regex Engine - hiargs.rs:L478-482\" id=\"a03b1238-c735-4679-a3e8-782afc9e93e0\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"850\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Configure Printer with Replacement Text - hiargs.rs:L624\" value=\"Configure Printer with Replacement Text - hiargs.rs:L624\" id=\"d10772ea-5a19-4c72-ad04-754a0208a213\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"720\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Compile Preprocessor Globs - hiargs.rs:L1226-1238\" value=\"Compile Preprocessor Globs - hiargs.rs:L1226-1238\" id=\"dad1acc0-24c5-45ef-8a24-7b84a04f3620\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"200.0000000000002\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Configure Directory Walker - hiargs.rs:L863-871\" value=\"Configure Directory Walker - hiargs.rs:L863-871\" id=\"02cc98f2-4801-485b-b0ee-9780bcee6344\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"898b7926-b1c0-43cf-80c2-b06695d8fe1c\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"330.0000000000001\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"2b3fde20-eac5-4250-b825-23b44081ba08\" value=\"Flow 1:&#xa;Transmit Glob&#xa;Patterns\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=19;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"cb3a4534-fcff-4d6e-a249-7dc152bd9a32\" target=\"fbfa66cf-8419-4584-8997-3dcb1520343c\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1310\" y=\"1983.380640347422\" />\n              <mxPoint x=\"1310\" y=\"1801.9864916644444\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"1279f8bf-17d7-4a0a-a789-6f364aa3e5cf\" value=\"Flow 2:&#xa;Transmit Type&#xa;Changes\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=19;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"38526dce-9250-40d1-8e4b-b6489562aee3\" target=\"c6ed14cf-fad1-4551-b5c4-ddfa4af6afe0\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1300\" y=\"1853.380640347422\" />\n              <mxPoint x=\"1300\" y=\"1671.9864916644444\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"66e9ca05-7027-45f5-a953-d9fa1ff7f1a0\" value=\"Standard Output&#xa;Flow: Transmit&#xa;Parsed Arguments\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=19;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"8e2b5abc-ba17-4126-8196-2d863574dd03\" target=\"8a7a07f1-7758-4c90-9a3b-f49dc60d12f1\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1270\" y=\"1463.3806403474218\" />\n              <mxPoint x=\"1270\" y=\"1281.9864916644444\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"b054dd02-8e6a-4e42-be4a-7e082e6187d9\" value=\"JSON Output&#xa;Flow: Transmit&#xa;Parsed Arguments\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=19;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"dc9f30d5-6599-4494-867c-a5f5726f7aa2\" target=\"aedf481e-7a26-4f1a-8f80-e270d31af954\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1320\" y=\"2113.380640347422\" />\n              <mxPoint x=\"1320\" y=\"1931.9864916644442\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d\" value=\"Engine Choice&#xa;Configuration Passed\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"6825dcae-96a0-412f-ab1b-8e65b339933d\" target=\"019eb844-4613-490c-9b1a-5743aa71aeb4\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1055\" y=\"943.3806403474218\" />\n              <mxPoint x=\"1055\" y=\"943.6937016447714\" />\n              <mxPoint x=\"1230\" y=\"943.6937016447714\" />\n              <mxPoint x=\"1230\" y=\"762.0138545487746\" />\n              <mxPoint x=\"1495\" y=\"762.0138545487745\" />\n              <mxPoint x=\"1495\" y=\"761.9864916644442\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"lowargs.rs\" value=\"lowargs.rs\" id=\"5440e915-a99c-4d7c-a041-ed3214ef356e\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=16;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" vertex=\"1\">\n            <mxGeometry x=\"245\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"acb6f4f0-b4fe-475e-9f15-96bff8ad5f13\" value=\"Transmit Low-Level&#xa;Arguments\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=19;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"b5bf4086-9be8-40aa-a51f-b67c6f172778\" target=\"3e247a17-fe8e-4353-bc30-5ea6711f2d85\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1260\" y=\"1333.3806403474218\" />\n              <mxPoint x=\"1260\" y=\"1151.9864916644444\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"bcc616ab-4fd0-4234-9d6c-9b29eda63456\" value=\"Configuration Transfer\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=19;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"65e6f10c-354e-430e-8920-63ca301b13f6\" target=\"a03b1238-c735-4679-a3e8-782afc9e93e0\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1290\" y=\"1723.380640347422\" />\n              <mxPoint x=\"1290\" y=\"1541.9864916644442\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"205c10d8-385d-45c1-9829-2e59c67b8005\" value=\"Propagate Replacement&#xa;Argument\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=19;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"4fd8d6c1-cc49-4bfe-a852-ab24cffcf443\" target=\"d10772ea-5a19-4c72-ad04-754a0208a213\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1280\" y=\"1593.380640347422\" />\n              <mxPoint x=\"1280\" y=\"1411.9864916644442\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"e2b512be-0da5-4e08-a8f0-4d5271c56bec\" value=\"Pass Raw&#xa;Arguments for&#xa;Compilation\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=19;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"371cba6e-4f3e-43f1-a988-edb4f54e2c44\" target=\"dad1acc0-24c5-45ef-8a24-7b84a04f3620\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1240\" y=\"1073.3806403474218\" />\n              <mxPoint x=\"1240\" y=\"891.9864916644444\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"parse.rs\" value=\"parse.rs\" id=\"23cc6e15-ec4f-467a-9e19-4cca7bad4056\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" vertex=\"1\">\n            <mxGeometry x=\"175\" y=\"1088.461939877807\" width=\"320\" height=\"360.24710152500006\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Start Execution and Parse Arguments - parse.rs:L71-75\" value=\"Start Execution and Parse Arguments - parse.rs:L71-75\" id=\"f762e7b2-4ed1-4ae0-8746-b958e16b2499\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"23cc6e15-ec4f-467a-9e19-4cca7bad4056\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"200.24710152500003\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Merge and Re-parse All Arguments - parse.rs:L96-104\" value=\"Merge and Re-parse All Arguments - parse.rs:L96-104\" id=\"0ea2e988-76a8-4989-9841-0c4c130de7a9\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"23cc6e15-ec4f-467a-9e19-4cca7bad4056\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"config.rs\" value=\"config.rs\" id=\"7715a01b-ffc3-4e46-8446-5f55b158012e\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" vertex=\"1\">\n            <mxGeometry x=\"685\" y=\"558.3806403474218\" width=\"320\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Parse Configuration File - config.rs:L65-72\" value=\"Parse Configuration File - config.rs:L65-72\" id=\"dbfee10c-86e3-476f-86f0-7e2ca77cc529\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"7715a01b-ffc3-4e46-8446-5f55b158012e\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"fadf13c2-4eee-46a9-945d-a0a12855832b\" value=\"Check for&#xa;Configuration File\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=18;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"f762e7b2-4ed1-4ae0-8746-b958e16b2499\" target=\"dbfee10c-86e3-476f-86f0-7e2ca77cc529\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"560\" y=\"1333.709041402807\" />\n              <mxPoint x=\"560\" y=\"673.3806403474218\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"fc568437-30b2-4ab2-a1f0-876eec72e1db\" value=\"Transmit Parsed&#xa;Config Arguments\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"dbfee10c-86e3-476f-86f0-7e2ca77cc529\" target=\"0ea2e988-76a8-4989-9841-0c4c130de7a9\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1230\" y=\"673.3806403474218\" />\n              <mxPoint x=\"1230\" y=\"508.3806403474218\" />\n              <mxPoint x=\"110\" y=\"508.3806403474218\" />\n              <mxPoint x=\"110\" y=\"1203.461939877807\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"e7a3ab74-74b5-4476-9b14-836f04678cc7\" value=\"Transmit Low-Level&#xa;Arguments\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=18;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"0ea2e988-76a8-4989-9841-0c4c130de7a9\" target=\"0cfd7f6c-1a85-422b-9ea8-8c1dcf0467c1\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"795\" y=\"1203.461939877807\" />\n              <mxPoint x=\"795\" y=\"1203.3806403474216\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"d07f3a20-1f28-42d6-8f89-d63f5372b039\" value=\"Transmit High-Level&#xa;Configuration\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=19;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e\" source=\"0cfd7f6c-1a85-422b-9ea8-8c1dcf0467c1\" target=\"02cc98f2-4801-485b-b0ee-9780bcee6344\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1250\" y=\"1203.3806403474218\" />\n              <mxPoint x=\"1250\" y=\"1021.9864916644443\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"94bf3581-9419-46ea-9a55-94598c438500\" value=\"Compiled PCRE2&#xa;Matcher Passed&#xa;to Searcher\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"debf18dd-047e-44e4-9016-2ee07faaf18b\" source=\"c2791749-9b9a-4275-990a-a2c2319735f9\" target=\"1c3b00d3-1533-4f77-855a-0a5ae9d0abd1\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"2360\" y=\"841.8589090550794\" />\n              <mxPoint x=\"2360\" y=\"832.0211880925714\" />\n              <mxPoint x=\"2595\" y=\"832.0211880925713\" />\n              <mxPoint x=\"2595\" y=\"828.1396360390709\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"57f135d9-c844-4467-9dce-d84057fd5869\" value=\"Pass Config&#xa;to Search&#xa;Worker Builder\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"debf18dd-047e-44e4-9016-2ee07faaf18b\" source=\"3e247a17-fe8e-4353-bc30-5ea6711f2d85\" target=\"cadc0775-86e8-4e88-bd26-61f174b086eb\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1850\" y=\"1221.9864916644444\" />\n              <mxPoint x=\"1850\" y=\"1225.486970676196\" />\n              <mxPoint x=\"2360\" y=\"1225.486970676196\" />\n              <mxPoint x=\"2360\" y=\"1218.1396360390709\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"aacee49a-819e-4c4f-b165-f5c39c9c867f\" value=\"Pass Compiled&#xa;Arguments to&#xa;Worker Builder\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"debf18dd-047e-44e4-9016-2ee07faaf18b\" source=\"dad1acc0-24c5-45ef-8a24-7b84a04f3620\" target=\"41c68e49-b2b4-463f-b7e9-444a1f388ede\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1850\" y=\"961.9864916644444\" />\n              <mxPoint x=\"1850\" y=\"970.1747923929652\" />\n              <mxPoint x=\"2360\" y=\"970.1747923929652\" />\n              <mxPoint x=\"2360\" y=\"958.1396360390709\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"b72ce07f-2387-40a1-90ba-4deafeeb4793\" value=\"Yield Matching&#xa;Files\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"debf18dd-047e-44e4-9016-2ee07faaf18b\" source=\"02cc98f2-4801-485b-b0ee-9780bcee6344\" target=\"f922a6d3-7cbf-48ac-b204-399522834fe1\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1850\" y=\"1091.9864916644444\" />\n              <mxPoint x=\"1850\" y=\"1097.8308815345806\" />\n              <mxPoint x=\"2360\" y=\"1097.8308815345806\" />\n              <mxPoint x=\"2360\" y=\"1088.1396360390709\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"ignore\" value=\"ignore\" id=\"e66e9e2a-b18d-4361-a5a8-c389d3bb600e\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=45;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f9f3f3\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" vertex=\"1\">\n            <mxGeometry x=\"4345\" y=\"1647.3157140006708\" width=\"1855\" height=\"770.1214714955\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"src\" value=\"src\" id=\"71ab6f47-6fdc-4073-9554-d51e4844c87e\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=40;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f4e9e9\" parent=\"e66e9e2a-b18d-4361-a5a8-c389d3bb600e\" vertex=\"1\">\n            <mxGeometry x=\"175\" y=\"70\" width=\"1585\" height=\"630.1214714955\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"walk.rs\" value=\"walk.rs\" id=\"1280b1d7-f3fd-41aa-9a95-53e5509e82a0\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"71ab6f47-6fdc-4073-9554-d51e4844c87e\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"199.2869064176607\" width=\"320\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Initializing the Directory Walker - walk.rs:L520-530\" value=\"Initializing the Directory Walker - walk.rs:L520-530\" id=\"06b0a86e-bf34-4e78-b2d3-0b1442aef61e\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"1280b1d7-f3fd-41aa-9a95-53e5509e82a0\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"gitignore.rs\" value=\"gitignore.rs\" id=\"6f90ad17-9829-4744-a1f0-1b721c6339ab\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"71ab6f47-6fdc-4073-9554-d51e4844c87e\" vertex=\"1\">\n            <mxGeometry x=\"580\" y=\"199.2869064176607\" width=\"320\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Parsing `.gitignore` File - gitignore.rs:L391-416\" value=\"Parsing `.gitignore` File - gitignore.rs:L391-416\" id=\"d3448e0e-d81f-476d-aff3-3bd9ab26026d\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"6f90ad17-9829-4744-a1f0-1b721c6339ab\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"dir.rs\" value=\"dir.rs\" id=\"75eb0e51-195c-493c-a132-126ec4994742\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"71ab6f47-6fdc-4073-9554-d51e4844c87e\" vertex=\"1\">\n            <mxGeometry x=\"1090\" y=\"70\" width=\"400\" height=\"490.1214714955\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Applying Filtering Rules to a Path - dir.rs:L396-544\" value=\"Applying Filtering Rules to a Path - dir.rs:L396-544\" id=\"7abfc016-6e09-4293-9c51-8be0e01bd020\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"75eb0e51-195c-493c-a132-126ec4994742\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"200\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Flow 1: Filter Path with Override Matcher - dir.rs:L381-389\" value=\"Flow 1: Filter Path with Override Matcher - dir.rs:L381-389\" id=\"8570a0fe-3867-4504-8509-b48052799065\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"75eb0e51-195c-493c-a132-126ec4994742\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"330.1214714955\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Flow 2: Filter Path with Type Matcher - dir.rs:L396-406\" value=\"Flow 2: Filter Path with Type Matcher - dir.rs:L396-406\" id=\"1280e475-b2ba-4864-964c-5ce2738208ab\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"75eb0e51-195c-493c-a132-126ec4994742\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"8179e991-1e79-4612-abe1-b15ebc81ee7a\" value=\"Directory Walker&#xa;Begins Traversal\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=10;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"71ab6f47-6fdc-4073-9554-d51e4844c87e\" source=\"06b0a86e-bf34-4e78-b2d3-0b1442aef61e\" target=\"d3448e0e-d81f-476d-aff3-3bd9ab26026d\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\" />\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"643dc76d-7619-485d-812b-937f5adb8ad9\" value=\"Transferring Compiled&#xa;Globs\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=15;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"71ab6f47-6fdc-4073-9554-d51e4844c87e\" source=\"d3448e0e-d81f-476d-aff3-3bd9ab26026d\" target=\"7abfc016-6e09-4293-9c51-8be0e01bd020\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"965\" y=\"314.2869064176606\" />\n              <mxPoint x=\"965\" y=\"314.9999999999999\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"searcher\" value=\"searcher\" id=\"50938285-d56a-4404-8807-f18ce4804f62\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=45;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f9f3f3\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" vertex=\"1\">\n            <mxGeometry x=\"6390\" y=\"1215.9864820352748\" width=\"2070\" height=\"1308.310770224141\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"src\" value=\"src\" id=\"f08293c4-eb87-4446-8a1c-b208513e40bd\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=45;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f4e9e9\" parent=\"50938285-d56a-4404-8807-f18ce4804f62\" vertex=\"1\">\n            <mxGeometry x=\"95\" y=\"70\" width=\"1880\" height=\"1168.310770224141\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"searcher\" value=\"searcher\" id=\"7a2a4538-5e5a-4df6-85cc-b341c95545a1\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=34;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"f08293c4-eb87-4446-8a1c-b208513e40bd\" vertex=\"1\">\n            <mxGeometry x=\"95\" y=\"70\" width=\"1180\" height=\"702.3659479101082\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"mod.rs\" value=\"mod.rs\" id=\"f05bde61-7d65-4d33-a433-141321ba0c95\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=25;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#ead5d5\" parent=\"7a2a4538-5e5a-4df6-85cc-b341c95545a1\" vertex=\"1\">\n            <mxGeometry x=\"95\" y=\"100.74034783821577\" width=\"480\" height=\"490\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Choose Search Strategy (Mmap vs. Incremental) - mod.rs:L699-702\" value=\"Choose Search Strategy (Mmap vs. Incremental) - mod.rs:L699-702\" id=\"32bcfcb7-b4b6-4993-893c-1676d6ecaf77\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"f05bde61-7d65-4d33-a433-141321ba0c95\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"330\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Configuring Searcher for Binary Detection - mod.rs:L503-510\" value=\"Configuring Searcher for Binary Detection - mod.rs:L503-510\" id=\"2f67c4c9-54b4-4da2-9448-5bfa18537099\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"f05bde61-7d65-4d33-a433-141321ba0c95\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"200\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Select Multiline Search Strategy - mod.rs:L700-707\" value=\"Select Multiline Search Strategy - mod.rs:L700-707\" id=\"d77e8ea1-2850-488f-af80-6417c53c8099\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"f05bde61-7d65-4d33-a433-141321ba0c95\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"core.rs\" value=\"core.rs\" id=\"d7cca382-50e5-4a19-a577-d94f1ea52683\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#ead5d5\" parent=\"7a2a4538-5e5a-4df6-85cc-b341c95545a1\" vertex=\"1\">\n            <mxGeometry x=\"765\" y=\"402.36594791010805\" width=\"320\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Execute Fast Line-by-Line Search - core.rs:L479-497\" value=\"Execute Fast Line-by-Line Search - core.rs:L479-497\" id=\"b4d3b26e-19e7-477d-979f-702fb33ff014\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"d7cca382-50e5-4a19-a577-d94f1ea52683\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"0c2fcc7e-11d6-43a5-ae89-13180aed99eb\" value=\"Pass File&#xa;Content Slice&#xa;to Search&#xa;Routine\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=14;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"7a2a4538-5e5a-4df6-85cc-b341c95545a1\" source=\"32bcfcb7-b4b6-4993-893c-1676d6ecaf77\" target=\"b4d3b26e-19e7-477d-979f-702fb33ff014\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"640\" y=\"475.7403478382156\" />\n              <mxPoint x=\"640\" y=\"517.3659479101079\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"glue.rs\" value=\"glue.rs\" id=\"ef09f321-34b3-4a42-869e-19002e3a4382\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#ead5d5\" parent=\"7a2a4538-5e5a-4df6-85cc-b341c95545a1\" vertex=\"1\">\n            <mxGeometry x=\"765\" y=\"70\" width=\"320\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Execute Search on Buffer - glue.rs:L146-162\" value=\"Execute Search on Buffer - glue.rs:L146-162\" id=\"b8833d1c-74e5-4db9-9775-056216d25c47\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"ef09f321-34b3-4a42-869e-19002e3a4382\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"0a935202-428b-429e-a4c4-b1dd464e4bda\" value=\"Buffer Passed&#xa;to MultiLine&#xa;Searcher\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=13;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"7a2a4538-5e5a-4df6-85cc-b341c95545a1\" source=\"d77e8ea1-2850-488f-af80-6417c53c8099\" target=\"b8833d1c-74e5-4db9-9775-056216d25c47\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"465\" y=\"215.74034783821577\" />\n              <mxPoint x=\"465\" y=\"216.6638830910198\" />\n              <mxPoint x=\"640\" y=\"216.66388309101967\" />\n              <mxPoint x=\"640\" y=\"184.99999999999986\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"line_buffer.rs\" value=\"line_buffer.rs\" id=\"4d08cdc3-7059-4f0e-b863-a2557475e192\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"f08293c4-eb87-4446-8a1c-b208513e40bd\" vertex=\"1\">\n            <mxGeometry x=\"1465\" y=\"303.7070605703529\" width=\"320\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Detecting NUL Byte - line_buffer.rs:L436-443\" value=\"Detecting NUL Byte - line_buffer.rs:L436-443\" id=\"b80fd0a4-3357-49c4-baf5-2fa06862eb09\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"4d08cdc3-7059-4f0e-b863-a2557475e192\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"b04390e9-6b12-4665-9c2d-4afc76a8be4b\" value=\"Reading File&#xa;Contents into&#xa;Buffer\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=18;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"f08293c4-eb87-4446-8a1c-b208513e40bd\" source=\"2f67c4c9-54b4-4da2-9448-5bfa18537099\" target=\"b80fd0a4-3357-49c4-baf5-2fa06862eb09\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"735\" y=\"415.74034783821565\" />\n              <mxPoint x=\"735\" y=\"419.9999999999998\" />\n              <mxPoint x=\"1340\" y=\"419.9999999999998\" />\n              <mxPoint x=\"1340\" y=\"418.7070605703528\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"sink.rs\" value=\"sink.rs\" id=\"548054c3-b0a3-4817-8e47-3dfac7999d27\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=16;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"f08293c4-eb87-4446-8a1c-b208513e40bd\" vertex=\"1\">\n            <mxGeometry x=\"595\" y=\"1008.3107702241409\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"printer\" value=\"printer\" id=\"1e13c78f-707d-4438-9cb6-50f939de598d\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=45;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f9f3f3\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" vertex=\"1\">\n            <mxGeometry x=\"8650\" y=\"519.986482035275\" width=\"1860\" height=\"1801.5866241660224\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"src\" value=\"src\" id=\"a9858ff0-4d39-4382-b671-fae85b74aaa3\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=40;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f4e9e9\" parent=\"1e13c78f-707d-4438-9cb6-50f939de598d\" vertex=\"1\">\n            <mxGeometry x=\"175\" y=\"70\" width=\"1590\" height=\"1661.5866241660224\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"standard.rs\" value=\"standard.rs\" id=\"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=28;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"a9858ff0-4d39-4382-b671-fae85b74aaa3\" vertex=\"1\">\n            <mxGeometry x=\"185\" y=\"70\" width=\"720\" height=\"880.0000000000002\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Format Match in Sink - standard.rs:L769-788\" value=\"Format Match in Sink - standard.rs:L769-788\" id=\"31b67024-80a9-4f66-9e16-50d98e7d05c7\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"720.0000000000002\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Standard Output Flow: Execute Search and Sink Results - standard.rs:L764-823\" value=\"Standard Output Flow: Execute Search and Sink Results - standard.rs:L764-823\" id=\"7d6a3f10-0382-4eaa-8a62-e3492e6000c2\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"330.0000000000001\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Standard Output Flow: Format Human-Readable Output - standard.rs:L871-929\" value=\"Standard Output Flow: Format Human-Readable Output - standard.rs:L871-929\" id=\"b7e5cc9d-83e0-44e5-bcd8-0f7886685f38\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550\" vertex=\"1\">\n            <mxGeometry x=\"470\" y=\"336.38112244359024\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"262b607f-db42-4642-91b9-abd5a1108374\" value=\"Standard Output&#xa;Flow: Transmit&#xa;Match and&#xa;Context Data\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=11;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550\" source=\"7d6a3f10-0382-4eaa-8a62-e3492e6000c2\" target=\"b7e5cc9d-83e0-44e5-bcd8-0f7886685f38\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"370\" y=\"375.0000000000001\" />\n              <mxPoint x=\"370\" y=\"381.38112244359024\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"Format and Print Match - standard.rs:L1044-1049\" value=\"Format and Print Match - standard.rs:L1044-1049\" id=\"1f3ae57d-ae3d-4633-be82-877091353aa6\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"590.0000000000002\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Process Match and Initiate Replacement - standard.rs:L777\" value=\"Process Match and Initiate Replacement - standard.rs:L777\" id=\"2897d065-bc9c-47a0-935d-58720d432394\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"460\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Construct Final Output Line - standard.rs:L906-911\" value=\"Construct Final Output Line - standard.rs:L906-911\" id=\"7138d741-53de-48fc-a962-99b13e1d7706\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Write to Output Stream - standard.rs:L1647-1651\" value=\"Write to Output Stream - standard.rs:L1647-1651\" id=\"ee822001-55cc-47c3-8efc-295818547c1a\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550\" vertex=\"1\">\n            <mxGeometry x=\"470\" y=\"71.06310648634602\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"349e4381-82c9-490b-bfdd-bdc9bb872c75\" value=\"Data for&#xa;Final Print\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=11;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550\" source=\"7138d741-53de-48fc-a962-99b13e1d7706\" target=\"ee822001-55cc-47c3-8efc-295818547c1a\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"370\" y=\"115\" />\n              <mxPoint x=\"370\" y=\"116.06310648634602\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"Format and Print Match - standard.rs:L1178-1188\" value=\"Format and Print Match - standard.rs:L1178-1188\" id=\"fd865b14-7ee5-4b22-afc0-f1642849edd8\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550\" vertex=\"1\">\n            <mxGeometry x=\"150\" y=\"200.00000000000009\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"summary.rs\" value=\"summary.rs\" id=\"32eebe96-86ec-41f2-ac0d-3c5874bb3b44\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"a9858ff0-4d39-4382-b671-fae85b74aaa3\" vertex=\"1\">\n            <mxGeometry x=\"185\" y=\"990\" width=\"320\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Skipping Binary File - summary.rs:L724-739\" value=\"Skipping Binary File - summary.rs:L724-739\" id=\"723470cf-d7a8-443a-8713-f4840c0ae560\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"32eebe96-86ec-41f2-ac0d-3c5874bb3b44\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"json.rs\" value=\"json.rs\" id=\"f64da727-0b70-4f27-880c-862de575dd0a\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"a9858ff0-4d39-4382-b671-fae85b74aaa3\" vertex=\"1\">\n            <mxGeometry x=\"385\" y=\"1361.5866241660224\" width=\"320\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"JSON Output Flow: Execute Search and Sink to JSON Printer - json.rs:L722-785\" value=\"JSON Output Flow: Execute Search and Sink to JSON Printer - json.rs:L722-785\" id=\"9078ceb1-5c41-402c-867a-d9960eb41e6e\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"f64da727-0b70-4f27-880c-862de575dd0a\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"jsont.rs\" value=\"jsont.rs\" id=\"0e8f4962-c836-4d7b-93b1-b8b18f64a725\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"a9858ff0-4d39-4382-b671-fae85b74aaa3\" vertex=\"1\">\n            <mxGeometry x=\"1095\" y=\"1361.5866241660224\" width=\"320\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"JSON Output Flow: Construct and Serialize JSON Messages - jsont.rs:L11-44\" value=\"JSON Output Flow: Construct and Serialize JSON Messages - jsont.rs:L11-44\" id=\"b0962b62-8b3f-4dae-a197-aed83fe5a827\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"0e8f4962-c836-4d7b-93b1-b8b18f64a725\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"605d4cc4-7749-425e-8ba5-e12c6b23d1a3\" value=\"JSON Output&#xa;Flow: Transmit&#xa;Match and&#xa;Context Data\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=10;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"a9858ff0-4d39-4382-b671-fae85b74aaa3\" source=\"9078ceb1-5c41-402c-867a-d9960eb41e6e\" target=\"b0962b62-8b3f-4dae-a197-aed83fe5a827\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\" />\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"util.rs\" value=\"util.rs\" id=\"d77a4716-11cf-4b4f-8142-92ff0d375bf2\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"a9858ff0-4d39-4382-b671-fae85b74aaa3\" vertex=\"1\">\n            <mxGeometry x=\"1095\" y=\"599.4486286868929\" width=\"320\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Perform Replacement via Interpolation - util.rs:L87-102\" value=\"Perform Replacement via Interpolation - util.rs:L87-102\" id=\"6f4daaff-ddca-41f0-ad53-d48d290d885b\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"d77a4716-11cf-4b4f-8142-92ff0d375bf2\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"da844bfb-d742-4ee0-af58-61cd861b9350\" value=\"Send Match&#xa;Data to&#xa;Replacer\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=17;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"a9858ff0-4d39-4382-b671-fae85b74aaa3\" source=\"2897d065-bc9c-47a0-935d-58720d432394\" target=\"6f4daaff-ddca-41f0-ad53-d48d290d885b\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"555\" y=\"575\" />\n              <mxPoint x=\"555\" y=\"575.146383937318\" />\n              <mxPoint x=\"970\" y=\"575.1463839373184\" />\n              <mxPoint x=\"970\" y=\"714.4486286868932\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"5c3f5839-6758-4eaf-98b1-71868c95b20d\" value=\"Pass File&#xa;Path and&#xa;Sink to&#xa;Searcher\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"2196ff9f-2695-4b8a-8a75-d5702b89371f\" target=\"32bcfcb7-b4b6-4993-893c-1676d6ecaf77\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"2495\" y=\"2741.07720302705\" />\n              <mxPoint x=\"2495\" y=\"2726.7794047020648\" />\n              <mxPoint x=\"6275\" y=\"2726.779404702065\" />\n              <mxPoint x=\"6275\" y=\"1831.7268298734907\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"87179a07-e417-4140-99b7-02a9f9a02887\" value=\"Pass Confirmed&#xa;Match to&#xa;Sink\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"b4d3b26e-19e7-477d-979f-702fb33ff014\" target=\"31b67024-80a9-4f66-9e16-50d98e7d05c7\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"8535\" y=\"1873.3524299453825\" />\n              <mxPoint x=\"8535\" y=\"1590.9548692142225\" />\n              <mxPoint x=\"8935\" y=\"1590.9548692142225\" />\n              <mxPoint x=\"8935\" y=\"1424.986482035275\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"347bc957-3191-4e20-94e9-4e1901111130\" value=\"Transmit Formatted&#xa;Output to&#xa;Buffer\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"31b67024-80a9-4f66-9e16-50d98e7d05c7\" target=\"f6322f9f-f154-481a-a997-75b09226c146\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"9380\" y=\"1424.9864820352752\" />\n              <mxPoint x=\"9380\" y=\"1402.412353237778\" />\n              <mxPoint x=\"9795\" y=\"1402.4123532377785\" />\n              <mxPoint x=\"9795\" y=\"1505.4935335513119\" />\n              <mxPoint x=\"10575\" y=\"1505.4935335513119\" />\n              <mxPoint x=\"10575\" y=\"3015.994724448654\" />\n              <mxPoint x=\"70\" y=\"3015.994724448654\" />\n              <mxPoint x=\"70\" y=\"2650.919425179235\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"b37077b4-3a28-4e20-8572-adb309282e6e\" value=\"Yielding a&#xa;Valid File&#xa;Path\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"7abfc016-6e09-4293-9c51-8be0e01bd020\" target=\"2f67c4c9-54b4-4da2-9448-5bfa18537099\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"6265\" y=\"2032.3157140006706\" />\n              <mxPoint x=\"6265\" y=\"1701.7268298734903\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"66a36773-5189-4bc2-909a-0d5ce55eb772\" value=\"Signaling Binary&#xa;File Detection\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"b80fd0a4-3357-49c4-baf5-2fa06862eb09\" target=\"723470cf-d7a8-443a-8713-f4840c0ae560\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"8525\" y=\"1704.6935426056277\" />\n              <mxPoint x=\"8525\" y=\"1580.4736164832605\" />\n              <mxPoint x=\"8760\" y=\"1580.4736164832607\" />\n              <mxPoint x=\"8760\" y=\"1580.954869214223\" />\n              <mxPoint x=\"8945\" y=\"1580.954869214223\" />\n              <mxPoint x=\"8945\" y=\"1694.986482035275\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"ba4298a3-e951-4215-a0b0-55c94dffc690\" value=\"Flow 1:&#xa;Configure Walker&#xa;with Override&#xa;Matcher\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"fbfa66cf-8419-4584-8997-3dcb1520343c\" target=\"8570a0fe-3867-4504-8509-b48052799065\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1985\" y=\"1991.9864916644444\" />\n              <mxPoint x=\"1985\" y=\"1983.7674163842735\" />\n              <mxPoint x=\"2495\" y=\"1983.7674163842735\" />\n              <mxPoint x=\"2495\" y=\"1992.7921337552666\" />\n              <mxPoint x=\"4230\" y=\"1992.7921337552664\" />\n              <mxPoint x=\"4230\" y=\"2196.6026204183318\" />\n              <mxPoint x=\"5485\" y=\"2196.6026204183318\" />\n              <mxPoint x=\"5485\" y=\"2162.437185496171\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"f44a0aa4-4205-4ea4-9d80-5a62385e2307\" value=\"Flow 2:&#xa;Configure Walker&#xa;with Type&#xa;Matcher\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"c6ed14cf-fad1-4551-b5c4-ddfa4af6afe0\" target=\"1280e475-b2ba-4864-964c-5ce2738208ab\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1985\" y=\"1861.9864916644444\" />\n              <mxPoint x=\"1985\" y=\"1856.1113272426578\" />\n              <mxPoint x=\"2495\" y=\"1856.111327242658\" />\n              <mxPoint x=\"2495\" y=\"1867.5147520325909\" />\n              <mxPoint x=\"4455\" y=\"1867.5147520325909\" />\n              <mxPoint x=\"4455\" y=\"1865.6026204183318\" />\n              <mxPoint x=\"5485\" y=\"1865.6026204183313\" />\n              <mxPoint x=\"5485\" y=\"1903.404186353638\" />\n              <mxPoint x=\"5720\" y=\"1903.4041863536381\" />\n              <mxPoint x=\"5720\" y=\"1902.315714000671\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"cli\" value=\"cli\" id=\"63a9d821-0a1b-4daf-9f0d-0482d2ded1a5\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=31;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f9f3f3\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" vertex=\"1\">\n            <mxGeometry x=\"4345\" y=\"228.83228038727447\" width=\"970\" height=\"835.154201648\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"src\" value=\"src\" id=\"bbd871fb-2a85-4f90-b28d-abc336580454\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=31;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f4e9e9\" parent=\"63a9d821-0a1b-4daf-9f0d-0482d2ded1a5\" vertex=\"1\">\n            <mxGeometry x=\"95\" y=\"70\" width=\"805\" height=\"695.154201648\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"wtr.rs\" value=\"wtr.rs\" id=\"3aa0bd2b-5f86-46a6-8763-2b5371ab045d\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=16;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"bbd871fb-2a85-4f90-b28d-abc336580454\" vertex=\"1\">\n            <mxGeometry x=\"312.5\" y=\"405.154201648\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"decompress.rs\" value=\"decompress.rs\" id=\"2e2dd6c4-6e83-424c-8da5-b8171ce5479f\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=28;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"bbd871fb-2a85-4f90-b28d-abc336580454\" vertex=\"1\">\n            <mxGeometry x=\"95\" y=\"70\" width=\"640\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Create Decompression Process - decompress.rs:L221-245\" value=\"Create Decompression Process - decompress.rs:L221-245\" id=\"626197b8-ae20-4c15-9110-5e97703d7612\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"2e2dd6c4-6e83-424c-8da5-b8171ce5479f\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Search Decompressed Stream - decompress.rs:L389-395\" value=\"Search Decompressed Stream - decompress.rs:L389-395\" id=\"88dd5a3a-40c2-43e3-ac59-ec2e806c3825\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"2e2dd6c4-6e83-424c-8da5-b8171ce5479f\" vertex=\"1\">\n            <mxGeometry x=\"390\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"e5d149ac-77cd-44b7-adaf-e71df369fe88\" value=\"Return Reader&#xa;Interface\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=11;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"2e2dd6c4-6e83-424c-8da5-b8171ce5479f\" source=\"626197b8-ae20-4c15-9110-5e97703d7612\" target=\"88dd5a3a-40c2-43e3-ac59-ec2e806c3825\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\" />\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"process.rs\" value=\"process.rs\" id=\"cd38b9ee-aec0-4a28-87fb-462f8ec364c2\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=16;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"bbd871fb-2a85-4f90-b28d-abc336580454\" vertex=\"1\">\n            <mxGeometry x=\"312.5\" y=\"535.154201648\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a\" value=\"Standard Output&#xa;Flow: Transmit&#xa;Configured Searcher&#xa;and Printer\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"8a7a07f1-7758-4c90-9a3b-f49dc60d12f1\" target=\"7d6a3f10-0382-4eaa-8a62-e3492e6000c2\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1985\" y=\"1471.9864916644444\" />\n              <mxPoint x=\"1985\" y=\"1473.1430598178115\" />\n              <mxPoint x=\"2495\" y=\"1473.1430598178115\" />\n              <mxPoint x=\"2495\" y=\"1507.049190739225\" />\n              <mxPoint x=\"4240\" y=\"1507.049190739225\" />\n              <mxPoint x=\"4240\" y=\"1113.9864820352748\" />\n              <mxPoint x=\"8525\" y=\"1113.9864820352748\" />\n              <mxPoint x=\"8525\" y=\"1034.986482035275\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"81663818-d2d6-4cfe-8a71-7b37237f7f95\" value=\"Standard Output&#xa;Flow: Write&#xa;Formatted String&#xa;to stdout\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"b7e5cc9d-83e0-44e5-bcd8-0f7886685f38\" target=\"dc9f30d5-6599-4494-867c-a5f5726f7aa2\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"9795\" y=\"1041.3676044788656\" />\n              <mxPoint x=\"9795\" y=\"1108.3677875531794\" />\n              <mxPoint x=\"10305\" y=\"1108.3677875531794\" />\n              <mxPoint x=\"10305\" y=\"1138.5595866575925\" />\n              <mxPoint x=\"10575\" y=\"1138.5595866575923\" />\n              <mxPoint x=\"10575\" y=\"70.00000000000023\" />\n              <mxPoint x=\"70\" y=\"70.00000000000023\" />\n              <mxPoint x=\"70\" y=\"2145.0843672136034\" />\n              <mxPoint x=\"790\" y=\"2145.0843672136034\" />\n              <mxPoint x=\"790\" y=\"2303.380640347422\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"6bb72882-9525-4207-88b9-9573f7a6b654\" value=\"JSON Output&#xa;Flow: Transmit&#xa;Configured JSON&#xa;Printer\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"aedf481e-7a26-4f1a-8f80-e270d31af954\" target=\"9078ceb1-5c41-402c-867a-d9960eb41e6e\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1985\" y=\"2121.986491664444\" />\n              <mxPoint x=\"1985\" y=\"2111.4235055258887\" />\n              <mxPoint x=\"2495\" y=\"2111.4235055258887\" />\n              <mxPoint x=\"2495\" y=\"2118.0695154779423\" />\n              <mxPoint x=\"4220\" y=\"2118.0695154779423\" />\n              <mxPoint x=\"4220\" y=\"2574.2972522594155\" />\n              <mxPoint x=\"8525\" y=\"2574.2972522594155\" />\n              <mxPoint x=\"8525\" y=\"2066.5731062012974\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"a2c78834-0693-40f4-91ad-076a6600ec8e\" value=\"Request Decompressed&#xa;Stream\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"36ea22a2-80cb-4c97-b055-b14052750de7\" target=\"626197b8-ae20-4c15-9110-5e97703d7612\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"4230\" y=\"1252.6857969761188\" />\n              <mxPoint x=\"4230\" y=\"483.8322803872744\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"8e2520f4-89df-4244-9f53-91795625ca10\" value=\"Matcher Sent&#xa;to Searcher\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"a03b1238-c735-4679-a3e8-782afc9e93e0\" target=\"d77e8ea1-2850-488f-af80-6417c53c8099\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1985\" y=\"1731.9864916644442\" />\n              <mxPoint x=\"1985\" y=\"1728.4552381010426\" />\n              <mxPoint x=\"2495\" y=\"1728.4552381010424\" />\n              <mxPoint x=\"2495\" y=\"1742.2373703099147\" />\n              <mxPoint x=\"4260\" y=\"1742.2373703099145\" />\n              <mxPoint x=\"4260\" y=\"1397.7258841406167\" />\n              <mxPoint x=\"6265\" y=\"1397.7258841406167\" />\n              <mxPoint x=\"6265\" y=\"1572.4304339933144\" />\n              <mxPoint x=\"6785\" y=\"1572.4304339933142\" />\n              <mxPoint x=\"6785\" y=\"1571.7268298734905\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"7f305131-1f1e-4245-8dd4-d27e022f994a\" value=\"Matches Sent&#xa;to Sink\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"b8833d1c-74e5-4db9-9775-056216d25c47\" target=\"1f3ae57d-ae3d-4633-be82-877091353aa6\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"7825\" y=\"1540.9864820352745\" />\n              <mxPoint x=\"7825\" y=\"1538.1765095692888\" />\n              <mxPoint x=\"8525\" y=\"1538.176509569289\" />\n              <mxPoint x=\"8525\" y=\"1294.9864820352752\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <UserObject label=\"matcher\" value=\"matcher\" id=\"bc250234-cbc6-45a9-bb30-a680e8a25434\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=28;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f9f3f3\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" vertex=\"1\">\n            <mxGeometry x=\"10700\" y=\"919.435110722168\" width=\"700\" height=\"640\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"src\" value=\"src\" id=\"97c08d6d-4900-4c90-8c85-4ba11ef19a61\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=25;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#f4e9e9\" parent=\"bc250234-cbc6-45a9-bb30-a680e8a25434\" vertex=\"1\">\n            <mxGeometry x=\"95\" y=\"70\" width=\"510\" height=\"500\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"lib.rs\" value=\"lib.rs\" id=\"c50efe68-b749-49a4-a253-6c52052d4fe6\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=16;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"97c08d6d-4900-4c90-8c85-4ba11ef19a61\" vertex=\"1\">\n            <mxGeometry x=\"165\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"interpolate.rs\" value=\"interpolate.rs\" id=\"613effaa-920d-4cad-84b3-74ea88807b5c\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=22;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;align=left;verticalAlign=bottom;spacing=0;spacingTop=-14;spacingLeft=15;arcSize=4;labelPosition=center;verticalLabelPosition=top;;fillColor=#efdfdf\" parent=\"97c08d6d-4900-4c90-8c85-4ba11ef19a61\" vertex=\"1\">\n            <mxGeometry x=\"95\" y=\"200\" width=\"320\" height=\"230\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <UserObject label=\"Substitute Capture Groups - interpolate.rs:L14-57\" value=\"Substitute Capture Groups - interpolate.rs:L14-57\" id=\"778e8bbe-678f-4a3c-8911-52fab94d475b\">\n          <mxCell style=\"rounded=1;whiteSpace=wrap;html=1;container=1;glass=0;comic=0;fontSize=12;fontColor=#615B5B;strokeWidth=0.7;strokeColor=#999190;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontStyle=0;\" parent=\"613effaa-920d-4cad-84b3-74ea88807b5c\" vertex=\"1\">\n            <mxGeometry x=\"70\" y=\"70\" width=\"180\" height=\"90\" as=\"geometry\" />\n          </mxCell>\n        </UserObject>\n        <mxCell id=\"ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02\" value=\"Create Printer&#xa;Sink\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"d10772ea-5a19-4c72-ad04-754a0208a213\" target=\"2897d065-bc9c-47a0-935d-58720d432394\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"1985\" y=\"1601.9864916644442\" />\n              <mxPoint x=\"1985\" y=\"1600.799148959427\" />\n              <mxPoint x=\"2495\" y=\"1600.799148959427\" />\n              <mxPoint x=\"2495\" y=\"1616.9599885872387\" />\n              <mxPoint x=\"4250\" y=\"1616.9599885872387\" />\n              <mxPoint x=\"4250\" y=\"1164.9864820352748\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"5442b0ed-343b-41ed-b7fc-f5baf0e5991c\" value=\"Pass Data&#xa;to Core&#xa;Interpolation Logic\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=10;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"6f4daaff-ddca-41f0-ad53-d48d290d885b\" target=\"778e8bbe-678f-4a3c-8911-52fab94d475b\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\" />\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"50dbd73e-3872-4462-8540-93e549529ef2\" value=\"Return Replaced&#xa;Text\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"778e8bbe-678f-4a3c-8911-52fab94d475b\" target=\"7138d741-53de-48fc-a962-99b13e1d7706\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"11465\" y=\"1304.435110722168\" />\n              <mxPoint x=\"11465\" y=\"435.9673672664875\" />\n              <mxPoint x=\"8535\" y=\"435.9673672664875\" />\n              <mxPoint x=\"8535\" y=\"803.5436142086762\" />\n              <mxPoint x=\"8760\" y=\"803.5436142086762\" />\n              <mxPoint x=\"8760\" y=\"802.8391934724086\" />\n              <mxPoint x=\"8935\" y=\"802.8391934724086\" />\n              <mxPoint x=\"8935\" y=\"776.0398877110172\" />\n              <mxPoint x=\"9120\" y=\"776.0398877110172\" />\n              <mxPoint x=\"9120\" y=\"774.9864820352749\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n        <mxCell id=\"bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d\" value=\"Pass Match&#xa;Data to&#xa;Printer\" style=\"edgeStyle=orthogonalEdgeStyle;shape=connector;rounded=1;sketch=0;jumpStyle=arc;jumpSize=17;orthogonalLoop=1;jettySize=auto;html=0;shadow=0;labelBackgroundColor=none;fontFamily=Poppins;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DPoppins;fontSize=20;fontColor=#5C5C5C;endArrow=block;endFill=1;endSize=5;sourcePerimeterSpacing=0;targetPerimeterSpacing=0;strokeColor=#A1A1A1;strokeWidth=2;arcSize=50;labelPosition=center;verticalLabelPosition=top;align=center;verticalAlign=bottom;container=1;\" parent=\"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa\" source=\"fa7bdd21-d61e-497f-9427-eda4d39438cd\" target=\"fd865b14-7ee5-4b22-afc0-f1642849edd8\" edge=\"1\">\n          <mxGeometry relative=\"1\" as=\"geometry\">\n            <Array as=\"points\">\n              <mxPoint x=\"4045\" y=\"1089.412099325037\" />\n              <mxPoint x=\"4045\" y=\"1093.1805559790264\" />\n              <mxPoint x=\"4220\" y=\"1093.1805559790262\" />\n              <mxPoint x=\"4220\" y=\"177.8322803872744\" />\n              <mxPoint x=\"8525\" y=\"177.8322803872744\" />\n              <mxPoint x=\"8525\" y=\"904.986482035275\" />\n            </Array>\n          </mxGeometry>\n        </mxCell>\n      </root>\n    </mxGraphModel>\n  </diagram>\n</mxfile>\n",
+	"fileName": "",
+	"fileURL": "github",
+	"repoData": {
+		"crates": {
+			"path": "crates",
+			"fileName": "crates",
+			"cellName": "crates",
+			"cellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa",
+			"visible": true,
+			"children": [
+				"crates/core",
+				"crates/ignore",
+				"crates/searcher",
+				"crates/printer",
+				"crates/cli",
+				"crates/matcher"
+			]
+		},
+		"crates/cli": {
+			"path": "crates/cli",
+			"fileName": "cli",
+			"cellName": "cli",
+			"cellId": "63a9d821-0a1b-4daf-9f0d-0482d2ded1a5",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa",
+			"children": [
+				"crates/cli/src"
+			]
+		},
+		"crates/cli/src": {
+			"path": "crates/cli/src",
+			"fileName": "src",
+			"cellName": "src",
+			"cellId": "bbd871fb-2a85-4f90-b28d-abc336580454",
+			"visible": true,
+			"parentCellId": "63a9d821-0a1b-4daf-9f0d-0482d2ded1a5",
+			"children": [
+				"crates/cli/src/wtr.rs",
+				"crates/cli/src/decompress.rs",
+				"crates/cli/src/process.rs"
+			]
+		},
+		"crates/cli/src/decompress.rs": {
+			"path": "crates/cli/src/decompress.rs",
+			"fileName": "decompress.rs",
+			"cellName": "decompress.rs",
+			"cellId": "2e2dd6c4-6e83-424c-8da5-b8171ce5479f",
+			"visible": true,
+			"parentCellId": "bbd871fb-2a85-4f90-b28d-abc336580454",
+			"children": [
+				"crates/cli/src/decompress.rs-simstep-8e6d5c6c-f294-4dae-901e-1f74837d5791",
+				"crates/cli/src/decompress.rs-simstep-d8c3b0bc-3ff0-4aee-bf11-5653be83ea9b"
+			]
+		},
+		"crates/cli/src/process.rs": {
+			"path": "crates/cli/src/process.rs",
+			"fileName": "process.rs",
+			"cellName": "process.rs",
+			"cellId": "cd38b9ee-aec0-4a28-87fb-462f8ec364c2",
+			"visible": true,
+			"parentCellId": "bbd871fb-2a85-4f90-b28d-abc336580454"
+		},
+		"crates/cli/src/wtr.rs": {
+			"path": "crates/cli/src/wtr.rs",
+			"fileName": "wtr.rs",
+			"cellName": "wtr.rs",
+			"cellId": "3aa0bd2b-5f86-46a6-8763-2b5371ab045d",
+			"visible": true,
+			"parentCellId": "bbd871fb-2a85-4f90-b28d-abc336580454"
+		},
+		"crates/core": {
+			"path": "crates/core",
+			"fileName": "core",
+			"cellName": "core",
+			"cellId": "debf18dd-047e-44e4-9016-2ee07faaf18b",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa",
+			"children": [
+				"crates/core/main.rs",
+				"crates/core/search.rs",
+				"crates/core/flags"
+			]
+		},
+		"crates/core/flags": {
+			"path": "crates/core/flags",
+			"fileName": "flags",
+			"cellName": "flags",
+			"cellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e",
+			"visible": true,
+			"parentCellId": "debf18dd-047e-44e4-9016-2ee07faaf18b",
+			"children": [
+				"crates/core/flags/defs.rs",
+				"crates/core/flags/hiargs.rs",
+				"crates/core/flags/lowargs.rs",
+				"crates/core/flags/parse.rs",
+				"crates/core/flags/config.rs"
+			]
+		},
+		"crates/core/flags/config.rs": {
+			"path": "crates/core/flags/config.rs",
+			"fileName": "config.rs",
+			"cellName": "config.rs",
+			"cellId": "7715a01b-ffc3-4e46-8446-5f55b158012e",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e",
+			"children": [
+				"crates/core/flags/config.rs-simstep-feb6f7e3-8788-40e3-9408-fc32898d04e0"
+			]
+		},
+		"crates/core/flags/defs.rs": {
+			"path": "crates/core/flags/defs.rs",
+			"fileName": "defs.rs",
+			"cellName": "defs.rs",
+			"cellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e",
+			"children": [
+				"crates/core/flags/defs.rs-simstep-8cdd9622-d34d-456c-8cbd-df9939e9ea65",
+				"crates/core/flags/defs.rs-simstep-87114100-cc4e-473c-8213-577fe0eed9e4",
+				"crates/core/flags/defs.rs-simstep-a234a4fc-6910-49ab-9692-3629e7029a19",
+				"crates/core/flags/defs.rs-simstep-b94bbc3b-921b-4dcf-8678-da515f9752ad",
+				"crates/core/flags/defs.rs-simstep-2d298238-6bc9-4690-a137-78749b0e824e",
+				"crates/core/flags/defs.rs-simstep-028f086b-a018-4564-82a0-7069685c5fe6",
+				"crates/core/flags/defs.rs-simstep-0548c99b-847a-422e-98ee-68d9d8e74274",
+				"crates/core/flags/defs.rs-simstep-6c3035dc-c539-474d-9d08-380371747982",
+				"crates/core/flags/defs.rs-simstep-ac7d4e6d-0c1f-4f09-835e-15a57c688ef7",
+				"crates/core/flags/defs.rs-simstep-1e1e2b32-f650-47f5-b13d-e8b6a6f9c47e"
+			]
+		},
+		"crates/core/flags/hiargs.rs": {
+			"path": "crates/core/flags/hiargs.rs",
+			"fileName": "hiargs.rs",
+			"cellName": "hiargs.rs",
+			"cellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e",
+			"children": [
+				"crates/core/flags/hiargs.rs-simstep-1c3b6417-4da9-4192-a8da-70e0f7079d88",
+				"crates/core/flags/hiargs.rs-simstep-9b9b64e8-bf1a-43f6-aefa-f2bad985f294",
+				"crates/core/flags/hiargs.rs-simstep-3e717203-9460-44e7-835e-49cd8340dbc6",
+				"crates/core/flags/hiargs.rs-simstep-f9ec9573-13f1-41ea-8286-d86c8bb66a3f",
+				"crates/core/flags/hiargs.rs-simstep-74c81953-d698-4cf4-8ed6-8324c078e7ff",
+				"crates/core/flags/hiargs.rs-simstep-54b70a6d-b1ee-42e1-87f2-ac6a947ac7cc",
+				"crates/core/flags/hiargs.rs-simstep-978bc900-d4de-4d46-a790-971e589fa824",
+				"crates/core/flags/hiargs.rs-simstep-f93bf41d-9482-4e31-8513-5f150b8839e1",
+				"crates/core/flags/hiargs.rs-simstep-0d5fe06c-3899-4862-b2a7-dcbeb7d70e78",
+				"crates/core/flags/hiargs.rs-simstep-358073c2-ed72-4198-91b7-b96779ef1070",
+				"crates/core/flags/hiargs.rs-simstep-487a5b7a-65d2-4fdf-9a73-2911d82b7f61"
+			]
+		},
+		"crates/core/flags/lowargs.rs": {
+			"path": "crates/core/flags/lowargs.rs",
+			"fileName": "lowargs.rs",
+			"cellName": "lowargs.rs",
+			"cellId": "5440e915-a99c-4d7c-a041-ed3214ef356e",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"crates/core/flags/parse.rs": {
+			"path": "crates/core/flags/parse.rs",
+			"fileName": "parse.rs",
+			"cellName": "parse.rs",
+			"cellId": "23cc6e15-ec4f-467a-9e19-4cca7bad4056",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e",
+			"children": [
+				"crates/core/flags/parse.rs-simstep-480456a6-14e2-435f-a647-f548b7db9da2",
+				"crates/core/flags/parse.rs-simstep-6f8fc4cd-ab98-4f17-8883-d5938b953bf4"
+			]
+		},
+		"crates/core/main.rs": {
+			"path": "crates/core/main.rs",
+			"fileName": "main.rs",
+			"cellName": "main.rs",
+			"cellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53",
+			"visible": true,
+			"parentCellId": "debf18dd-047e-44e4-9016-2ee07faaf18b",
+			"children": [
+				"crates/core/main.rs-simstep-89b90516-5fbf-4f93-bc07-ad7b9c73c8ac",
+				"crates/core/main.rs-simstep-74f2428a-8ad9-4ee1-9186-810db6e72b63",
+				"crates/core/main.rs-simstep-4b7da167-9174-4295-83bc-b069e9331106",
+				"crates/core/main.rs-simstep-32e761c6-06c3-4e7d-85a8-5a944e48aea5",
+				"crates/core/main.rs-simstep-eef7e6fb-0baf-47db-8786-cbef119a75c6"
+			]
+		},
+		"crates/core/search.rs": {
+			"path": "crates/core/search.rs",
+			"fileName": "search.rs",
+			"cellName": "search.rs",
+			"cellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"visible": true,
+			"parentCellId": "debf18dd-047e-44e4-9016-2ee07faaf18b",
+			"children": [
+				"crates/core/search.rs-simstep-7151f213-e403-4b2d-ad9f-112e4d69af4e",
+				"crates/core/search.rs-simstep-b53b5e9f-939c-4ee5-a88c-437397bbe57f",
+				"crates/core/search.rs-simstep-bbe67bc0-80ec-4573-af90-99a3044945be",
+				"crates/core/search.rs-simstep-b5e56eed-3eaf-41fc-8ace-df49b7975aa0",
+				"crates/core/search.rs-simstep-804852c5-f087-4553-a287-f0b4309ea273",
+				"crates/core/search.rs-simstep-d3f25c6a-769a-46e8-8b8d-bbdc9e2a2f86",
+				"crates/core/search.rs-simstep-26355175-5341-488d-a476-30e2f796176c",
+				"crates/core/search.rs-simstep-cd58a6a2-35b8-4bee-9a79-e6419ea3942d"
+			]
+		},
+		"crates/ignore": {
+			"path": "crates/ignore",
+			"fileName": "ignore",
+			"cellName": "ignore",
+			"cellId": "e66e9e2a-b18d-4361-a5a8-c389d3bb600e",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa",
+			"children": [
+				"crates/ignore/src"
+			]
+		},
+		"crates/ignore/src": {
+			"path": "crates/ignore/src",
+			"fileName": "src",
+			"cellName": "src",
+			"cellId": "71ab6f47-6fdc-4073-9554-d51e4844c87e",
+			"visible": true,
+			"parentCellId": "e66e9e2a-b18d-4361-a5a8-c389d3bb600e",
+			"children": [
+				"crates/ignore/src/walk.rs",
+				"crates/ignore/src/gitignore.rs",
+				"crates/ignore/src/dir.rs"
+			]
+		},
+		"crates/ignore/src/dir.rs": {
+			"path": "crates/ignore/src/dir.rs",
+			"fileName": "dir.rs",
+			"cellName": "dir.rs",
+			"cellId": "75eb0e51-195c-493c-a132-126ec4994742",
+			"visible": true,
+			"parentCellId": "71ab6f47-6fdc-4073-9554-d51e4844c87e",
+			"children": [
+				"crates/ignore/src/dir.rs-simstep-025792a2-a063-4347-ac2f-5978300032d4",
+				"crates/ignore/src/dir.rs-simstep-18eead12-d6f4-4f5d-82f5-979a40c61c6b",
+				"crates/ignore/src/dir.rs-simstep-c47913bd-2425-4d97-b7c3-c66f5e6a084c"
+			]
+		},
+		"crates/ignore/src/gitignore.rs": {
+			"path": "crates/ignore/src/gitignore.rs",
+			"fileName": "gitignore.rs",
+			"cellName": "gitignore.rs",
+			"cellId": "6f90ad17-9829-4744-a1f0-1b721c6339ab",
+			"visible": true,
+			"parentCellId": "71ab6f47-6fdc-4073-9554-d51e4844c87e",
+			"children": [
+				"crates/ignore/src/gitignore.rs-simstep-1b894775-da3b-4578-b6d2-484f23e1ec50"
+			]
+		},
+		"crates/ignore/src/walk.rs": {
+			"path": "crates/ignore/src/walk.rs",
+			"fileName": "walk.rs",
+			"cellName": "walk.rs",
+			"cellId": "1280b1d7-f3fd-41aa-9a95-53e5509e82a0",
+			"visible": true,
+			"parentCellId": "71ab6f47-6fdc-4073-9554-d51e4844c87e",
+			"children": [
+				"crates/ignore/src/walk.rs-simstep-9e34d9f4-60cf-49dd-9881-81338f158b78"
+			]
+		},
+		"crates/matcher": {
+			"path": "crates/matcher",
+			"fileName": "matcher",
+			"cellName": "matcher",
+			"cellId": "bc250234-cbc6-45a9-bb30-a680e8a25434",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa",
+			"children": [
+				"crates/matcher/src"
+			]
+		},
+		"crates/matcher/src": {
+			"path": "crates/matcher/src",
+			"fileName": "src",
+			"cellName": "src",
+			"cellId": "97c08d6d-4900-4c90-8c85-4ba11ef19a61",
+			"visible": true,
+			"parentCellId": "bc250234-cbc6-45a9-bb30-a680e8a25434",
+			"children": [
+				"crates/matcher/src/lib.rs",
+				"crates/matcher/src/interpolate.rs"
+			]
+		},
+		"crates/matcher/src/interpolate.rs": {
+			"path": "crates/matcher/src/interpolate.rs",
+			"fileName": "interpolate.rs",
+			"cellName": "interpolate.rs",
+			"cellId": "613effaa-920d-4cad-84b3-74ea88807b5c",
+			"visible": true,
+			"parentCellId": "97c08d6d-4900-4c90-8c85-4ba11ef19a61",
+			"children": [
+				"crates/matcher/src/interpolate.rs-simstep-86be35a1-d0f0-424f-9f87-9f3e7e924ed7"
+			]
+		},
+		"crates/matcher/src/lib.rs": {
+			"path": "crates/matcher/src/lib.rs",
+			"fileName": "lib.rs",
+			"cellName": "lib.rs",
+			"cellId": "c50efe68-b749-49a4-a253-6c52052d4fe6",
+			"visible": true,
+			"parentCellId": "97c08d6d-4900-4c90-8c85-4ba11ef19a61"
+		},
+		"crates/printer": {
+			"path": "crates/printer",
+			"fileName": "printer",
+			"cellName": "printer",
+			"cellId": "1e13c78f-707d-4438-9cb6-50f939de598d",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa",
+			"children": [
+				"crates/printer/src"
+			]
+		},
+		"crates/printer/src": {
+			"path": "crates/printer/src",
+			"fileName": "src",
+			"cellName": "src",
+			"cellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3",
+			"visible": true,
+			"parentCellId": "1e13c78f-707d-4438-9cb6-50f939de598d",
+			"children": [
+				"crates/printer/src/standard.rs",
+				"crates/printer/src/summary.rs",
+				"crates/printer/src/json.rs",
+				"crates/printer/src/jsont.rs",
+				"crates/printer/src/util.rs"
+			]
+		},
+		"crates/printer/src/json.rs": {
+			"path": "crates/printer/src/json.rs",
+			"fileName": "json.rs",
+			"cellName": "json.rs",
+			"cellId": "f64da727-0b70-4f27-880c-862de575dd0a",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3",
+			"children": [
+				"crates/printer/src/json.rs-simstep-081da804-e09a-472d-b815-dae4ad93407a"
+			]
+		},
+		"crates/printer/src/jsont.rs": {
+			"path": "crates/printer/src/jsont.rs",
+			"fileName": "jsont.rs",
+			"cellName": "jsont.rs",
+			"cellId": "0e8f4962-c836-4d7b-93b1-b8b18f64a725",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3",
+			"children": [
+				"crates/printer/src/jsont.rs-simstep-d4b5b12e-dfcb-4663-9015-fe99a6c72b8a"
+			]
+		},
+		"crates/printer/src/standard.rs": {
+			"path": "crates/printer/src/standard.rs",
+			"fileName": "standard.rs",
+			"cellName": "standard.rs",
+			"cellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3",
+			"children": [
+				"crates/printer/src/standard.rs-simstep-c346a2e8-331c-4d3f-a2cb-9e1afcbc7ac1",
+				"crates/printer/src/standard.rs-simstep-127bdb74-45b0-4569-b7be-89b9b808c24b",
+				"crates/printer/src/standard.rs-simstep-89d044cb-ba97-423b-b877-e022fd3aadc5",
+				"crates/printer/src/standard.rs-simstep-30500bdd-89dc-4b27-917c-7c554ca5ec5a",
+				"crates/printer/src/standard.rs-simstep-bfb926ff-af12-4d27-8b74-1b216918243c",
+				"crates/printer/src/standard.rs-simstep-6506fc09-ffcb-4339-bd4a-e84253d0c1b6",
+				"crates/printer/src/standard.rs-simstep-0c6dc36c-3ce4-40c7-9fe0-91ab470855a5",
+				"crates/printer/src/standard.rs-simstep-4ff85d42-34c0-41f3-a939-2eca1f58810d"
+			]
+		},
+		"crates/printer/src/summary.rs": {
+			"path": "crates/printer/src/summary.rs",
+			"fileName": "summary.rs",
+			"cellName": "summary.rs",
+			"cellId": "32eebe96-86ec-41f2-ac0d-3c5874bb3b44",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3",
+			"children": [
+				"crates/printer/src/summary.rs-simstep-10c3a95e-70bc-4232-9eb2-d16a22ee39cb"
+			]
+		},
+		"crates/printer/src/util.rs": {
+			"path": "crates/printer/src/util.rs",
+			"fileName": "util.rs",
+			"cellName": "util.rs",
+			"cellId": "d77a4716-11cf-4b4f-8142-92ff0d375bf2",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3",
+			"children": [
+				"crates/printer/src/util.rs-simstep-7e01b0f6-7c2f-4578-8bcd-e92dff0173d8"
+			]
+		},
+		"crates/searcher": {
+			"path": "crates/searcher",
+			"fileName": "searcher",
+			"cellName": "searcher",
+			"cellId": "50938285-d56a-4404-8807-f18ce4804f62",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa",
+			"children": [
+				"crates/searcher/src"
+			]
+		},
+		"crates/searcher/src": {
+			"path": "crates/searcher/src",
+			"fileName": "src",
+			"cellName": "src",
+			"cellId": "f08293c4-eb87-4446-8a1c-b208513e40bd",
+			"visible": true,
+			"parentCellId": "50938285-d56a-4404-8807-f18ce4804f62",
+			"children": [
+				"crates/searcher/src/searcher",
+				"crates/searcher/src/line_buffer.rs",
+				"crates/searcher/src/sink.rs"
+			]
+		},
+		"crates/searcher/src/line_buffer.rs": {
+			"path": "crates/searcher/src/line_buffer.rs",
+			"fileName": "line_buffer.rs",
+			"cellName": "line_buffer.rs",
+			"cellId": "4d08cdc3-7059-4f0e-b863-a2557475e192",
+			"visible": true,
+			"parentCellId": "f08293c4-eb87-4446-8a1c-b208513e40bd",
+			"children": [
+				"crates/searcher/src/line_buffer.rs-simstep-722f695f-377d-448e-9b44-9265ca920a1c"
+			]
+		},
+		"crates/searcher/src/searcher": {
+			"path": "crates/searcher/src/searcher",
+			"fileName": "searcher",
+			"cellName": "searcher",
+			"cellId": "7a2a4538-5e5a-4df6-85cc-b341c95545a1",
+			"visible": true,
+			"parentCellId": "f08293c4-eb87-4446-8a1c-b208513e40bd",
+			"children": [
+				"crates/searcher/src/searcher/mod.rs",
+				"crates/searcher/src/searcher/core.rs",
+				"crates/searcher/src/searcher/glue.rs"
+			]
+		},
+		"crates/searcher/src/searcher/core.rs": {
+			"path": "crates/searcher/src/searcher/core.rs",
+			"fileName": "core.rs",
+			"cellName": "core.rs",
+			"cellId": "d7cca382-50e5-4a19-a577-d94f1ea52683",
+			"visible": true,
+			"parentCellId": "7a2a4538-5e5a-4df6-85cc-b341c95545a1",
+			"children": [
+				"crates/searcher/src/searcher/core.rs-simstep-bb853ccd-0b47-4741-ae7c-abfd7d75fa92"
+			]
+		},
+		"crates/searcher/src/searcher/glue.rs": {
+			"path": "crates/searcher/src/searcher/glue.rs",
+			"fileName": "glue.rs",
+			"cellName": "glue.rs",
+			"cellId": "ef09f321-34b3-4a42-869e-19002e3a4382",
+			"visible": true,
+			"parentCellId": "7a2a4538-5e5a-4df6-85cc-b341c95545a1",
+			"children": [
+				"crates/searcher/src/searcher/glue.rs-simstep-a0a4371e-e74e-4fa4-b643-6f351759a477"
+			]
+		},
+		"crates/searcher/src/searcher/mod.rs": {
+			"path": "crates/searcher/src/searcher/mod.rs",
+			"fileName": "mod.rs",
+			"cellName": "mod.rs",
+			"cellId": "f05bde61-7d65-4d33-a433-141321ba0c95",
+			"visible": true,
+			"parentCellId": "7a2a4538-5e5a-4df6-85cc-b341c95545a1",
+			"children": [
+				"crates/searcher/src/searcher/mod.rs-simstep-886efe56-50a7-4387-99c3-a460e0a03834",
+				"crates/searcher/src/searcher/mod.rs-simstep-5e4d02cc-50e4-40ab-a1f4-cd11b845f582",
+				"crates/searcher/src/searcher/mod.rs-simstep-cc78378e-da78-43a0-926d-0c40f5ca294d"
+			]
+		},
+		"crates/searcher/src/sink.rs": {
+			"path": "crates/searcher/src/sink.rs",
+			"fileName": "sink.rs",
+			"cellName": "sink.rs",
+			"cellId": "548054c3-b0a3-4817-8e47-3dfac7999d27",
+			"visible": true,
+			"parentCellId": "f08293c4-eb87-4446-8a1c-b208513e40bd"
+		},
+		"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa": {
+			"path": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa",
+			"fileName": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa",
+			"cellName": "crates",
+			"cellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa",
+			"visible": true
+		},
+		"debf18dd-047e-44e4-9016-2ee07faaf18b": {
+			"path": "debf18dd-047e-44e4-9016-2ee07faaf18b",
+			"fileName": "debf18dd-047e-44e4-9016-2ee07faaf18b",
+			"cellName": "core",
+			"cellId": "debf18dd-047e-44e4-9016-2ee07faaf18b",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"e66e9e2a-b18d-4361-a5a8-c389d3bb600e": {
+			"path": "e66e9e2a-b18d-4361-a5a8-c389d3bb600e",
+			"fileName": "e66e9e2a-b18d-4361-a5a8-c389d3bb600e",
+			"cellName": "ignore",
+			"cellId": "e66e9e2a-b18d-4361-a5a8-c389d3bb600e",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"50938285-d56a-4404-8807-f18ce4804f62": {
+			"path": "50938285-d56a-4404-8807-f18ce4804f62",
+			"fileName": "50938285-d56a-4404-8807-f18ce4804f62",
+			"cellName": "searcher",
+			"cellId": "50938285-d56a-4404-8807-f18ce4804f62",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"1e13c78f-707d-4438-9cb6-50f939de598d": {
+			"path": "1e13c78f-707d-4438-9cb6-50f939de598d",
+			"fileName": "1e13c78f-707d-4438-9cb6-50f939de598d",
+			"cellName": "printer",
+			"cellId": "1e13c78f-707d-4438-9cb6-50f939de598d",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"0508ecd1-fc1d-499a-8811-8cfff3245a53": {
+			"path": "0508ecd1-fc1d-499a-8811-8cfff3245a53",
+			"fileName": "0508ecd1-fc1d-499a-8811-8cfff3245a53",
+			"cellName": "main.rs",
+			"cellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53",
+			"visible": true,
+			"parentCellId": "debf18dd-047e-44e4-9016-2ee07faaf18b"
+		},
+		"fbd72afc-9b46-46a0-a2f0-c3757937fd45": {
+			"path": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"fileName": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"cellName": "search.rs",
+			"cellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"visible": true,
+			"parentCellId": "debf18dd-047e-44e4-9016-2ee07faaf18b"
+		},
+		"71ab6f47-6fdc-4073-9554-d51e4844c87e": {
+			"path": "71ab6f47-6fdc-4073-9554-d51e4844c87e",
+			"fileName": "71ab6f47-6fdc-4073-9554-d51e4844c87e",
+			"cellName": "src",
+			"cellId": "71ab6f47-6fdc-4073-9554-d51e4844c87e",
+			"visible": true,
+			"parentCellId": "e66e9e2a-b18d-4361-a5a8-c389d3bb600e"
+		},
+		"f08293c4-eb87-4446-8a1c-b208513e40bd": {
+			"path": "f08293c4-eb87-4446-8a1c-b208513e40bd",
+			"fileName": "f08293c4-eb87-4446-8a1c-b208513e40bd",
+			"cellName": "src",
+			"cellId": "f08293c4-eb87-4446-8a1c-b208513e40bd",
+			"visible": true,
+			"parentCellId": "50938285-d56a-4404-8807-f18ce4804f62"
+		},
+		"a9858ff0-4d39-4382-b671-fae85b74aaa3": {
+			"path": "a9858ff0-4d39-4382-b671-fae85b74aaa3",
+			"fileName": "a9858ff0-4d39-4382-b671-fae85b74aaa3",
+			"cellName": "src",
+			"cellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3",
+			"visible": true,
+			"parentCellId": "1e13c78f-707d-4438-9cb6-50f939de598d"
+		},
+		"1280b1d7-f3fd-41aa-9a95-53e5509e82a0": {
+			"path": "1280b1d7-f3fd-41aa-9a95-53e5509e82a0",
+			"fileName": "1280b1d7-f3fd-41aa-9a95-53e5509e82a0",
+			"cellName": "walk.rs",
+			"cellId": "1280b1d7-f3fd-41aa-9a95-53e5509e82a0",
+			"visible": true,
+			"parentCellId": "71ab6f47-6fdc-4073-9554-d51e4844c87e"
+		},
+		"7a2a4538-5e5a-4df6-85cc-b341c95545a1": {
+			"path": "7a2a4538-5e5a-4df6-85cc-b341c95545a1",
+			"fileName": "7a2a4538-5e5a-4df6-85cc-b341c95545a1",
+			"cellName": "searcher",
+			"cellId": "7a2a4538-5e5a-4df6-85cc-b341c95545a1",
+			"visible": true,
+			"parentCellId": "f08293c4-eb87-4446-8a1c-b208513e40bd"
+		},
+		"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550": {
+			"path": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"fileName": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"cellName": "standard.rs",
+			"cellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3"
+		},
+		"f05bde61-7d65-4d33-a433-141321ba0c95": {
+			"path": "f05bde61-7d65-4d33-a433-141321ba0c95",
+			"fileName": "f05bde61-7d65-4d33-a433-141321ba0c95",
+			"cellName": "mod.rs",
+			"cellId": "f05bde61-7d65-4d33-a433-141321ba0c95",
+			"visible": true,
+			"parentCellId": "7a2a4538-5e5a-4df6-85cc-b341c95545a1"
+		},
+		"d7cca382-50e5-4a19-a577-d94f1ea52683": {
+			"path": "d7cca382-50e5-4a19-a577-d94f1ea52683",
+			"fileName": "d7cca382-50e5-4a19-a577-d94f1ea52683",
+			"cellName": "core.rs",
+			"cellId": "d7cca382-50e5-4a19-a577-d94f1ea52683",
+			"visible": true,
+			"parentCellId": "7a2a4538-5e5a-4df6-85cc-b341c95545a1"
+		},
+		"f571f13d-a5b1-4696-810d-016af864988b": {
+			"path": "f571f13d-a5b1-4696-810d-016af864988b",
+			"fileName": "f571f13d-a5b1-4696-810d-016af864988b",
+			"cellName": "Start Parallel Search - main.rs:L86-90",
+			"cellId": "f571f13d-a5b1-4696-810d-016af864988b",
+			"visible": true,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53"
+		},
+		"crates/core/main.rs-simstep-89b90516-5fbf-4f93-bc07-ad7b9c73c8ac": {
+			"path": "crates/core/main.rs-simstep-89b90516-5fbf-4f93-bc07-ad7b9c73c8ac",
+			"fileName": "main.rs",
+			"wiki": "The main 'run' function determines that a parallel search is required based on the command-line arguments (e.g., thread count > 1). It then invokes the 'search_parallel' function to handle the multithreaded search execution.",
+			"cellName": "Start Parallel Search - main.rs:L86-90",
+			"cellId": "f571f13d-a5b1-4696-810d-016af864988b",
+			"visible": true,
+			"startLine": 86,
+			"endLine": 90,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53",
+			"parentPath": "crates/core/main.rs"
+		},
+		"bdea59c2-5355-45cb-babe-67dfd0c2717e": {
+			"path": "bdea59c2-5355-45cb-babe-67dfd0c2717e",
+			"fileName": "bdea59c2-5355-45cb-babe-67dfd0c2717e",
+			"cellName": "Configure Parallel Directory Walker - main.rs:L185-187",
+			"cellId": "bdea59c2-5355-45cb-babe-67dfd0c2717e",
+			"visible": true,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53"
+		},
+		"crates/core/main.rs-simstep-74f2428a-8ad9-4ee1-9186-810db6e72b63": {
+			"path": "crates/core/main.rs-simstep-74f2428a-8ad9-4ee1-9186-810db6e72b63",
+			"fileName": "main.rs",
+			"wiki": "The 'search_parallel' function constructs a 'WalkParallel' instance from the 'ignore' crate. This walker is configured to respect ignore files (.gitignore, .ignore) and other filtering rules. It also prepares a 'SearchWorker' which encapsulates the compiled regex matcher, searcher, and printer. The 'run' method is then called on the walker with a closure that defines the work to be done by each thread.",
+			"cellName": "Configure Parallel Directory Walker - main.rs:L185-187",
+			"cellId": "bdea59c2-5355-45cb-babe-67dfd0c2717e",
+			"visible": true,
+			"startLine": 185,
+			"endLine": 187,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53",
+			"parentPath": "crates/core/main.rs"
+		},
+		"2196ff9f-2695-4b8a-8a75-d5702b89371f": {
+			"path": "2196ff9f-2695-4b8a-8a75-d5702b89371f",
+			"fileName": "2196ff9f-2695-4b8a-8a75-d5702b89371f",
+			"cellName": "Worker Thread Processes a File Entry - main.rs:L193-200",
+			"cellId": "2196ff9f-2695-4b8a-8a75-d5702b89371f",
+			"visible": true,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53"
+		},
+		"crates/core/main.rs-simstep-4b7da167-9174-4295-83bc-b069e9331106": {
+			"path": "crates/core/main.rs-simstep-4b7da167-9174-4295-83bc-b069e9331106",
+			"fileName": "main.rs",
+			"wiki": "A worker thread receives a 'DirEntry' result from the work queue. It builds a 'Haystack' object (a representation of the thing to be searched) and invokes 'searcher.search()' to perform the search on that specific file, using its own cloned instance of the 'SearchWorker'.",
+			"cellName": "Worker Thread Processes a File Entry - main.rs:L193-200",
+			"cellId": "2196ff9f-2695-4b8a-8a75-d5702b89371f",
+			"visible": true,
+			"startLine": 193,
+			"endLine": 200,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53",
+			"parentPath": "crates/core/main.rs"
+		},
+		"32bcfcb7-b4b6-4993-893c-1676d6ecaf77": {
+			"path": "32bcfcb7-b4b6-4993-893c-1676d6ecaf77",
+			"fileName": "32bcfcb7-b4b6-4993-893c-1676d6ecaf77",
+			"cellName": "Choose Search Strategy (Mmap vs. Incremental) - mod.rs:L699-702",
+			"cellId": "32bcfcb7-b4b6-4993-893c-1676d6ecaf77",
+			"visible": true,
+			"parentCellId": "f05bde61-7d65-4d33-a433-141321ba0c95"
+		},
+		"crates/searcher/src/searcher/mod.rs-simstep-886efe56-50a7-4387-99c3-a460e0a03834": {
+			"path": "crates/searcher/src/searcher/mod.rs-simstep-886efe56-50a7-4387-99c3-a460e0a03834",
+			"fileName": "mod.rs",
+			"wiki": "The 'Searcher' checks its configuration and the file metadata to decide on the optimal search strategy. For high performance on single files, it often chooses to memory-map the file, which allows searching it directly in memory as a byte slice.",
+			"cellName": "Choose Search Strategy (Mmap vs. Incremental) - mod.rs:L699-702",
+			"cellId": "32bcfcb7-b4b6-4993-893c-1676d6ecaf77",
+			"visible": true,
+			"startLine": 699,
+			"endLine": 702,
+			"parentCellId": "f05bde61-7d65-4d33-a433-141321ba0c95",
+			"parentPath": "crates/searcher/src/searcher/mod.rs"
+		},
+		"b4d3b26e-19e7-477d-979f-702fb33ff014": {
+			"path": "b4d3b26e-19e7-477d-979f-702fb33ff014",
+			"fileName": "b4d3b26e-19e7-477d-979f-702fb33ff014",
+			"cellName": "Execute Fast Line-by-Line Search - core.rs:L479-497",
+			"cellId": "b4d3b26e-19e7-477d-979f-702fb33ff014",
+			"visible": true,
+			"parentCellId": "d7cca382-50e5-4a19-a577-d94f1ea52683"
+		},
+		"crates/searcher/src/searcher/core.rs-simstep-bb853ccd-0b47-4741-ae7c-abfd7d75fa92": {
+			"path": "crates/searcher/src/searcher/core.rs-simstep-bb853ccd-0b47-4741-ae7c-abfd7d75fa92",
+			"fileName": "core.rs",
+			"wiki": "The search routine for slices ('SliceByLine') iterates through the byte slice. It uses a highly optimized 'fast path' that leverages literal extraction from the regex pattern to quickly find candidate lines, skipping non-matching lines without invoking the full regex engine. Once a candidate is found, the regex match is confirmed.",
+			"cellName": "Execute Fast Line-by-Line Search - core.rs:L479-497",
+			"cellId": "b4d3b26e-19e7-477d-979f-702fb33ff014",
+			"visible": true,
+			"startLine": 479,
+			"endLine": 497,
+			"parentCellId": "d7cca382-50e5-4a19-a577-d94f1ea52683",
+			"parentPath": "crates/searcher/src/searcher/core.rs"
+		},
+		"31b67024-80a9-4f66-9e16-50d98e7d05c7": {
+			"path": "31b67024-80a9-4f66-9e16-50d98e7d05c7",
+			"fileName": "31b67024-80a9-4f66-9e16-50d98e7d05c7",
+			"cellName": "Format Match in Sink - standard.rs:L769-788",
+			"cellId": "31b67024-80a9-4f66-9e16-50d98e7d05c7",
+			"visible": true,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550"
+		},
+		"crates/printer/src/standard.rs-simstep-c346a2e8-331c-4d3f-a2cb-9e1afcbc7ac1": {
+			"path": "crates/printer/src/standard.rs-simstep-c346a2e8-331c-4d3f-a2cb-9e1afcbc7ac1",
+			"fileName": "standard.rs",
+			"wiki": "The 'StandardSink' receives the 'SinkMatch'. It increments its internal match count and invokes its implementation logic to format the output. This includes prepending the file path and line number, and applying colors for highlighting the matched text.",
+			"cellName": "Format Match in Sink - standard.rs:L769-788",
+			"cellId": "31b67024-80a9-4f66-9e16-50d98e7d05c7",
+			"visible": true,
+			"startLine": 769,
+			"endLine": 788,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"f6322f9f-f154-481a-a997-75b09226c146": {
+			"path": "f6322f9f-f154-481a-a997-75b09226c146",
+			"fileName": "f6322f9f-f154-481a-a997-75b09226c146",
+			"cellName": "Consolidate and Print Buffered Output - main.rs:L204-211",
+			"cellId": "f6322f9f-f154-481a-a997-75b09226c146",
+			"visible": true,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53"
+		},
+		"crates/core/main.rs-simstep-32e761c6-06c3-4e7d-85a8-5a944e48aea5": {
+			"path": "crates/core/main.rs-simstep-32e761c6-06c3-4e7d-85a8-5a944e48aea5",
+			"fileName": "main.rs",
+			"wiki": "After searching a file, the worker thread's closure takes the formatted content from its local printer buffer and writes it to a shared, thread-safe writer. This ensures that output from different files is printed atomically without being interleaved, preserving the integrity of the search results.",
+			"cellName": "Consolidate and Print Buffered Output - main.rs:L204-211",
+			"cellId": "f6322f9f-f154-481a-a997-75b09226c146",
+			"visible": true,
+			"startLine": 204,
+			"endLine": 211,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53",
+			"parentPath": "crates/core/main.rs"
+		},
+		"344c1f2c-d241-4b5f-a686-7c1ea7037c5c": {
+			"path": "344c1f2c-d241-4b5f-a686-7c1ea7037c5c",
+			"fileName": "344c1f2c-d241-4b5f-a686-7c1ea7037c5c",
+			"cellName": "Aggregate Final Results - main.rs:L220-228",
+			"cellId": "344c1f2c-d241-4b5f-a686-7c1ea7037c5c",
+			"visible": true,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53"
+		},
+		"crates/core/main.rs-simstep-eef7e6fb-0baf-47db-8786-cbef119a75c6": {
+			"path": "crates/core/main.rs-simstep-eef7e6fb-0baf-47db-8786-cbef119a75c6",
+			"fileName": "main.rs",
+			"wiki": "After all worker threads complete, the main thread aggregates the results. It combines statistics from all searches into a final summary (if requested) and determines the final exit code based on whether 'has_match' was true for any file searched.",
+			"cellName": "Aggregate Final Results - main.rs:L220-228",
+			"cellId": "344c1f2c-d241-4b5f-a686-7c1ea7037c5c",
+			"visible": true,
+			"startLine": 220,
+			"endLine": 228,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53",
+			"parentPath": "crates/core/main.rs"
+		},
+		"7789b62c-d2f3-4540-aa1a-a737a35b60c8": {
+			"path": "7789b62c-d2f3-4540-aa1a-a737a35b60c8",
+			"fileName": "7789b62c-d2f3-4540-aa1a-a737a35b60c8",
+			"cellName": "Pass Arguments\nto Parallel\nSearch",
+			"cellId": "7789b62c-d2f3-4540-aa1a-a737a35b60c8",
+			"visible": true,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53"
+		},
+		"generated-edge-simstep-ac3640cf-d344-4813-869f-a260233103d5-7789b62c-d2f3-4540-aa1a-a737a35b60c8": {
+			"path": "generated-edge-simstep-ac3640cf-d344-4813-869f-a260233103d5-7789b62c-d2f3-4540-aa1a-a737a35b60c8",
+			"fileName": "main.rs",
+			"cellName": "Pass Arguments to Parallel Search",
+			"cellId": "7789b62c-d2f3-4540-aa1a-a737a35b60c8",
+			"visible": true,
+			"startLine": 88,
+			"endLine": 88,
+			"parentPath": "crates/core/main.rs"
+		},
+		"590b160d-861c-4b10-a432-28127a3d547b": {
+			"path": "590b160d-861c-4b10-a432-28127a3d547b",
+			"fileName": "590b160d-861c-4b10-a432-28127a3d547b",
+			"cellName": "Dispatch Directory\nEntries to\nWorker Threads",
+			"cellId": "590b160d-861c-4b10-a432-28127a3d547b",
+			"visible": true,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53"
+		},
+		"generated-edge-simstep-5161ea00-fede-4558-b465-a301e1f26076-590b160d-861c-4b10-a432-28127a3d547b": {
+			"path": "generated-edge-simstep-5161ea00-fede-4558-b465-a301e1f26076-590b160d-861c-4b10-a432-28127a3d547b",
+			"fileName": "main.rs",
+			"cellName": "Dispatch Directory Entries to Worker Threads",
+			"cellId": "590b160d-861c-4b10-a432-28127a3d547b",
+			"visible": true,
+			"startLine": 1507,
+			"endLine": 1511,
+			"parentPath": "crates/core/main.rs"
+		},
+		"5c3f5839-6758-4eaf-98b1-71868c95b20d": {
+			"path": "5c3f5839-6758-4eaf-98b1-71868c95b20d",
+			"fileName": "5c3f5839-6758-4eaf-98b1-71868c95b20d",
+			"cellName": "Pass File\nPath and\nSink to\nSearcher",
+			"cellId": "5c3f5839-6758-4eaf-98b1-71868c95b20d",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-15ce35a6-7ce6-4bea-aeb6-05d2a5f5cda1-5c3f5839-6758-4eaf-98b1-71868c95b20d": {
+			"path": "generated-edge-simstep-15ce35a6-7ce6-4bea-aeb6-05d2a5f5cda1-5c3f5839-6758-4eaf-98b1-71868c95b20d",
+			"fileName": "main.rs",
+			"cellName": "Pass File Path and Sink to Searcher",
+			"cellId": "5c3f5839-6758-4eaf-98b1-71868c95b20d",
+			"visible": true,
+			"startLine": 377,
+			"endLine": 385,
+			"parentPath": "crates/core/main.rs"
+		},
+		"0c2fcc7e-11d6-43a5-ae89-13180aed99eb": {
+			"path": "0c2fcc7e-11d6-43a5-ae89-13180aed99eb",
+			"fileName": "0c2fcc7e-11d6-43a5-ae89-13180aed99eb",
+			"cellName": "Pass File\nContent Slice\nto Search\nRoutine",
+			"cellId": "0c2fcc7e-11d6-43a5-ae89-13180aed99eb",
+			"visible": true,
+			"parentCellId": "7a2a4538-5e5a-4df6-85cc-b341c95545a1"
+		},
+		"generated-edge-simstep-c67074c1-8a09-479c-b153-ead7b0fa19d9-0c2fcc7e-11d6-43a5-ae89-13180aed99eb": {
+			"path": "generated-edge-simstep-c67074c1-8a09-479c-b153-ead7b0fa19d9-0c2fcc7e-11d6-43a5-ae89-13180aed99eb",
+			"fileName": "mod.rs",
+			"cellName": "Pass File Content Slice to Search Routine",
+			"cellId": "0c2fcc7e-11d6-43a5-ae89-13180aed99eb",
+			"visible": true,
+			"startLine": 702,
+			"endLine": 702,
+			"parentPath": "crates/searcher/src/searcher/mod.rs"
+		},
+		"87179a07-e417-4140-99b7-02a9f9a02887": {
+			"path": "87179a07-e417-4140-99b7-02a9f9a02887",
+			"fileName": "87179a07-e417-4140-99b7-02a9f9a02887",
+			"cellName": "Pass Confirmed\nMatch to\nSink",
+			"cellId": "87179a07-e417-4140-99b7-02a9f9a02887",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-ad8a1176-c06c-41ec-92c0-7b64a8079bc1-87179a07-e417-4140-99b7-02a9f9a02887": {
+			"path": "generated-edge-simstep-ad8a1176-c06c-41ec-92c0-7b64a8079bc1-87179a07-e417-4140-99b7-02a9f9a02887",
+			"fileName": "core.rs",
+			"cellName": "Pass Confirmed Match to Sink",
+			"cellId": "87179a07-e417-4140-99b7-02a9f9a02887",
+			"visible": true,
+			"startLine": 531,
+			"endLine": 544,
+			"parentPath": "crates/searcher/src/searcher/core.rs"
+		},
+		"347bc957-3191-4e20-94e9-4e1901111130": {
+			"path": "347bc957-3191-4e20-94e9-4e1901111130",
+			"fileName": "347bc957-3191-4e20-94e9-4e1901111130",
+			"cellName": "Transmit Formatted\nOutput to\nBuffer",
+			"cellId": "347bc957-3191-4e20-94e9-4e1901111130",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-ea8511c5-6417-49e1-8dd0-ff2555007454-347bc957-3191-4e20-94e9-4e1901111130": {
+			"path": "generated-edge-simstep-ea8511c5-6417-49e1-8dd0-ff2555007454-347bc957-3191-4e20-94e9-4e1901111130",
+			"fileName": "standard.rs",
+			"cellName": "Transmit Formatted Output to Buffer",
+			"cellId": "347bc957-3191-4e20-94e9-4e1901111130",
+			"visible": true,
+			"startLine": 931,
+			"endLine": 935,
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"5f9ee588-f79d-40bd-bb72-9ec3368ab21f": {
+			"path": "5f9ee588-f79d-40bd-bb72-9ec3368ab21f",
+			"fileName": "5f9ee588-f79d-40bd-bb72-9ec3368ab21f",
+			"cellName": "Return Search\nResult Statistics",
+			"cellId": "5f9ee588-f79d-40bd-bb72-9ec3368ab21f",
+			"visible": true,
+			"parentCellId": "0508ecd1-fc1d-499a-8811-8cfff3245a53"
+		},
+		"generated-edge-simstep-5db3b846-cbc9-4272-b024-6ada2be69cce-5f9ee588-f79d-40bd-bb72-9ec3368ab21f": {
+			"path": "generated-edge-simstep-5db3b846-cbc9-4272-b024-6ada2be69cce-5f9ee588-f79d-40bd-bb72-9ec3368ab21f",
+			"fileName": "main.rs",
+			"cellName": "Return Search Result Statistics",
+			"cellId": "5f9ee588-f79d-40bd-bb72-9ec3368ab21f",
+			"visible": true,
+			"startLine": 197,
+			"endLine": 197,
+			"parentPath": "crates/core/main.rs"
+		},
+		"6f90ad17-9829-4744-a1f0-1b721c6339ab": {
+			"path": "6f90ad17-9829-4744-a1f0-1b721c6339ab",
+			"fileName": "6f90ad17-9829-4744-a1f0-1b721c6339ab",
+			"cellName": "gitignore.rs",
+			"cellId": "6f90ad17-9829-4744-a1f0-1b721c6339ab",
+			"visible": true,
+			"parentCellId": "71ab6f47-6fdc-4073-9554-d51e4844c87e"
+		},
+		"75eb0e51-195c-493c-a132-126ec4994742": {
+			"path": "75eb0e51-195c-493c-a132-126ec4994742",
+			"fileName": "75eb0e51-195c-493c-a132-126ec4994742",
+			"cellName": "dir.rs",
+			"cellId": "75eb0e51-195c-493c-a132-126ec4994742",
+			"visible": true,
+			"parentCellId": "71ab6f47-6fdc-4073-9554-d51e4844c87e"
+		},
+		"4d08cdc3-7059-4f0e-b863-a2557475e192": {
+			"path": "4d08cdc3-7059-4f0e-b863-a2557475e192",
+			"fileName": "4d08cdc3-7059-4f0e-b863-a2557475e192",
+			"cellName": "line_buffer.rs",
+			"cellId": "4d08cdc3-7059-4f0e-b863-a2557475e192",
+			"visible": true,
+			"parentCellId": "f08293c4-eb87-4446-8a1c-b208513e40bd"
+		},
+		"32eebe96-86ec-41f2-ac0d-3c5874bb3b44": {
+			"path": "32eebe96-86ec-41f2-ac0d-3c5874bb3b44",
+			"fileName": "32eebe96-86ec-41f2-ac0d-3c5874bb3b44",
+			"cellName": "summary.rs",
+			"cellId": "32eebe96-86ec-41f2-ac0d-3c5874bb3b44",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3"
+		},
+		"06b0a86e-bf34-4e78-b2d3-0b1442aef61e": {
+			"path": "06b0a86e-bf34-4e78-b2d3-0b1442aef61e",
+			"fileName": "06b0a86e-bf34-4e78-b2d3-0b1442aef61e",
+			"cellName": "Initializing the Directory Walker - walk.rs:L520-530",
+			"cellId": "06b0a86e-bf34-4e78-b2d3-0b1442aef61e",
+			"visible": true,
+			"parentCellId": "1280b1d7-f3fd-41aa-9a95-53e5509e82a0"
+		},
+		"crates/ignore/src/walk.rs-simstep-9e34d9f4-60cf-49dd-9881-81338f158b78": {
+			"path": "crates/ignore/src/walk.rs-simstep-9e34d9f4-60cf-49dd-9881-81338f158b78",
+			"fileName": "walk.rs",
+			"wiki": "The `WalkBuilder` is instantiated for the search paths. It is configured with default filtering options, which include respecting `.gitignore` and `.ignore` files, skipping hidden files, and traversing parent directories for ignore files. These settings are controlled by command-line arguments, with the defaults enabling smart filtering.",
+			"cellName": "Initializing the Directory Walker - walk.rs:L520-530",
+			"cellId": "06b0a86e-bf34-4e78-b2d3-0b1442aef61e",
+			"visible": true,
+			"startLine": 520,
+			"endLine": 530,
+			"parentCellId": "1280b1d7-f3fd-41aa-9a95-53e5509e82a0",
+			"parentPath": "crates/ignore/src/walk.rs"
+		},
+		"d3448e0e-d81f-476d-aff3-3bd9ab26026d": {
+			"path": "d3448e0e-d81f-476d-aff3-3bd9ab26026d",
+			"fileName": "d3448e0e-d81f-476d-aff3-3bd9ab26026d",
+			"cellName": "Parsing `.gitignore` File - gitignore.rs:L391-416",
+			"cellId": "d3448e0e-d81f-476d-aff3-3bd9ab26026d",
+			"visible": true,
+			"parentCellId": "6f90ad17-9829-4744-a1f0-1b721c6339ab"
+		},
+		"crates/ignore/src/gitignore.rs-simstep-1b894775-da3b-4578-b6d2-484f23e1ec50": {
+			"path": "crates/ignore/src/gitignore.rs-simstep-1b894775-da3b-4578-b6d2-484f23e1ec50",
+			"fileName": "gitignore.rs",
+			"wiki": "As the walker traverses directories, it discovers ignore files like `.gitignore`. It opens the file, reads it line by line, and parses each line into a glob pattern. Comments (starting with `#`) and empty lines are skipped. The UTF-8 BOM is also handled.",
+			"cellName": "Parsing `.gitignore` File - gitignore.rs:L391-416",
+			"cellId": "d3448e0e-d81f-476d-aff3-3bd9ab26026d",
+			"visible": true,
+			"startLine": 391,
+			"endLine": 416,
+			"parentCellId": "6f90ad17-9829-4744-a1f0-1b721c6339ab",
+			"parentPath": "crates/ignore/src/gitignore.rs"
+		},
+		"7abfc016-6e09-4293-9c51-8be0e01bd020": {
+			"path": "7abfc016-6e09-4293-9c51-8be0e01bd020",
+			"fileName": "7abfc016-6e09-4293-9c51-8be0e01bd020",
+			"cellName": "Applying Filtering Rules to a Path - dir.rs:L396-544",
+			"cellId": "7abfc016-6e09-4293-9c51-8be0e01bd020",
+			"visible": true,
+			"parentCellId": "75eb0e51-195c-493c-a132-126ec4994742"
+		},
+		"crates/ignore/src/dir.rs-simstep-025792a2-a063-4347-ac2f-5978300032d4": {
+			"path": "crates/ignore/src/dir.rs-simstep-025792a2-a063-4347-ac2f-5978300032d4",
+			"fileName": "dir.rs",
+			"wiki": "For each file or directory encountered (`DirEntry`), the walker applies all relevant filters. First, it checks if the path is hidden (starts with '.'). Then, it consults the `Ignore` matcher, which checks against globs from all applicable sources (`.ignore`, `.gitignore`, global git config, etc.) in the correct order of precedence, from the current directory up to the repository root.",
+			"cellName": "Applying Filtering Rules to a Path - dir.rs:L396-544",
+			"cellId": "7abfc016-6e09-4293-9c51-8be0e01bd020",
+			"visible": true,
+			"startLine": 396,
+			"endLine": 544,
+			"parentCellId": "75eb0e51-195c-493c-a132-126ec4994742",
+			"parentPath": "crates/ignore/src/dir.rs"
+		},
+		"2f67c4c9-54b4-4da2-9448-5bfa18537099": {
+			"path": "2f67c4c9-54b4-4da2-9448-5bfa18537099",
+			"fileName": "2f67c4c9-54b4-4da2-9448-5bfa18537099",
+			"cellName": "Configuring Searcher for Binary Detection - mod.rs:L503-510",
+			"cellId": "2f67c4c9-54b4-4da2-9448-5bfa18537099",
+			"visible": true,
+			"parentCellId": "f05bde61-7d65-4d33-a433-141321ba0c95"
+		},
+		"crates/searcher/src/searcher/mod.rs-simstep-5e4d02cc-50e4-40ab-a1f4-cd11b845f582": {
+			"path": "crates/searcher/src/searcher/mod.rs-simstep-5e4d02cc-50e4-40ab-a1f4-cd11b845f582",
+			"fileName": "mod.rs",
+			"wiki": "For each file to be searched, a `Searcher` is configured. The `BinaryDetection` strategy is set based on command-line flags. For automatic recursive searching, the default is `quit(b'\\x00')`, which stops searching a file as soon as a NUL byte is found.",
+			"cellName": "Configuring Searcher for Binary Detection - mod.rs:L503-510",
+			"cellId": "2f67c4c9-54b4-4da2-9448-5bfa18537099",
+			"visible": true,
+			"startLine": 503,
+			"endLine": 510,
+			"parentCellId": "f05bde61-7d65-4d33-a433-141321ba0c95",
+			"parentPath": "crates/searcher/src/searcher/mod.rs"
+		},
+		"b80fd0a4-3357-49c4-baf5-2fa06862eb09": {
+			"path": "b80fd0a4-3357-49c4-baf5-2fa06862eb09",
+			"fileName": "b80fd0a4-3357-49c4-baf5-2fa06862eb09",
+			"cellName": "Detecting NUL Byte - line_buffer.rs:L436-443",
+			"cellId": "b80fd0a4-3357-49c4-baf5-2fa06862eb09",
+			"visible": true,
+			"parentCellId": "4d08cdc3-7059-4f0e-b863-a2557475e192"
+		},
+		"crates/searcher/src/line_buffer.rs-simstep-722f695f-377d-448e-9b44-9265ca920a1c": {
+			"path": "crates/searcher/src/line_buffer.rs-simstep-722f695f-377d-448e-9b44-9265ca920a1c",
+			"fileName": "line_buffer.rs",
+			"wiki": "As the line buffer is filled with new data from the file, it is scanned for the binary detection byte (NUL, `\\x00`). If the byte is found, the buffer's end is marked at the position of the byte, the binary offset is recorded, and the fill operation stops.",
+			"cellName": "Detecting NUL Byte - line_buffer.rs:L436-443",
+			"cellId": "b80fd0a4-3357-49c4-baf5-2fa06862eb09",
+			"visible": true,
+			"startLine": 436,
+			"endLine": 443,
+			"parentCellId": "4d08cdc3-7059-4f0e-b863-a2557475e192",
+			"parentPath": "crates/searcher/src/line_buffer.rs"
+		},
+		"723470cf-d7a8-443a-8713-f4840c0ae560": {
+			"path": "723470cf-d7a8-443a-8713-f4840c0ae560",
+			"fileName": "723470cf-d7a8-443a-8713-f4840c0ae560",
+			"cellName": "Skipping Binary File - summary.rs:L724-739",
+			"cellId": "723470cf-d7a8-443a-8713-f4840c0ae560",
+			"visible": true,
+			"parentCellId": "32eebe96-86ec-41f2-ac0d-3c5874bb3b44"
+		},
+		"crates/printer/src/summary.rs-simstep-10c3a95e-70bc-4232-9eb2-d16a22ee39cb": {
+			"path": "crates/printer/src/summary.rs-simstep-10c3a95e-70bc-4232-9eb2-d16a22ee39cb",
+			"fileName": "summary.rs",
+			"wiki": "Upon receiving the binary detection signal, the search logic for the current file is terminated. The printer is notified via the `SinkFinish` call, which includes the binary offset. Depending on the output format, a message like 'Binary file matches' may be printed, but the file's contents are not, effectively filtering it from the results.",
+			"cellName": "Skipping Binary File - summary.rs:L724-739",
+			"cellId": "723470cf-d7a8-443a-8713-f4840c0ae560",
+			"visible": true,
+			"startLine": 724,
+			"endLine": 739,
+			"parentCellId": "32eebe96-86ec-41f2-ac0d-3c5874bb3b44",
+			"parentPath": "crates/printer/src/summary.rs"
+		},
+		"8179e991-1e79-4612-abe1-b15ebc81ee7a": {
+			"path": "8179e991-1e79-4612-abe1-b15ebc81ee7a",
+			"fileName": "8179e991-1e79-4612-abe1-b15ebc81ee7a",
+			"cellName": "Directory Walker\nBegins Traversal",
+			"cellId": "8179e991-1e79-4612-abe1-b15ebc81ee7a",
+			"visible": true,
+			"parentCellId": "71ab6f47-6fdc-4073-9554-d51e4844c87e"
+		},
+		"generated-edge-simstep-95bc5326-9e38-43a4-b4a8-970c33b57d4b-8179e991-1e79-4612-abe1-b15ebc81ee7a": {
+			"path": "generated-edge-simstep-95bc5326-9e38-43a4-b4a8-970c33b57d4b-8179e991-1e79-4612-abe1-b15ebc81ee7a",
+			"fileName": "walk.rs",
+			"cellName": "Directory Walker Begins Traversal",
+			"cellId": "8179e991-1e79-4612-abe1-b15ebc81ee7a",
+			"visible": true,
+			"startLine": 939,
+			"endLine": 939,
+			"parentPath": "crates/ignore/src/walk.rs"
+		},
+		"643dc76d-7619-485d-812b-937f5adb8ad9": {
+			"path": "643dc76d-7619-485d-812b-937f5adb8ad9",
+			"fileName": "643dc76d-7619-485d-812b-937f5adb8ad9",
+			"cellName": "Transferring Compiled\nGlobs",
+			"cellId": "643dc76d-7619-485d-812b-937f5adb8ad9",
+			"visible": true,
+			"parentCellId": "71ab6f47-6fdc-4073-9554-d51e4844c87e"
+		},
+		"generated-edge-simstep-fc573a17-a164-4433-8631-85e9d9a86d05-643dc76d-7619-485d-812b-937f5adb8ad9": {
+			"path": "generated-edge-simstep-fc573a17-a164-4433-8631-85e9d9a86d05-643dc76d-7619-485d-812b-937f5adb8ad9",
+			"fileName": "gitignore.rs",
+			"cellName": "Transferring Compiled Globs",
+			"cellId": "643dc76d-7619-485d-812b-937f5adb8ad9",
+			"visible": true,
+			"startLine": 335,
+			"endLine": 347,
+			"parentPath": "crates/ignore/src/gitignore.rs"
+		},
+		"b37077b4-3a28-4e20-8572-adb309282e6e": {
+			"path": "b37077b4-3a28-4e20-8572-adb309282e6e",
+			"fileName": "b37077b4-3a28-4e20-8572-adb309282e6e",
+			"cellName": "Yielding a\nValid File\nPath",
+			"cellId": "b37077b4-3a28-4e20-8572-adb309282e6e",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-dcb8f230-7cf4-471b-b2ee-4b2ea0afe105-b37077b4-3a28-4e20-8572-adb309282e6e": {
+			"path": "generated-edge-simstep-dcb8f230-7cf4-471b-b2ee-4b2ea0afe105-b37077b4-3a28-4e20-8572-adb309282e6e",
+			"fileName": "dir.rs",
+			"cellName": "Yielding a Valid File Path",
+			"cellId": "b37077b4-3a28-4e20-8572-adb309282e6e",
+			"visible": true,
+			"startLine": 1056,
+			"endLine": 1056,
+			"parentPath": "crates/ignore/src/dir.rs"
+		},
+		"b04390e9-6b12-4665-9c2d-4afc76a8be4b": {
+			"path": "b04390e9-6b12-4665-9c2d-4afc76a8be4b",
+			"fileName": "b04390e9-6b12-4665-9c2d-4afc76a8be4b",
+			"cellName": "Reading File\nContents into\nBuffer",
+			"cellId": "b04390e9-6b12-4665-9c2d-4afc76a8be4b",
+			"visible": true,
+			"parentCellId": "f08293c4-eb87-4446-8a1c-b208513e40bd"
+		},
+		"generated-edge-simstep-fba70f94-ac0e-47a2-8d50-5a6a733e996b-b04390e9-6b12-4665-9c2d-4afc76a8be4b": {
+			"path": "generated-edge-simstep-fba70f94-ac0e-47a2-8d50-5a6a733e996b-b04390e9-6b12-4665-9c2d-4afc76a8be4b",
+			"fileName": "mod.rs",
+			"cellName": "Reading File Contents into Buffer",
+			"cellId": "b04390e9-6b12-4665-9c2d-4afc76a8be4b",
+			"visible": true,
+			"startLine": 415,
+			"endLine": 415,
+			"parentPath": "crates/searcher/src/searcher/mod.rs"
+		},
+		"66a36773-5189-4bc2-909a-0d5ce55eb772": {
+			"path": "66a36773-5189-4bc2-909a-0d5ce55eb772",
+			"fileName": "66a36773-5189-4bc2-909a-0d5ce55eb772",
+			"cellName": "Signaling Binary\nFile Detection",
+			"cellId": "66a36773-5189-4bc2-909a-0d5ce55eb772",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-57c81d35-e9c1-4342-b7aa-da6ade908b5a-66a36773-5189-4bc2-909a-0d5ce55eb772": {
+			"path": "generated-edge-simstep-57c81d35-e9c1-4342-b7aa-da6ade908b5a-66a36773-5189-4bc2-909a-0d5ce55eb772",
+			"fileName": "line_buffer.rs",
+			"cellName": "Signaling Binary File Detection",
+			"cellId": "66a36773-5189-4bc2-909a-0d5ce55eb772",
+			"visible": true,
+			"startLine": 216,
+			"endLine": 225,
+			"parentPath": "crates/searcher/src/line_buffer.rs"
+		},
+		"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e": {
+			"path": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e",
+			"fileName": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e",
+			"cellName": "flags",
+			"cellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e",
+			"visible": true,
+			"parentCellId": "debf18dd-047e-44e4-9016-2ee07faaf18b"
+		},
+		"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb": {
+			"path": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"fileName": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"cellName": "defs.rs",
+			"cellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"898b7926-b1c0-43cf-80c2-b06695d8fe1c": {
+			"path": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"fileName": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"cellName": "hiargs.rs",
+			"cellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"cb3a4534-fcff-4d6e-a249-7dc152bd9a32": {
+			"path": "cb3a4534-fcff-4d6e-a249-7dc152bd9a32",
+			"fileName": "cb3a4534-fcff-4d6e-a249-7dc152bd9a32",
+			"cellName": "Flow 1: Parse '--glob' Flag - defs.rs:L2555-2558",
+			"cellId": "cb3a4534-fcff-4d6e-a249-7dc152bd9a32",
+			"visible": true,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb"
+		},
+		"crates/core/flags/defs.rs-simstep-8cdd9622-d34d-456c-8cbd-df9939e9ea65": {
+			"path": "crates/core/flags/defs.rs-simstep-8cdd9622-d34d-456c-8cbd-df9939e9ea65",
+			"fileName": "defs.rs",
+			"wiki": "The command-line parser encounters the '-g' or '--glob' flag and its value. This value is stored as a raw string in the `globs` vector within a low-level arguments struct for later processing.",
+			"cellName": "Flow 1: Parse '--glob' Flag - defs.rs:L2555-2558",
+			"cellId": "cb3a4534-fcff-4d6e-a249-7dc152bd9a32",
+			"visible": true,
+			"startLine": 2555,
+			"endLine": 2558,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"fbfa66cf-8419-4584-8997-3dcb1520343c": {
+			"path": "fbfa66cf-8419-4584-8997-3dcb1520343c",
+			"fileName": "fbfa66cf-8419-4584-8997-3dcb1520343c",
+			"cellName": "Flow 1: Build Glob Override Matcher - hiargs.rs:L1205-1225",
+			"cellId": "fbfa66cf-8419-4584-8997-3dcb1520343c",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"crates/core/flags/hiargs.rs-simstep-1c3b6417-4da9-4192-a8da-70e0f7079d88": {
+			"path": "crates/core/flags/hiargs.rs-simstep-1c3b6417-4da9-4192-a8da-70e0f7079d88",
+			"fileName": "hiargs.rs",
+			"wiki": "The raw glob patterns are compiled into an efficient `Override` matcher. This function initializes an `OverrideBuilder`, adds each glob pattern, and then builds the final `Override` object. This matcher uses `globset` internally for fast, simultaneous matching of multiple globs.",
+			"cellName": "Flow 1: Build Glob Override Matcher - hiargs.rs:L1205-1225",
+			"cellId": "fbfa66cf-8419-4584-8997-3dcb1520343c",
+			"visible": true,
+			"startLine": 1205,
+			"endLine": 1225,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"8570a0fe-3867-4504-8509-b48052799065": {
+			"path": "8570a0fe-3867-4504-8509-b48052799065",
+			"fileName": "8570a0fe-3867-4504-8509-b48052799065",
+			"cellName": "Flow 1: Filter Path with Override Matcher - dir.rs:L381-389",
+			"cellId": "8570a0fe-3867-4504-8509-b48052799065",
+			"visible": true,
+			"parentCellId": "75eb0e51-195c-493c-a132-126ec4994742"
+		},
+		"crates/ignore/src/dir.rs-simstep-18eead12-d6f4-4f5d-82f5-979a40c61c6b": {
+			"path": "crates/ignore/src/dir.rs-simstep-18eead12-d6f4-4f5d-82f5-979a40c61c6b",
+			"fileName": "dir.rs",
+			"wiki": "During directory traversal, for each path encountered, the `Override` matcher is checked first. If a path matches a glob, a decision to include (whitelist) or exclude (ignore) it is made immediately, taking precedence over all other ignore rules like .gitignore or file types.",
+			"cellName": "Flow 1: Filter Path with Override Matcher - dir.rs:L381-389",
+			"cellId": "8570a0fe-3867-4504-8509-b48052799065",
+			"visible": true,
+			"startLine": 381,
+			"endLine": 389,
+			"parentCellId": "75eb0e51-195c-493c-a132-126ec4994742",
+			"parentPath": "crates/ignore/src/dir.rs"
+		},
+		"38526dce-9250-40d1-8e4b-b6489562aee3": {
+			"path": "38526dce-9250-40d1-8e4b-b6489562aee3",
+			"fileName": "38526dce-9250-40d1-8e4b-b6489562aee3",
+			"cellName": "Flow 2: Parse File Type Flags - defs.rs:L6901-7126",
+			"cellId": "38526dce-9250-40d1-8e4b-b6489562aee3",
+			"visible": true,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb"
+		},
+		"crates/core/flags/defs.rs-simstep-87114100-cc4e-473c-8213-577fe0eed9e4": {
+			"path": "crates/core/flags/defs.rs-simstep-87114100-cc4e-473c-8213-577fe0eed9e4",
+			"fileName": "defs.rs",
+			"wiki": "The parser processes flags like '-t' (type), '-T' (type-not), '--type-add', and '--type-clear'. These are converted into a structured `TypeChange` enum and collected in a list for later processing.",
+			"cellName": "Flow 2: Parse File Type Flags - defs.rs:L6901-7126",
+			"cellId": "38526dce-9250-40d1-8e4b-b6489562aee3",
+			"visible": true,
+			"startLine": 6901,
+			"endLine": 7126,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"c6ed14cf-fad1-4551-b5c4-ddfa4af6afe0": {
+			"path": "c6ed14cf-fad1-4551-b5c4-ddfa4af6afe0",
+			"fileName": "c6ed14cf-fad1-4551-b5c4-ddfa4af6afe0",
+			"cellName": "Flow 2: Build File Type Matcher - hiargs.rs:L1180-1202",
+			"cellId": "c6ed14cf-fad1-4551-b5c4-ddfa4af6afe0",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"crates/core/flags/hiargs.rs-simstep-9b9b64e8-bf1a-43f6-aefa-f2bad985f294": {
+			"path": "crates/core/flags/hiargs.rs-simstep-9b9b64e8-bf1a-43f6-aefa-f2bad985f294",
+			"fileName": "hiargs.rs",
+			"wiki": "A `TypesBuilder` is created and populated with default file type definitions. It's then modified according to the user's `TypeChange` requests (e.g., adding a 'web' type, selecting 'rust', and negating 'js'). Finally, a `Types` matcher is built, which compiles the necessary globs into a `globset::GlobSet` for efficient matching.",
+			"cellName": "Flow 2: Build File Type Matcher - hiargs.rs:L1180-1202",
+			"cellId": "c6ed14cf-fad1-4551-b5c4-ddfa4af6afe0",
+			"visible": true,
+			"startLine": 1180,
+			"endLine": 1202,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"1280e475-b2ba-4864-964c-5ce2738208ab": {
+			"path": "1280e475-b2ba-4864-964c-5ce2738208ab",
+			"fileName": "1280e475-b2ba-4864-964c-5ce2738208ab",
+			"cellName": "Flow 2: Filter Path with Type Matcher - dir.rs:L396-406",
+			"cellId": "1280e475-b2ba-4864-964c-5ce2738208ab",
+			"visible": true,
+			"parentCellId": "75eb0e51-195c-493c-a132-126ec4994742"
+		},
+		"crates/ignore/src/dir.rs-simstep-c47913bd-2425-4d97-b7c3-c66f5e6a084c": {
+			"path": "crates/ignore/src/dir.rs-simstep-c47913bd-2425-4d97-b7c3-c66f5e6a084c",
+			"fileName": "dir.rs",
+			"wiki": "During directory traversal, if a path is not filtered by a glob override or other ignore rules, the `Types` matcher is checked. It determines if the file matches a selected type (whitelisted), a negated type (ignored), or if it should be ignored because it doesn't match any of the selected types.",
+			"cellName": "Flow 2: Filter Path with Type Matcher - dir.rs:L396-406",
+			"cellId": "1280e475-b2ba-4864-964c-5ce2738208ab",
+			"visible": true,
+			"startLine": 396,
+			"endLine": 406,
+			"parentCellId": "75eb0e51-195c-493c-a132-126ec4994742",
+			"parentPath": "crates/ignore/src/dir.rs"
+		},
+		"2b3fde20-eac5-4250-b825-23b44081ba08": {
+			"path": "2b3fde20-eac5-4250-b825-23b44081ba08",
+			"fileName": "2b3fde20-eac5-4250-b825-23b44081ba08",
+			"cellName": "Flow 1:\nTransmit Glob\nPatterns",
+			"cellId": "2b3fde20-eac5-4250-b825-23b44081ba08",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-03e12913-6e17-41ca-aa86-096355546fab-2b3fde20-eac5-4250-b825-23b44081ba08": {
+			"path": "generated-edge-simstep-03e12913-6e17-41ca-aa86-096355546fab-2b3fde20-eac5-4250-b825-23b44081ba08",
+			"fileName": "defs.rs",
+			"cellName": "Flow 1: Transmit Glob Patterns",
+			"cellId": "2b3fde20-eac5-4250-b825-23b44081ba08",
+			"visible": true,
+			"startLine": 152,
+			"endLine": 152,
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"ba4298a3-e951-4215-a0b0-55c94dffc690": {
+			"path": "ba4298a3-e951-4215-a0b0-55c94dffc690",
+			"fileName": "ba4298a3-e951-4215-a0b0-55c94dffc690",
+			"cellName": "Flow 1:\nConfigure Walker\nwith Override\nMatcher",
+			"cellId": "ba4298a3-e951-4215-a0b0-55c94dffc690",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-bb850076-72a4-403a-be38-e533ecc251ad-ba4298a3-e951-4215-a0b0-55c94dffc690": {
+			"path": "generated-edge-simstep-bb850076-72a4-403a-be38-e533ecc251ad-ba4298a3-e951-4215-a0b0-55c94dffc690",
+			"fileName": "hiargs.rs",
+			"cellName": "Flow 1: Configure Walker with Override Matcher",
+			"cellId": "ba4298a3-e951-4215-a0b0-55c94dffc690",
+			"visible": true,
+			"startLine": 892,
+			"endLine": 892,
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"1279f8bf-17d7-4a0a-a789-6f364aa3e5cf": {
+			"path": "1279f8bf-17d7-4a0a-a789-6f364aa3e5cf",
+			"fileName": "1279f8bf-17d7-4a0a-a789-6f364aa3e5cf",
+			"cellName": "Flow 2:\nTransmit Type\nChanges",
+			"cellId": "1279f8bf-17d7-4a0a-a789-6f364aa3e5cf",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-6c28187f-874c-462c-a17c-e5c547ed0812-1279f8bf-17d7-4a0a-a789-6f364aa3e5cf": {
+			"path": "generated-edge-simstep-6c28187f-874c-462c-a17c-e5c547ed0812-1279f8bf-17d7-4a0a-a789-6f364aa3e5cf",
+			"fileName": "defs.rs",
+			"cellName": "Flow 2: Transmit Type Changes",
+			"cellId": "1279f8bf-17d7-4a0a-a789-6f364aa3e5cf",
+			"visible": true,
+			"startLine": 151,
+			"endLine": 151,
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"f44a0aa4-4205-4ea4-9d80-5a62385e2307": {
+			"path": "f44a0aa4-4205-4ea4-9d80-5a62385e2307",
+			"fileName": "f44a0aa4-4205-4ea4-9d80-5a62385e2307",
+			"cellName": "Flow 2:\nConfigure Walker\nwith Type\nMatcher",
+			"cellId": "f44a0aa4-4205-4ea4-9d80-5a62385e2307",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-0e14c00a-6383-43b4-9285-b35fe6261f7a-f44a0aa4-4205-4ea4-9d80-5a62385e2307": {
+			"path": "generated-edge-simstep-0e14c00a-6383-43b4-9285-b35fe6261f7a-f44a0aa4-4205-4ea4-9d80-5a62385e2307",
+			"fileName": "hiargs.rs",
+			"cellName": "Flow 2: Configure Walker with Type Matcher",
+			"cellId": "f44a0aa4-4205-4ea4-9d80-5a62385e2307",
+			"visible": true,
+			"startLine": 893,
+			"endLine": 893,
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"63a9d821-0a1b-4daf-9f0d-0482d2ded1a5": {
+			"path": "63a9d821-0a1b-4daf-9f0d-0482d2ded1a5",
+			"fileName": "63a9d821-0a1b-4daf-9f0d-0482d2ded1a5",
+			"cellName": "cli",
+			"cellId": "63a9d821-0a1b-4daf-9f0d-0482d2ded1a5",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"bbd871fb-2a85-4f90-b28d-abc336580454": {
+			"path": "bbd871fb-2a85-4f90-b28d-abc336580454",
+			"fileName": "bbd871fb-2a85-4f90-b28d-abc336580454",
+			"cellName": "src",
+			"cellId": "bbd871fb-2a85-4f90-b28d-abc336580454",
+			"visible": true,
+			"parentCellId": "63a9d821-0a1b-4daf-9f0d-0482d2ded1a5"
+		},
+		"f64da727-0b70-4f27-880c-862de575dd0a": {
+			"path": "f64da727-0b70-4f27-880c-862de575dd0a",
+			"fileName": "f64da727-0b70-4f27-880c-862de575dd0a",
+			"cellName": "json.rs",
+			"cellId": "f64da727-0b70-4f27-880c-862de575dd0a",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3"
+		},
+		"0e8f4962-c836-4d7b-93b1-b8b18f64a725": {
+			"path": "0e8f4962-c836-4d7b-93b1-b8b18f64a725",
+			"fileName": "0e8f4962-c836-4d7b-93b1-b8b18f64a725",
+			"cellName": "jsont.rs",
+			"cellId": "0e8f4962-c836-4d7b-93b1-b8b18f64a725",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3"
+		},
+		"548054c3-b0a3-4817-8e47-3dfac7999d27": {
+			"path": "548054c3-b0a3-4817-8e47-3dfac7999d27",
+			"fileName": "548054c3-b0a3-4817-8e47-3dfac7999d27",
+			"cellName": "sink.rs",
+			"cellId": "548054c3-b0a3-4817-8e47-3dfac7999d27",
+			"visible": true,
+			"parentCellId": "f08293c4-eb87-4446-8a1c-b208513e40bd"
+		},
+		"3aa0bd2b-5f86-46a6-8763-2b5371ab045d": {
+			"path": "3aa0bd2b-5f86-46a6-8763-2b5371ab045d",
+			"fileName": "3aa0bd2b-5f86-46a6-8763-2b5371ab045d",
+			"cellName": "wtr.rs",
+			"cellId": "3aa0bd2b-5f86-46a6-8763-2b5371ab045d",
+			"visible": true,
+			"parentCellId": "bbd871fb-2a85-4f90-b28d-abc336580454"
+		},
+		"8e2b5abc-ba17-4126-8196-2d863574dd03": {
+			"path": "8e2b5abc-ba17-4126-8196-2d863574dd03",
+			"fileName": "8e2b5abc-ba17-4126-8196-2d863574dd03",
+			"cellName": "Standard Output Flow: Parse Context and Formatting Flags - defs.rs:L995-1024",
+			"cellId": "8e2b5abc-ba17-4126-8196-2d863574dd03",
+			"visible": true,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb"
+		},
+		"crates/core/flags/defs.rs-simstep-a234a4fc-6910-49ab-9692-3629e7029a19": {
+			"path": "crates/core/flags/defs.rs-simstep-a234a4fc-6910-49ab-9692-3629e7029a19",
+			"fileName": "defs.rs",
+			"wiki": "Ripgrep's command-line interface parses arguments to configure the search output. Flags like `-A` (after-context), `-B` (before-context), `-C` (context), `--column` (show column numbers), and `-b` (show byte offset) are processed. These flags determine how search results will be formatted for human-readable output.",
+			"cellName": "Standard Output Flow: Parse Context and Formatting Flags - defs.rs:L995-1024",
+			"cellId": "8e2b5abc-ba17-4126-8196-2d863574dd03",
+			"visible": true,
+			"startLine": 995,
+			"endLine": 1024,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"8a7a07f1-7758-4c90-9a3b-f49dc60d12f1": {
+			"path": "8a7a07f1-7758-4c90-9a3b-f49dc60d12f1",
+			"fileName": "8a7a07f1-7758-4c90-9a3b-f49dc60d12f1",
+			"cellName": "Standard Output Flow: Configure Searcher and Printer - hiargs.rs:L599-633",
+			"cellId": "8a7a07f1-7758-4c90-9a3b-f49dc60d12f1",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"crates/core/flags/hiargs.rs-simstep-3e717203-9460-44e7-835e-49cd8340dbc6": {
+			"path": "crates/core/flags/hiargs.rs-simstep-3e717203-9460-44e7-835e-49cd8340dbc6",
+			"fileName": "hiargs.rs",
+			"wiki": "The high-level arguments are used to configure the `Searcher` and the `Standard` printer. The `SearcherBuilder` is configured with context line settings (`before_context`, `after_context`), while the `StandardBuilder` is configured with formatting options like `byte_offset` and `column`.",
+			"cellName": "Standard Output Flow: Configure Searcher and Printer - hiargs.rs:L599-633",
+			"cellId": "8a7a07f1-7758-4c90-9a3b-f49dc60d12f1",
+			"visible": true,
+			"startLine": 599,
+			"endLine": 633,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"7d6a3f10-0382-4eaa-8a62-e3492e6000c2": {
+			"path": "7d6a3f10-0382-4eaa-8a62-e3492e6000c2",
+			"fileName": "7d6a3f10-0382-4eaa-8a62-e3492e6000c2",
+			"cellName": "Standard Output Flow: Execute Search and Sink Results - standard.rs:L764-823",
+			"cellId": "7d6a3f10-0382-4eaa-8a62-e3492e6000c2",
+			"visible": true,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550"
+		},
+		"crates/printer/src/standard.rs-simstep-127bdb74-45b0-4569-b7be-89b9b808c24b": {
+			"path": "crates/printer/src/standard.rs-simstep-127bdb74-45b0-4569-b7be-89b9b808c24b",
+			"fileName": "standard.rs",
+			"wiki": "The `Searcher` iterates through the input file, finds matches, and identifies any surrounding context lines. For each match or context line, it calls the corresponding method (`matched` or `context`) on the `StandardSink`, which is responsible for printing.",
+			"cellName": "Standard Output Flow: Execute Search and Sink Results - standard.rs:L764-823",
+			"cellId": "7d6a3f10-0382-4eaa-8a62-e3492e6000c2",
+			"visible": true,
+			"startLine": 764,
+			"endLine": 823,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"b7e5cc9d-83e0-44e5-bcd8-0f7886685f38": {
+			"path": "b7e5cc9d-83e0-44e5-bcd8-0f7886685f38",
+			"fileName": "b7e5cc9d-83e0-44e5-bcd8-0f7886685f38",
+			"cellName": "Standard Output Flow: Format Human-Readable Output - standard.rs:L871-929",
+			"cellId": "b7e5cc9d-83e0-44e5-bcd8-0f7886685f38",
+			"visible": true,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550"
+		},
+		"crates/printer/src/standard.rs-simstep-89d044cb-ba97-423b-b877-e022fd3aadc5": {
+			"path": "crates/printer/src/standard.rs-simstep-89d044cb-ba97-423b-b877-e022fd3aadc5",
+			"fileName": "standard.rs",
+			"wiki": "The `StandardSink` uses a helper, `StandardImpl`, to format the output. It consults the printer's configuration to decide whether to include line numbers, column numbers, byte offsets, context separators, and colors, then assembles the final output string for each line.",
+			"cellName": "Standard Output Flow: Format Human-Readable Output - standard.rs:L871-929",
+			"cellId": "b7e5cc9d-83e0-44e5-bcd8-0f7886685f38",
+			"visible": true,
+			"startLine": 871,
+			"endLine": 929,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"dc9f30d5-6599-4494-867c-a5f5726f7aa2": {
+			"path": "dc9f30d5-6599-4494-867c-a5f5726f7aa2",
+			"fileName": "dc9f30d5-6599-4494-867c-a5f5726f7aa2",
+			"cellName": "JSON Output Flow: Parse --json Flag - defs.rs:L3429-3512",
+			"cellId": "dc9f30d5-6599-4494-867c-a5f5726f7aa2",
+			"visible": true,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb"
+		},
+		"crates/core/flags/defs.rs-simstep-b94bbc3b-921b-4dcf-8678-da515f9752ad": {
+			"path": "crates/core/flags/defs.rs-simstep-b94bbc3b-921b-4dcf-8678-da515f9752ad",
+			"fileName": "defs.rs",
+			"wiki": "The application starts by parsing the `--json` command-line flag. When this flag is present, it sets the application's output mode to `SearchMode::JSON`, fundamentally changing how results are presented.",
+			"cellName": "JSON Output Flow: Parse --json Flag - defs.rs:L3429-3512",
+			"cellId": "dc9f30d5-6599-4494-867c-a5f5726f7aa2",
+			"visible": true,
+			"startLine": 3429,
+			"endLine": 3512,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"aedf481e-7a26-4f1a-8f80-e270d31af954": {
+			"path": "aedf481e-7a26-4f1a-8f80-e270d31af954",
+			"fileName": "aedf481e-7a26-4f1a-8f80-e270d31af954",
+			"cellName": "JSON Output Flow: Select and Build JSON Printer - hiargs.rs:L586-596",
+			"cellId": "aedf481e-7a26-4f1a-8f80-e270d31af954",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"crates/core/flags/hiargs.rs-simstep-f9ec9573-13f1-41ea-8286-d86c8bb66a3f": {
+			"path": "crates/core/flags/hiargs.rs-simstep-f9ec9573-13f1-41ea-8286-d86c8bb66a3f",
+			"fileName": "hiargs.rs",
+			"wiki": "The high-level argument processor checks the search mode. Since it's `SearchMode::JSON`, it selects and constructs a `JSON` printer using the `JSONBuilder`. This printer is specifically designed to output results in a machine-readable JSON Lines format.",
+			"cellName": "JSON Output Flow: Select and Build JSON Printer - hiargs.rs:L586-596",
+			"cellId": "aedf481e-7a26-4f1a-8f80-e270d31af954",
+			"visible": true,
+			"startLine": 586,
+			"endLine": 596,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"9078ceb1-5c41-402c-867a-d9960eb41e6e": {
+			"path": "9078ceb1-5c41-402c-867a-d9960eb41e6e",
+			"fileName": "9078ceb1-5c41-402c-867a-d9960eb41e6e",
+			"cellName": "JSON Output Flow: Execute Search and Sink to JSON Printer - json.rs:L722-785",
+			"cellId": "9078ceb1-5c41-402c-867a-d9960eb41e6e",
+			"visible": true,
+			"parentCellId": "f64da727-0b70-4f27-880c-862de575dd0a"
+		},
+		"crates/printer/src/json.rs-simstep-081da804-e09a-472d-b815-dae4ad93407a": {
+			"path": "crates/printer/src/json.rs-simstep-081da804-e09a-472d-b815-dae4ad93407a",
+			"fileName": "json.rs",
+			"wiki": "The `Searcher` finds matches and context lines, then calls the `matched` or `context` methods on the `JSONSink`. The sink is responsible for converting these search events into JSON objects.",
+			"cellName": "JSON Output Flow: Execute Search and Sink to JSON Printer - json.rs:L722-785",
+			"cellId": "9078ceb1-5c41-402c-867a-d9960eb41e6e",
+			"visible": true,
+			"startLine": 722,
+			"endLine": 785,
+			"parentCellId": "f64da727-0b70-4f27-880c-862de575dd0a",
+			"parentPath": "crates/printer/src/json.rs"
+		},
+		"b0962b62-8b3f-4dae-a197-aed83fe5a827": {
+			"path": "b0962b62-8b3f-4dae-a197-aed83fe5a827",
+			"fileName": "b0962b62-8b3f-4dae-a197-aed83fe5a827",
+			"cellName": "JSON Output Flow: Construct and Serialize JSON Messages - jsont.rs:L11-44",
+			"cellId": "b0962b62-8b3f-4dae-a197-aed83fe5a827",
+			"visible": true,
+			"parentCellId": "0e8f4962-c836-4d7b-93b1-b8b18f64a725"
+		},
+		"crates/printer/src/jsont.rs-simstep-d4b5b12e-dfcb-4663-9015-fe99a6c72b8a": {
+			"path": "crates/printer/src/jsont.rs-simstep-d4b5b12e-dfcb-4663-9015-fe99a6c72b8a",
+			"fileName": "jsont.rs",
+			"wiki": "The `JSONSink` receives the search result data and constructs structured message objects (`begin`, `match`, `context`, `end`). These objects contain details like file paths, line numbers, match offsets, and the text content (base64 encoded if not valid UTF-8). Each message is then serialized into a JSON string.",
+			"cellName": "JSON Output Flow: Construct and Serialize JSON Messages - jsont.rs:L11-44",
+			"cellId": "b0962b62-8b3f-4dae-a197-aed83fe5a827",
+			"visible": true,
+			"startLine": 11,
+			"endLine": 44,
+			"parentCellId": "0e8f4962-c836-4d7b-93b1-b8b18f64a725",
+			"parentPath": "crates/printer/src/jsont.rs"
+		},
+		"66e9ca05-7027-45f5-a953-d9fa1ff7f1a0": {
+			"path": "66e9ca05-7027-45f5-a953-d9fa1ff7f1a0",
+			"fileName": "66e9ca05-7027-45f5-a953-d9fa1ff7f1a0",
+			"cellName": "Standard Output\nFlow: Transmit\nParsed Arguments",
+			"cellId": "66e9ca05-7027-45f5-a953-d9fa1ff7f1a0",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-a17d799e-12b0-470a-8e98-5ec9ed6bd1b3-66e9ca05-7027-45f5-a953-d9fa1ff7f1a0": {
+			"path": "generated-edge-simstep-a17d799e-12b0-470a-8e98-5ec9ed6bd1b3-66e9ca05-7027-45f5-a953-d9fa1ff7f1a0",
+			"fileName": "defs.rs",
+			"cellName": "Standard Output Flow: Transmit Parsed Arguments",
+			"cellId": "66e9ca05-7027-45f5-a953-d9fa1ff7f1a0",
+			"visible": true,
+			"startLine": 119,
+			"endLine": 122,
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a": {
+			"path": "3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a",
+			"fileName": "3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a",
+			"cellName": "Standard Output\nFlow: Transmit\nConfigured Searcher\nand Printer",
+			"cellId": "3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-73c3f672-dfe3-460c-905d-c6bd9eddbd55-3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a": {
+			"path": "generated-edge-simstep-73c3f672-dfe3-460c-905d-c6bd9eddbd55-3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a",
+			"fileName": "hiargs.rs",
+			"cellName": "Standard Output Flow: Transmit Configured Searcher and Printer",
+			"cellId": "3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a",
+			"visible": true,
+			"startLine": 380,
+			"endLine": 383,
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"262b607f-db42-4642-91b9-abd5a1108374": {
+			"path": "262b607f-db42-4642-91b9-abd5a1108374",
+			"fileName": "262b607f-db42-4642-91b9-abd5a1108374",
+			"cellName": "Standard Output\nFlow: Transmit\nMatch and\nContext Data",
+			"cellId": "262b607f-db42-4642-91b9-abd5a1108374",
+			"visible": true,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550"
+		},
+		"generated-edge-simstep-35e70e93-56f9-4ae9-a4e0-d4eb08246f4b-262b607f-db42-4642-91b9-abd5a1108374": {
+			"path": "generated-edge-simstep-35e70e93-56f9-4ae9-a4e0-d4eb08246f4b-262b607f-db42-4642-91b9-abd5a1108374",
+			"fileName": "standard.rs",
+			"cellName": "Standard Output Flow: Transmit Match and Context Data",
+			"cellId": "262b607f-db42-4642-91b9-abd5a1108374",
+			"visible": true,
+			"startLine": 126,
+			"endLine": 132,
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"81663818-d2d6-4cfe-8a71-7b37237f7f95": {
+			"path": "81663818-d2d6-4cfe-8a71-7b37237f7f95",
+			"fileName": "81663818-d2d6-4cfe-8a71-7b37237f7f95",
+			"cellName": "Standard Output\nFlow: Write\nFormatted String\nto stdout",
+			"cellId": "81663818-d2d6-4cfe-8a71-7b37237f7f95",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-15986b7a-0256-4f61-97b4-61e8c654b7e4-81663818-d2d6-4cfe-8a71-7b37237f7f95": {
+			"path": "generated-edge-simstep-15986b7a-0256-4f61-97b4-61e8c654b7e4-81663818-d2d6-4cfe-8a71-7b37237f7f95",
+			"fileName": "standard.rs",
+			"cellName": "Standard Output Flow: Write Formatted String to stdout",
+			"cellId": "81663818-d2d6-4cfe-8a71-7b37237f7f95",
+			"visible": true,
+			"startLine": 66,
+			"endLine": 74,
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"b054dd02-8e6a-4e42-be4a-7e082e6187d9": {
+			"path": "b054dd02-8e6a-4e42-be4a-7e082e6187d9",
+			"fileName": "b054dd02-8e6a-4e42-be4a-7e082e6187d9",
+			"cellName": "JSON Output\nFlow: Transmit\nParsed Arguments",
+			"cellId": "b054dd02-8e6a-4e42-be4a-7e082e6187d9",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-60bc2812-8cec-4cf7-888d-7566c874c9dd-b054dd02-8e6a-4e42-be4a-7e082e6187d9": {
+			"path": "generated-edge-simstep-60bc2812-8cec-4cf7-888d-7566c874c9dd-b054dd02-8e6a-4e42-be4a-7e082e6187d9",
+			"fileName": "defs.rs",
+			"cellName": "JSON Output Flow: Transmit Parsed Arguments",
+			"cellId": "b054dd02-8e6a-4e42-be4a-7e082e6187d9",
+			"visible": true,
+			"startLine": 119,
+			"endLine": 122,
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"6bb72882-9525-4207-88b9-9573f7a6b654": {
+			"path": "6bb72882-9525-4207-88b9-9573f7a6b654",
+			"fileName": "6bb72882-9525-4207-88b9-9573f7a6b654",
+			"cellName": "JSON Output\nFlow: Transmit\nConfigured JSON\nPrinter",
+			"cellId": "6bb72882-9525-4207-88b9-9573f7a6b654",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-a46b12aa-0542-4121-b024-209610723a23-6bb72882-9525-4207-88b9-9573f7a6b654": {
+			"path": "generated-edge-simstep-a46b12aa-0542-4121-b024-209610723a23-6bb72882-9525-4207-88b9-9573f7a6b654",
+			"fileName": "hiargs.rs",
+			"cellName": "JSON Output Flow: Transmit Configured JSON Printer",
+			"cellId": "6bb72882-9525-4207-88b9-9573f7a6b654",
+			"visible": true,
+			"startLine": 210,
+			"endLine": 213,
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"605d4cc4-7749-425e-8ba5-e12c6b23d1a3": {
+			"path": "605d4cc4-7749-425e-8ba5-e12c6b23d1a3",
+			"fileName": "605d4cc4-7749-425e-8ba5-e12c6b23d1a3",
+			"cellName": "JSON Output\nFlow: Transmit\nMatch and\nContext Data",
+			"cellId": "605d4cc4-7749-425e-8ba5-e12c6b23d1a3",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3"
+		},
+		"generated-edge-simstep-eefd4073-c00d-49d2-96ce-793146d1a1ce-605d4cc4-7749-425e-8ba5-e12c6b23d1a3": {
+			"path": "generated-edge-simstep-eefd4073-c00d-49d2-96ce-793146d1a1ce-605d4cc4-7749-425e-8ba5-e12c6b23d1a3",
+			"fileName": "json.rs",
+			"cellName": "JSON Output Flow: Transmit Match and Context Data",
+			"cellId": "605d4cc4-7749-425e-8ba5-e12c6b23d1a3",
+			"visible": true,
+			"startLine": 126,
+			"endLine": 132,
+			"parentPath": "crates/printer/src/json.rs"
+		},
+		"6825dcae-96a0-412f-ab1b-8e65b339933d": {
+			"path": "6825dcae-96a0-412f-ab1b-8e65b339933d",
+			"fileName": "6825dcae-96a0-412f-ab1b-8e65b339933d",
+			"cellName": "Parse PCRE2 Command-Line Flag - defs.rs:L5381-5387",
+			"cellId": "6825dcae-96a0-412f-ab1b-8e65b339933d",
+			"visible": true,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb"
+		},
+		"crates/core/flags/defs.rs-simstep-2d298238-6bc9-4690-a137-78749b0e824e": {
+			"path": "crates/core/flags/defs.rs-simstep-2d298238-6bc9-4690-a137-78749b0e824e",
+			"fileName": "defs.rs",
+			"wiki": "The user invokes `ripgrep` with the `-P` or `--pcre2` flag to explicitly enable the PCRE2 regex engine. The argument parsing logic recognizes this flag and sets the engine choice configuration to `PCRE2`. This step is the entry point for using advanced regex features like look-around and backreferences.",
+			"cellName": "Parse PCRE2 Command-Line Flag - defs.rs:L5381-5387",
+			"cellId": "6825dcae-96a0-412f-ab1b-8e65b339933d",
+			"visible": true,
+			"startLine": 5381,
+			"endLine": 5387,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"019eb844-4613-490c-9b1a-5743aa71aeb4": {
+			"path": "019eb844-4613-490c-9b1a-5743aa71aeb4",
+			"fileName": "019eb844-4613-490c-9b1a-5743aa71aeb4",
+			"cellName": "Select PCRE2 Regex Matcher - hiargs.rs:L370-380",
+			"cellId": "019eb844-4613-490c-9b1a-5743aa71aeb4",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"crates/core/flags/hiargs.rs-simstep-74c81953-d698-4cf4-8ed6-8324c078e7ff": {
+			"path": "crates/core/flags/hiargs.rs-simstep-74c81953-d698-4cf4-8ed6-8324c078e7ff",
+			"fileName": "hiargs.rs",
+			"wiki": "Based on the `EngineChoice::PCRE2` configuration, the application logic selects the PCRE2 matcher builder. If the user had specified `--engine=auto` or `--auto-hybrid-regex`, this step would first attempt to use the default engine and then fall back to PCRE2 if the pattern compilation failed (e.g., due to unsupported features like look-around).",
+			"cellName": "Select PCRE2 Regex Matcher - hiargs.rs:L370-380",
+			"cellId": "019eb844-4613-490c-9b1a-5743aa71aeb4",
+			"visible": true,
+			"startLine": 370,
+			"endLine": 380,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"c2791749-9b9a-4275-990a-a2c2319735f9": {
+			"path": "c2791749-9b9a-4275-990a-a2c2319735f9",
+			"fileName": "c2791749-9b9a-4275-990a-a2c2319735f9",
+			"cellName": "Build PCRE2 Matcher - hiargs.rs:L405-454",
+			"cellId": "c2791749-9b9a-4275-990a-a2c2319735f9",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"crates/core/flags/hiargs.rs-simstep-54b70a6d-b1ee-42e1-87f2-ac6a947ac7cc": {
+			"path": "crates/core/flags/hiargs.rs-simstep-54b70a6d-b1ee-42e1-87f2-ac6a947ac7cc",
+			"fileName": "hiargs.rs",
+			"wiki": "The PCRE2 matcher builder compiles the given regex pattern. This involves using the `grep-pcre2` crate, which in turn calls the underlying PCRE2 C library. If the `pcre2` feature was not compiled into `ripgrep`, this step will fail. JIT compilation is enabled if available to speed up matching.",
+			"cellName": "Build PCRE2 Matcher - hiargs.rs:L405-454",
+			"cellId": "c2791749-9b9a-4275-990a-a2c2319735f9",
+			"visible": true,
+			"startLine": 405,
+			"endLine": 454,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"1c3b00d3-1533-4f77-855a-0a5ae9d0abd1": {
+			"path": "1c3b00d3-1533-4f77-855a-0a5ae9d0abd1",
+			"fileName": "1c3b00d3-1533-4f77-855a-0a5ae9d0abd1",
+			"cellName": "Execute Search with PCRE2 Matcher - search.rs:L341-350",
+			"cellId": "1c3b00d3-1533-4f77-855a-0a5ae9d0abd1",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"crates/core/search.rs-simstep-7151f213-e403-4b2d-ad9f-112e4d69af4e": {
+			"path": "crates/core/search.rs-simstep-7151f213-e403-4b2d-ad9f-112e4d69af4e",
+			"fileName": "search.rs",
+			"wiki": "The search worker receives the `PatternMatcher::PCRE2` instance. It then reads the target files and uses the PCRE2 matcher's methods to find lines that match the pattern, including patterns with look-around or backreferences.",
+			"cellName": "Execute Search with PCRE2 Matcher - search.rs:L341-350",
+			"cellId": "1c3b00d3-1533-4f77-855a-0a5ae9d0abd1",
+			"visible": true,
+			"startLine": 341,
+			"endLine": 350,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"parentPath": "crates/core/search.rs"
+		},
+		"030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d": {
+			"path": "030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d",
+			"fileName": "030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d",
+			"cellName": "Engine Choice\nConfiguration Passed",
+			"cellId": "030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-c48cab01-3dac-4912-ba64-6cc02c44dd4f-030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d": {
+			"path": "generated-edge-simstep-c48cab01-3dac-4912-ba64-6cc02c44dd4f-030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d",
+			"fileName": "defs.rs",
+			"cellName": "Engine Choice Configuration Passed",
+			"cellId": "030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d",
+			"visible": true,
+			"startLine": 5382,
+			"endLine": 5385,
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"85dfd805-df63-4482-a789-93fa055a046c": {
+			"path": "85dfd805-df63-4482-a789-93fa055a046c",
+			"fileName": "85dfd805-df63-4482-a789-93fa055a046c",
+			"cellName": "Invoke PCRE2\nMatcher Builder",
+			"cellId": "85dfd805-df63-4482-a789-93fa055a046c",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"generated-edge-simstep-9dd7d4c1-48f3-446f-bf14-16a43e174654-85dfd805-df63-4482-a789-93fa055a046c": {
+			"path": "generated-edge-simstep-9dd7d4c1-48f3-446f-bf14-16a43e174654-85dfd805-df63-4482-a789-93fa055a046c",
+			"fileName": "hiargs.rs",
+			"cellName": "Invoke PCRE2 Matcher Builder",
+			"cellId": "85dfd805-df63-4482-a789-93fa055a046c",
+			"visible": true,
+			"startLine": 374,
+			"endLine": 374,
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"94bf3581-9419-46ea-9a55-94598c438500": {
+			"path": "94bf3581-9419-46ea-9a55-94598c438500",
+			"fileName": "94bf3581-9419-46ea-9a55-94598c438500",
+			"cellName": "Compiled PCRE2\nMatcher Passed\nto Searcher",
+			"cellId": "94bf3581-9419-46ea-9a55-94598c438500",
+			"visible": true,
+			"parentCellId": "debf18dd-047e-44e4-9016-2ee07faaf18b"
+		},
+		"generated-edge-simstep-06fef420-4852-48e4-bc61-08ec1c756d79-94bf3581-9419-46ea-9a55-94598c438500": {
+			"path": "generated-edge-simstep-06fef420-4852-48e4-bc61-08ec1c756d79-94bf3581-9419-46ea-9a55-94598c438500",
+			"fileName": "hiargs.rs",
+			"cellName": "Compiled PCRE2 Matcher Passed to Searcher",
+			"cellId": "94bf3581-9419-46ea-9a55-94598c438500",
+			"visible": true,
+			"startLine": 442,
+			"endLine": 443,
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"5440e915-a99c-4d7c-a041-ed3214ef356e": {
+			"path": "5440e915-a99c-4d7c-a041-ed3214ef356e",
+			"fileName": "5440e915-a99c-4d7c-a041-ed3214ef356e",
+			"cellName": "lowargs.rs",
+			"cellId": "5440e915-a99c-4d7c-a041-ed3214ef356e",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"2e2dd6c4-6e83-424c-8da5-b8171ce5479f": {
+			"path": "2e2dd6c4-6e83-424c-8da5-b8171ce5479f",
+			"fileName": "2e2dd6c4-6e83-424c-8da5-b8171ce5479f",
+			"cellName": "decompress.rs",
+			"cellId": "2e2dd6c4-6e83-424c-8da5-b8171ce5479f",
+			"visible": true,
+			"parentCellId": "bbd871fb-2a85-4f90-b28d-abc336580454"
+		},
+		"b5bf4086-9be8-40aa-a51f-b67c6f172778": {
+			"path": "b5bf4086-9be8-40aa-a51f-b67c6f172778",
+			"fileName": "b5bf4086-9be8-40aa-a51f-b67c6f172778",
+			"cellName": "Parse '--search-zip' Flag - defs.rs:L6097-6103",
+			"cellId": "b5bf4086-9be8-40aa-a51f-b67c6f172778",
+			"visible": true,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb"
+		},
+		"crates/core/flags/defs.rs-simstep-028f086b-a018-4564-82a0-7069685c5fe6": {
+			"path": "crates/core/flags/defs.rs-simstep-028f086b-a018-4564-82a0-7069685c5fe6",
+			"fileName": "defs.rs",
+			"wiki": "The command-line argument parser processes the input flags provided by the user. When '-z' or '--search-zip' is detected, it updates the internal arguments configuration to enable searching within compressed files.",
+			"cellName": "Parse '--search-zip' Flag - defs.rs:L6097-6103",
+			"cellId": "b5bf4086-9be8-40aa-a51f-b67c6f172778",
+			"visible": true,
+			"startLine": 6097,
+			"endLine": 6103,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"3e247a17-fe8e-4353-bc30-5ea6711f2d85": {
+			"path": "3e247a17-fe8e-4353-bc30-5ea6711f2d85",
+			"fileName": "3e247a17-fe8e-4353-bc30-5ea6711f2d85",
+			"cellName": "Build High-Level Arguments - hiargs.rs:L310",
+			"cellId": "3e247a17-fe8e-4353-bc30-5ea6711f2d85",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"crates/core/flags/hiargs.rs-simstep-978bc900-d4de-4d46-a790-971e589fa824": {
+			"path": "crates/core/flags/hiargs.rs-simstep-978bc900-d4de-4d46-a790-971e589fa824",
+			"fileName": "hiargs.rs",
+			"wiki": "The `LowArgs` struct is transformed into a `HiArgs` struct. This conversion process consolidates and refines the arguments into a more structured format, carrying over the `search_zip` setting.",
+			"cellName": "Build High-Level Arguments - hiargs.rs:L310",
+			"cellId": "3e247a17-fe8e-4353-bc30-5ea6711f2d85",
+			"visible": true,
+			"startLine": 310,
+			"endLine": 310,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"cadc0775-86e8-4e88-bd26-61f174b086eb": {
+			"path": "cadc0775-86e8-4e88-bd26-61f174b086eb",
+			"fileName": "cadc0775-86e8-4e88-bd26-61f174b086eb",
+			"cellName": "Configure Search Worker for Decompression - search.rs:L127-134",
+			"cellId": "cadc0775-86e8-4e88-bd26-61f174b086eb",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"crates/core/search.rs-simstep-b53b5e9f-939c-4ee5-a88c-437397bbe57f": {
+			"path": "crates/core/search.rs-simstep-b53b5e9f-939c-4ee5-a88c-437397bbe57f",
+			"fileName": "search.rs",
+			"wiki": "The `SearchWorkerBuilder` receives the `search_zip` flag and stores it in its internal configuration. This builder is also initialized with a `DecompressionReaderBuilder` that contains default rules for matching compressed file types (e.g., *.gz, *.bz2).",
+			"cellName": "Configure Search Worker for Decompression - search.rs:L127-134",
+			"cellId": "cadc0775-86e8-4e88-bd26-61f174b086eb",
+			"visible": true,
+			"startLine": 127,
+			"endLine": 134,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"parentPath": "crates/core/search.rs"
+		},
+		"36ea22a2-80cb-4c97-b055-b14052750de7": {
+			"path": "36ea22a2-80cb-4c97-b055-b14052750de7",
+			"fileName": "36ea22a2-80cb-4c97-b055-b14052750de7",
+			"cellName": "Check if Decompression is Needed - search.rs:L275-280",
+			"cellId": "36ea22a2-80cb-4c97-b055-b14052750de7",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"crates/core/search.rs-simstep-bbe67bc0-80ec-4573-af90-99a3044945be": {
+			"path": "crates/core/search.rs-simstep-bbe67bc0-80ec-4573-af90-99a3044945be",
+			"fileName": "search.rs",
+			"wiki": "The search worker's `should_decompress` method checks two conditions: 1) if the `search_zip` config is enabled, and 2) if the file path matches a known decompression rule (e.g., ends with '.gz'). Both are true, so it decides to decompress.",
+			"cellName": "Check if Decompression is Needed - search.rs:L275-280",
+			"cellId": "36ea22a2-80cb-4c97-b055-b14052750de7",
+			"visible": true,
+			"startLine": 275,
+			"endLine": 280,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"parentPath": "crates/core/search.rs"
+		},
+		"626197b8-ae20-4c15-9110-5e97703d7612": {
+			"path": "626197b8-ae20-4c15-9110-5e97703d7612",
+			"fileName": "626197b8-ae20-4c15-9110-5e97703d7612",
+			"cellName": "Create Decompression Process - decompress.rs:L221-245",
+			"cellId": "626197b8-ae20-4c15-9110-5e97703d7612",
+			"visible": true,
+			"parentCellId": "2e2dd6c4-6e83-424c-8da5-b8171ce5479f"
+		},
+		"crates/cli/src/decompress.rs-simstep-8e6d5c6c-f294-4dae-901e-1f74837d5791": {
+			"path": "crates/cli/src/decompress.rs-simstep-8e6d5c6c-f294-4dae-901e-1f74837d5791",
+			"fileName": "decompress.rs",
+			"wiki": "The `DecompressionReaderBuilder` finds the command associated with the '.gz' extension (e.g., 'gzip'), spawns it as a child process (`gzip -d -c /path/to/file`), and creates a `DecompressionReader` that reads from the child process's standard output.",
+			"cellName": "Create Decompression Process - decompress.rs:L221-245",
+			"cellId": "626197b8-ae20-4c15-9110-5e97703d7612",
+			"visible": true,
+			"startLine": 221,
+			"endLine": 245,
+			"parentCellId": "2e2dd6c4-6e83-424c-8da5-b8171ce5479f",
+			"parentPath": "crates/cli/src/decompress.rs"
+		},
+		"88dd5a3a-40c2-43e3-ac59-ec2e806c3825": {
+			"path": "88dd5a3a-40c2-43e3-ac59-ec2e806c3825",
+			"fileName": "88dd5a3a-40c2-43e3-ac59-ec2e806c3825",
+			"cellName": "Search Decompressed Stream - decompress.rs:L389-395",
+			"cellId": "88dd5a3a-40c2-43e3-ac59-ec2e806c3825",
+			"visible": true,
+			"parentCellId": "2e2dd6c4-6e83-424c-8da5-b8171ce5479f"
+		},
+		"crates/cli/src/decompress.rs-simstep-d8c3b0bc-3ff0-4aee-bf11-5653be83ea9b": {
+			"path": "crates/cli/src/decompress.rs-simstep-d8c3b0bc-3ff0-4aee-bf11-5653be83ea9b",
+			"fileName": "decompress.rs",
+			"wiki": "The core search logic reads data chunk by chunk from the `DecompressionReader`. It is completely unaware of the underlying decompression; it simply receives plain text data from the `read` method and applies the regex pattern to find matches.",
+			"cellName": "Search Decompressed Stream - decompress.rs:L389-395",
+			"cellId": "88dd5a3a-40c2-43e3-ac59-ec2e806c3825",
+			"visible": true,
+			"startLine": 389,
+			"endLine": 395,
+			"parentCellId": "2e2dd6c4-6e83-424c-8da5-b8171ce5479f",
+			"parentPath": "crates/cli/src/decompress.rs"
+		},
+		"acb6f4f0-b4fe-475e-9f15-96bff8ad5f13": {
+			"path": "acb6f4f0-b4fe-475e-9f15-96bff8ad5f13",
+			"fileName": "acb6f4f0-b4fe-475e-9f15-96bff8ad5f13",
+			"cellName": "Transmit Low-Level\nArguments",
+			"cellId": "acb6f4f0-b4fe-475e-9f15-96bff8ad5f13",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-6703644c-54a4-44ac-9a0f-9e491ae74fb8-acb6f4f0-b4fe-475e-9f15-96bff8ad5f13": {
+			"path": "generated-edge-simstep-6703644c-54a4-44ac-9a0f-9e491ae74fb8-acb6f4f0-b4fe-475e-9f15-96bff8ad5f13",
+			"fileName": "defs.rs",
+			"cellName": "Transmit Low-Level Arguments",
+			"cellId": "acb6f4f0-b4fe-475e-9f15-96bff8ad5f13",
+			"visible": true,
+			"startLine": 100,
+			"endLine": 100,
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"57f135d9-c844-4467-9dce-d84057fd5869": {
+			"path": "57f135d9-c844-4467-9dce-d84057fd5869",
+			"fileName": "57f135d9-c844-4467-9dce-d84057fd5869",
+			"cellName": "Pass Config\nto Search\nWorker Builder",
+			"cellId": "57f135d9-c844-4467-9dce-d84057fd5869",
+			"visible": true,
+			"parentCellId": "debf18dd-047e-44e4-9016-2ee07faaf18b"
+		},
+		"generated-edge-simstep-5dfb2af4-d179-418b-ba1a-b3b4057951a7-57f135d9-c844-4467-9dce-d84057fd5869": {
+			"path": "generated-edge-simstep-5dfb2af4-d179-418b-ba1a-b3b4057951a7-57f135d9-c844-4467-9dce-d84057fd5869",
+			"fileName": "hiargs.rs",
+			"cellName": "Pass Config to Search Worker Builder",
+			"cellId": "57f135d9-c844-4467-9dce-d84057fd5869",
+			"visible": true,
+			"startLine": 701,
+			"endLine": 701,
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"a5c04342-f30c-4b03-88ef-fd5d5cc6dec5": {
+			"path": "a5c04342-f30c-4b03-88ef-fd5d5cc6dec5",
+			"fileName": "a5c04342-f30c-4b03-88ef-fd5d5cc6dec5",
+			"cellName": "Transmit File\nPath for\nDecompression Check",
+			"cellId": "a5c04342-f30c-4b03-88ef-fd5d5cc6dec5",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"generated-edge-simstep-cb703e0d-2a54-42ed-93b9-0648e42f39e2-a5c04342-f30c-4b03-88ef-fd5d5cc6dec5": {
+			"path": "generated-edge-simstep-cb703e0d-2a54-42ed-93b9-0648e42f39e2-a5c04342-f30c-4b03-88ef-fd5d5cc6dec5",
+			"fileName": "search.rs",
+			"cellName": "Transmit File Path for Decompression Check",
+			"cellId": "a5c04342-f30c-4b03-88ef-fd5d5cc6dec5",
+			"visible": true,
+			"startLine": 275,
+			"endLine": 275,
+			"parentPath": "crates/core/search.rs"
+		},
+		"a2c78834-0693-40f4-91ad-076a6600ec8e": {
+			"path": "a2c78834-0693-40f4-91ad-076a6600ec8e",
+			"fileName": "a2c78834-0693-40f4-91ad-076a6600ec8e",
+			"cellName": "Request Decompressed\nStream",
+			"cellId": "a2c78834-0693-40f4-91ad-076a6600ec8e",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-9d428183-5928-4541-bff7-2f3399eb9f9d-a2c78834-0693-40f4-91ad-076a6600ec8e": {
+			"path": "generated-edge-simstep-9d428183-5928-4541-bff7-2f3399eb9f9d-a2c78834-0693-40f4-91ad-076a6600ec8e",
+			"fileName": "search.rs",
+			"cellName": "Request Decompressed Stream",
+			"cellId": "a2c78834-0693-40f4-91ad-076a6600ec8e",
+			"visible": true,
+			"startLine": 221,
+			"endLine": 224,
+			"parentPath": "crates/core/search.rs"
+		},
+		"e5d149ac-77cd-44b7-adaf-e71df369fe88": {
+			"path": "e5d149ac-77cd-44b7-adaf-e71df369fe88",
+			"fileName": "e5d149ac-77cd-44b7-adaf-e71df369fe88",
+			"cellName": "Return Reader\nInterface",
+			"cellId": "e5d149ac-77cd-44b7-adaf-e71df369fe88",
+			"visible": true,
+			"parentCellId": "2e2dd6c4-6e83-424c-8da5-b8171ce5479f"
+		},
+		"generated-edge-simstep-3c0c4cad-0e48-4247-be8a-6c45e41015bf-e5d149ac-77cd-44b7-adaf-e71df369fe88": {
+			"path": "generated-edge-simstep-3c0c4cad-0e48-4247-be8a-6c45e41015bf-e5d149ac-77cd-44b7-adaf-e71df369fe88",
+			"fileName": "decompress.rs",
+			"cellName": "Return Reader Interface",
+			"cellId": "e5d149ac-77cd-44b7-adaf-e71df369fe88",
+			"visible": true,
+			"startLine": 388,
+			"endLine": 388,
+			"parentPath": "crates/cli/src/decompress.rs"
+		},
+		"ef09f321-34b3-4a42-869e-19002e3a4382": {
+			"path": "ef09f321-34b3-4a42-869e-19002e3a4382",
+			"fileName": "ef09f321-34b3-4a42-869e-19002e3a4382",
+			"cellName": "glue.rs",
+			"cellId": "ef09f321-34b3-4a42-869e-19002e3a4382",
+			"visible": true,
+			"parentCellId": "7a2a4538-5e5a-4df6-85cc-b341c95545a1"
+		},
+		"65e6f10c-354e-430e-8920-63ca301b13f6": {
+			"path": "65e6f10c-354e-430e-8920-63ca301b13f6",
+			"fileName": "65e6f10c-354e-430e-8920-63ca301b13f6",
+			"cellName": "Parse Multiline Flag - defs.rs:L4184-4190",
+			"cellId": "65e6f10c-354e-430e-8920-63ca301b13f6",
+			"visible": true,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb"
+		},
+		"crates/core/flags/defs.rs-simstep-0548c99b-847a-422e-98ee-68d9d8e74274": {
+			"path": "crates/core/flags/defs.rs-simstep-0548c99b-847a-422e-98ee-68d9d8e74274",
+			"fileName": "defs.rs",
+			"wiki": "The application starts by parsing the command-line arguments. When the user provides `-U` or `--multiline`, the `Multiline` flag struct is processed. Its `update` method sets the `multiline` boolean to `true` in the `LowArgs` struct, which stores the initial parsed arguments. This also disables the `stop-on-nonmatch` feature, as it's incompatible with multiline searching.",
+			"cellName": "Parse Multiline Flag - defs.rs:L4184-4190",
+			"cellId": "65e6f10c-354e-430e-8920-63ca301b13f6",
+			"visible": true,
+			"startLine": 4184,
+			"endLine": 4190,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"a03b1238-c735-4679-a3e8-782afc9e93e0": {
+			"path": "a03b1238-c735-4679-a3e8-782afc9e93e0",
+			"fileName": "a03b1238-c735-4679-a3e8-782afc9e93e0",
+			"cellName": "Configure Regex Engine - hiargs.rs:L478-482",
+			"cellId": "a03b1238-c735-4679-a3e8-782afc9e93e0",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"crates/core/flags/hiargs.rs-simstep-f93bf41d-9482-4e31-8513-5f150b8839e1": {
+			"path": "crates/core/flags/hiargs.rs-simstep-f93bf41d-9482-4e31-8513-5f150b8839e1",
+			"fileName": "hiargs.rs",
+			"wiki": "Based on the `HiArgs` configuration, the regex engine builder is configured. If `multiline` is true, it sets options to allow patterns to match across line terminators. Specifically, `dot_matches_new_line` is enabled if `multiline_dotall` is also true, and the default line terminator is removed, allowing patterns like `\\n` to match.",
+			"cellName": "Configure Regex Engine - hiargs.rs:L478-482",
+			"cellId": "a03b1238-c735-4679-a3e8-782afc9e93e0",
+			"visible": true,
+			"startLine": 478,
+			"endLine": 482,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"d77e8ea1-2850-488f-af80-6417c53c8099": {
+			"path": "d77e8ea1-2850-488f-af80-6417c53c8099",
+			"fileName": "d77e8ea1-2850-488f-af80-6417c53c8099",
+			"cellName": "Select Multiline Search Strategy - mod.rs:L700-707",
+			"cellId": "d77e8ea1-2850-488f-af80-6417c53c8099",
+			"visible": true,
+			"parentCellId": "f05bde61-7d65-4d33-a433-141321ba0c95"
+		},
+		"crates/searcher/src/searcher/mod.rs-simstep-cc78378e-da78-43a0-926d-0c40f5ca294d": {
+			"path": "crates/searcher/src/searcher/mod.rs-simstep-cc78378e-da78-43a0-926d-0c40f5ca294d",
+			"fileName": "mod.rs",
+			"wiki": "The `Searcher` checks if the provided matcher requires multiline support. Since the `-U` flag was used, `multi_line_with_matcher` returns true. This triggers the searcher to read the entire file's contents into an in-memory buffer (`multi_line_buffer`) before starting the search, as matches can span arbitrary lines and cannot be processed incrementally.",
+			"cellName": "Select Multiline Search Strategy - mod.rs:L700-707",
+			"cellId": "d77e8ea1-2850-488f-af80-6417c53c8099",
+			"visible": true,
+			"startLine": 700,
+			"endLine": 707,
+			"parentCellId": "f05bde61-7d65-4d33-a433-141321ba0c95",
+			"parentPath": "crates/searcher/src/searcher/mod.rs"
+		},
+		"b8833d1c-74e5-4db9-9775-056216d25c47": {
+			"path": "b8833d1c-74e5-4db9-9775-056216d25c47",
+			"fileName": "b8833d1c-74e5-4db9-9775-056216d25c47",
+			"cellName": "Execute Search on Buffer - glue.rs:L146-162",
+			"cellId": "b8833d1c-74e5-4db9-9775-056216d25c47",
+			"visible": true,
+			"parentCellId": "ef09f321-34b3-4a42-869e-19002e3a4382"
+		},
+		"crates/searcher/src/searcher/glue.rs-simstep-a0a4371e-e74e-4fa4-b643-6f351759a477": {
+			"path": "crates/searcher/src/searcher/glue.rs-simstep-a0a4371e-e74e-4fa4-b643-6f351759a477",
+			"fileName": "glue.rs",
+			"wiki": "The `MultiLine` searcher executes the regex against the entire in-memory byte slice. It finds all non-overlapping matches. For each match, it determines the start and end byte offsets and sends this information to the designated `Sink` for processing.",
+			"cellName": "Execute Search on Buffer - glue.rs:L146-162",
+			"cellId": "b8833d1c-74e5-4db9-9775-056216d25c47",
+			"visible": true,
+			"startLine": 146,
+			"endLine": 162,
+			"parentCellId": "ef09f321-34b3-4a42-869e-19002e3a4382",
+			"parentPath": "crates/searcher/src/searcher/glue.rs"
+		},
+		"1f3ae57d-ae3d-4633-be82-877091353aa6": {
+			"path": "1f3ae57d-ae3d-4633-be82-877091353aa6",
+			"fileName": "1f3ae57d-ae3d-4633-be82-877091353aa6",
+			"cellName": "Format and Print Match - standard.rs:L1044-1049",
+			"cellId": "1f3ae57d-ae3d-4633-be82-877091353aa6",
+			"visible": true,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550"
+		},
+		"crates/printer/src/standard.rs-simstep-30500bdd-89dc-4b27-917c-7c554ca5ec5a": {
+			"path": "crates/printer/src/standard.rs-simstep-30500bdd-89dc-4b27-917c-7c554ca5ec5a",
+			"fileName": "standard.rs",
+			"wiki": "The `Standard` printer receives the `SinkMatch`. Because the match can span multiple lines, it uses a `LineStep` iterator to break the matched byte slice into individual lines. It then prints each line, prepending the line number and applying any relevant coloring or formatting.",
+			"cellName": "Format and Print Match - standard.rs:L1044-1049",
+			"cellId": "1f3ae57d-ae3d-4633-be82-877091353aa6",
+			"visible": true,
+			"startLine": 1044,
+			"endLine": 1049,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"bcc616ab-4fd0-4234-9d6c-9b29eda63456": {
+			"path": "bcc616ab-4fd0-4234-9d6c-9b29eda63456",
+			"fileName": "bcc616ab-4fd0-4234-9d6c-9b29eda63456",
+			"cellName": "Configuration Transfer",
+			"cellId": "bcc616ab-4fd0-4234-9d6c-9b29eda63456",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-73978832-90e0-47df-9c70-60f5ecf6dbcb-bcc616ab-4fd0-4234-9d6c-9b29eda63456": {
+			"path": "generated-edge-simstep-73978832-90e0-47df-9c70-60f5ecf6dbcb-bcc616ab-4fd0-4234-9d6c-9b29eda63456",
+			"fileName": "defs.rs",
+			"cellName": "Configuration Transfer",
+			"cellId": "bcc616ab-4fd0-4234-9d6c-9b29eda63456",
+			"visible": true,
+			"startLine": 288,
+			"endLine": 289,
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"8e2520f4-89df-4244-9f53-91795625ca10": {
+			"path": "8e2520f4-89df-4244-9f53-91795625ca10",
+			"fileName": "8e2520f4-89df-4244-9f53-91795625ca10",
+			"cellName": "Matcher Sent\nto Searcher",
+			"cellId": "8e2520f4-89df-4244-9f53-91795625ca10",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-d0d166ef-3aad-4ea4-8186-939165e650d1-8e2520f4-89df-4244-9f53-91795625ca10": {
+			"path": "generated-edge-simstep-d0d166ef-3aad-4ea4-8186-939165e650d1-8e2520f4-89df-4244-9f53-91795625ca10",
+			"fileName": "hiargs.rs",
+			"cellName": "Matcher Sent to Searcher",
+			"cellId": "8e2520f4-89df-4244-9f53-91795625ca10",
+			"visible": true,
+			"startLine": 786,
+			"endLine": 786,
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"0a935202-428b-429e-a4c4-b1dd464e4bda": {
+			"path": "0a935202-428b-429e-a4c4-b1dd464e4bda",
+			"fileName": "0a935202-428b-429e-a4c4-b1dd464e4bda",
+			"cellName": "Buffer Passed\nto MultiLine\nSearcher",
+			"cellId": "0a935202-428b-429e-a4c4-b1dd464e4bda",
+			"visible": true,
+			"parentCellId": "7a2a4538-5e5a-4df6-85cc-b341c95545a1"
+		},
+		"generated-edge-simstep-351fecf5-1670-436c-abcc-5460f7ad0bbf-0a935202-428b-429e-a4c4-b1dd464e4bda": {
+			"path": "generated-edge-simstep-351fecf5-1670-436c-abcc-5460f7ad0bbf-0a935202-428b-429e-a4c4-b1dd464e4bda",
+			"fileName": "mod.rs",
+			"cellName": "Buffer Passed to MultiLine Searcher",
+			"cellId": "0a935202-428b-429e-a4c4-b1dd464e4bda",
+			"visible": true,
+			"startLine": 153,
+			"endLine": 155,
+			"parentPath": "crates/searcher/src/searcher/mod.rs"
+		},
+		"7f305131-1f1e-4245-8dd4-d27e022f994a": {
+			"path": "7f305131-1f1e-4245-8dd4-d27e022f994a",
+			"fileName": "7f305131-1f1e-4245-8dd4-d27e022f994a",
+			"cellName": "Matches Sent\nto Sink",
+			"cellId": "7f305131-1f1e-4245-8dd4-d27e022f994a",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-00c8ea3d-7f7f-46d3-b700-5ee54ccb6c18-7f305131-1f1e-4245-8dd4-d27e022f994a": {
+			"path": "generated-edge-simstep-00c8ea3d-7f7f-46d3-b700-5ee54ccb6c18-7f305131-1f1e-4245-8dd4-d27e022f994a",
+			"fileName": "glue.rs",
+			"cellName": "Matches Sent to Sink",
+			"cellId": "7f305131-1f1e-4245-8dd4-d27e022f994a",
+			"visible": true,
+			"startLine": 9,
+			"endLine": 11,
+			"parentPath": "crates/searcher/src/searcher/glue.rs"
+		},
+		"bc250234-cbc6-45a9-bb30-a680e8a25434": {
+			"path": "bc250234-cbc6-45a9-bb30-a680e8a25434",
+			"fileName": "bc250234-cbc6-45a9-bb30-a680e8a25434",
+			"cellName": "matcher",
+			"cellId": "bc250234-cbc6-45a9-bb30-a680e8a25434",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"97c08d6d-4900-4c90-8c85-4ba11ef19a61": {
+			"path": "97c08d6d-4900-4c90-8c85-4ba11ef19a61",
+			"fileName": "97c08d6d-4900-4c90-8c85-4ba11ef19a61",
+			"cellName": "src",
+			"cellId": "97c08d6d-4900-4c90-8c85-4ba11ef19a61",
+			"visible": true,
+			"parentCellId": "bc250234-cbc6-45a9-bb30-a680e8a25434"
+		},
+		"d77a4716-11cf-4b4f-8142-92ff0d375bf2": {
+			"path": "d77a4716-11cf-4b4f-8142-92ff0d375bf2",
+			"fileName": "d77a4716-11cf-4b4f-8142-92ff0d375bf2",
+			"cellName": "util.rs",
+			"cellId": "d77a4716-11cf-4b4f-8142-92ff0d375bf2",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3"
+		},
+		"c50efe68-b749-49a4-a253-6c52052d4fe6": {
+			"path": "c50efe68-b749-49a4-a253-6c52052d4fe6",
+			"fileName": "c50efe68-b749-49a4-a253-6c52052d4fe6",
+			"cellName": "lib.rs",
+			"cellId": "c50efe68-b749-49a4-a253-6c52052d4fe6",
+			"visible": true,
+			"parentCellId": "97c08d6d-4900-4c90-8c85-4ba11ef19a61"
+		},
+		"613effaa-920d-4cad-84b3-74ea88807b5c": {
+			"path": "613effaa-920d-4cad-84b3-74ea88807b5c",
+			"fileName": "613effaa-920d-4cad-84b3-74ea88807b5c",
+			"cellName": "interpolate.rs",
+			"cellId": "613effaa-920d-4cad-84b3-74ea88807b5c",
+			"visible": true,
+			"parentCellId": "97c08d6d-4900-4c90-8c85-4ba11ef19a61"
+		},
+		"4fd8d6c1-cc49-4bfe-a852-ab24cffcf443": {
+			"path": "4fd8d6c1-cc49-4bfe-a852-ab24cffcf443",
+			"fileName": "4fd8d6c1-cc49-4bfe-a852-ab24cffcf443",
+			"cellName": "Parse '--replace' Argument - defs.rs:L6029-6032",
+			"cellId": "4fd8d6c1-cc49-4bfe-a852-ab24cffcf443",
+			"visible": true,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb"
+		},
+		"crates/core/flags/defs.rs-simstep-6c3035dc-c539-474d-9d08-380371747982": {
+			"path": "crates/core/flags/defs.rs-simstep-6c3035dc-c539-474d-9d08-380371747982",
+			"fileName": "defs.rs",
+			"wiki": "The application parses the command-line arguments, identifying the `-r` or `--replace` flag. The provided replacement string is captured and stored in the `LowArgs` structure for later use.",
+			"cellName": "Parse '--replace' Argument - defs.rs:L6029-6032",
+			"cellId": "4fd8d6c1-cc49-4bfe-a852-ab24cffcf443",
+			"visible": true,
+			"startLine": 6029,
+			"endLine": 6032,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"d10772ea-5a19-4c72-ad04-754a0208a213": {
+			"path": "d10772ea-5a19-4c72-ad04-754a0208a213",
+			"fileName": "d10772ea-5a19-4c72-ad04-754a0208a213",
+			"cellName": "Configure Printer with Replacement Text - hiargs.rs:L624",
+			"cellId": "d10772ea-5a19-4c72-ad04-754a0208a213",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"crates/core/flags/hiargs.rs-simstep-0d5fe06c-3899-4862-b2a7-dcbeb7d70e78": {
+			"path": "crates/core/flags/hiargs.rs-simstep-0d5fe06c-3899-4862-b2a7-dcbeb7d70e78",
+			"fileName": "hiargs.rs",
+			"wiki": "The `HiArgs` containing the replacement string are used to build a printer (e.g., `Standard` or `JSON`). The replacement text is passed to the printer's builder, which stores it in its configuration.",
+			"cellName": "Configure Printer with Replacement Text - hiargs.rs:L624",
+			"cellId": "d10772ea-5a19-4c72-ad04-754a0208a213",
+			"visible": true,
+			"startLine": 624,
+			"endLine": 624,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"2897d065-bc9c-47a0-935d-58720d432394": {
+			"path": "2897d065-bc9c-47a0-935d-58720d432394",
+			"fileName": "2897d065-bc9c-47a0-935d-58720d432394",
+			"cellName": "Process Match and Initiate Replacement - standard.rs:L777",
+			"cellId": "2897d065-bc9c-47a0-935d-58720d432394",
+			"visible": true,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550"
+		},
+		"crates/printer/src/standard.rs-simstep-bfb926ff-af12-4d27-8b74-1b216918243c": {
+			"path": "crates/printer/src/standard.rs-simstep-bfb926ff-af12-4d27-8b74-1b216918243c",
+			"fileName": "standard.rs",
+			"wiki": "The `Searcher` finds a match in a file and invokes the `matched` method on the `StandardSink`. This method then calls its internal `replace` helper function to begin the replacement process for the matched line.",
+			"cellName": "Process Match and Initiate Replacement - standard.rs:L777",
+			"cellId": "2897d065-bc9c-47a0-935d-58720d432394",
+			"visible": true,
+			"startLine": 777,
+			"endLine": 777,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"6f4daaff-ddca-41f0-ad53-d48d290d885b": {
+			"path": "6f4daaff-ddca-41f0-ad53-d48d290d885b",
+			"fileName": "6f4daaff-ddca-41f0-ad53-d48d290d885b",
+			"cellName": "Perform Replacement via Interpolation - util.rs:L87-102",
+			"cellId": "6f4daaff-ddca-41f0-ad53-d48d290d885b",
+			"visible": true,
+			"parentCellId": "d77a4716-11cf-4b4f-8142-92ff0d375bf2"
+		},
+		"crates/printer/src/util.rs-simstep-7e01b0f6-7c2f-4578-8bcd-e92dff0173d8": {
+			"path": "crates/printer/src/util.rs-simstep-7e01b0f6-7c2f-4578-8bcd-e92dff0173d8",
+			"fileName": "util.rs",
+			"wiki": "The `Replacer::replace_all` method orchestrates the replacement. It finds all matches and uses `caps.interpolate` to handle capture groups (like `$1`) in the replacement string, building the new text in a buffer.",
+			"cellName": "Perform Replacement via Interpolation - util.rs:L87-102",
+			"cellId": "6f4daaff-ddca-41f0-ad53-d48d290d885b",
+			"visible": true,
+			"startLine": 87,
+			"endLine": 102,
+			"parentCellId": "d77a4716-11cf-4b4f-8142-92ff0d375bf2",
+			"parentPath": "crates/printer/src/util.rs"
+		},
+		"778e8bbe-678f-4a3c-8911-52fab94d475b": {
+			"path": "778e8bbe-678f-4a3c-8911-52fab94d475b",
+			"fileName": "778e8bbe-678f-4a3c-8911-52fab94d475b",
+			"cellName": "Substitute Capture Groups - interpolate.rs:L14-57",
+			"cellId": "778e8bbe-678f-4a3c-8911-52fab94d475b",
+			"visible": true,
+			"parentCellId": "613effaa-920d-4cad-84b3-74ea88807b5c"
+		},
+		"crates/matcher/src/interpolate.rs-simstep-86be35a1-d0f0-424f-9f87-9f3e7e924ed7": {
+			"path": "crates/matcher/src/interpolate.rs-simstep-86be35a1-d0f0-424f-9f87-9f3e7e924ed7",
+			"fileName": "interpolate.rs",
+			"wiki": "The `interpolate` function parses the replacement string for `$` characters. It identifies capture group references (e.g., `$1`, `$name`), looks up the corresponding captured text from the match, and writes the substituted string into the destination buffer.",
+			"cellName": "Substitute Capture Groups - interpolate.rs:L14-57",
+			"cellId": "778e8bbe-678f-4a3c-8911-52fab94d475b",
+			"visible": true,
+			"startLine": 14,
+			"endLine": 57,
+			"parentCellId": "613effaa-920d-4cad-84b3-74ea88807b5c",
+			"parentPath": "crates/matcher/src/interpolate.rs"
+		},
+		"7138d741-53de-48fc-a962-99b13e1d7706": {
+			"path": "7138d741-53de-48fc-a962-99b13e1d7706",
+			"fileName": "7138d741-53de-48fc-a962-99b13e1d7706",
+			"cellName": "Construct Final Output Line - standard.rs:L906-911",
+			"cellId": "7138d741-53de-48fc-a962-99b13e1d7706",
+			"visible": true,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550"
+		},
+		"crates/printer/src/standard.rs-simstep-6506fc09-ffcb-4339-bd4a-e84253d0c1b6": {
+			"path": "crates/printer/src/standard.rs-simstep-6506fc09-ffcb-4339-bd4a-e84253d0c1b6",
+			"fileName": "standard.rs",
+			"wiki": "Back in `StandardSink::matched`, the replaced text is retrieved from the `Replacer`. It is then encapsulated in a `Sunk` object, which represents the matched context but with the replaced bytes, abstracting it for the final printing logic.",
+			"cellName": "Construct Final Output Line - standard.rs:L906-911",
+			"cellId": "7138d741-53de-48fc-a962-99b13e1d7706",
+			"visible": true,
+			"startLine": 906,
+			"endLine": 911,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"ee822001-55cc-47c3-8efc-295818547c1a": {
+			"path": "ee822001-55cc-47c3-8efc-295818547c1a",
+			"fileName": "ee822001-55cc-47c3-8efc-295818547c1a",
+			"cellName": "Write to Output Stream - standard.rs:L1647-1651",
+			"cellId": "ee822001-55cc-47c3-8efc-295818547c1a",
+			"visible": true,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550"
+		},
+		"crates/printer/src/standard.rs-simstep-0c6dc36c-3ce4-40c7-9fe0-91ab470855a5": {
+			"path": "crates/printer/src/standard.rs-simstep-0c6dc36c-3ce4-40c7-9fe0-91ab470855a5",
+			"fileName": "standard.rs",
+			"wiki": "The final printing logic takes the `Sunk` object, formats the line with any other required elements (like line numbers or colors), and writes the result to the designated output stream (e.g., stdout).",
+			"cellName": "Write to Output Stream - standard.rs:L1647-1651",
+			"cellId": "ee822001-55cc-47c3-8efc-295818547c1a",
+			"visible": true,
+			"startLine": 1647,
+			"endLine": 1651,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"205c10d8-385d-45c1-9829-2e59c67b8005": {
+			"path": "205c10d8-385d-45c1-9829-2e59c67b8005",
+			"fileName": "205c10d8-385d-45c1-9829-2e59c67b8005",
+			"cellName": "Propagate Replacement\nArgument",
+			"cellId": "205c10d8-385d-45c1-9829-2e59c67b8005",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-2d10ae06-aecd-4480-8826-c036f9a2f1c9-205c10d8-385d-45c1-9829-2e59c67b8005": {
+			"path": "generated-edge-simstep-2d10ae06-aecd-4480-8826-c036f9a2f1c9-205c10d8-385d-45c1-9829-2e59c67b8005",
+			"fileName": "defs.rs",
+			"cellName": "Propagate Replacement Argument",
+			"cellId": "205c10d8-385d-45c1-9829-2e59c67b8005",
+			"visible": true,
+			"startLine": 309,
+			"endLine": 309,
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02": {
+			"path": "ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02",
+			"fileName": "ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02",
+			"cellName": "Create Printer\nSink",
+			"cellId": "ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-c2eae192-e8c3-413a-8c95-fda6e860e445-ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02": {
+			"path": "generated-edge-simstep-c2eae192-e8c3-413a-8c95-fda6e860e445-ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02",
+			"fileName": "hiargs.rs",
+			"cellName": "Create Printer Sink",
+			"cellId": "ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02",
+			"visible": true,
+			"startLine": 558,
+			"endLine": 566,
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"da844bfb-d742-4ee0-af58-61cd861b9350": {
+			"path": "da844bfb-d742-4ee0-af58-61cd861b9350",
+			"fileName": "da844bfb-d742-4ee0-af58-61cd861b9350",
+			"cellName": "Send Match\nData to\nReplacer",
+			"cellId": "da844bfb-d742-4ee0-af58-61cd861b9350",
+			"visible": true,
+			"parentCellId": "a9858ff0-4d39-4382-b671-fae85b74aaa3"
+		},
+		"generated-edge-simstep-50975416-4977-4580-a765-b51dfbe4b983-da844bfb-d742-4ee0-af58-61cd861b9350": {
+			"path": "generated-edge-simstep-50975416-4977-4580-a765-b51dfbe4b983-da844bfb-d742-4ee0-af58-61cd861b9350",
+			"fileName": "standard.rs",
+			"cellName": "Send Match Data to Replacer",
+			"cellId": "da844bfb-d742-4ee0-af58-61cd861b9350",
+			"visible": true,
+			"startLine": 752,
+			"endLine": 758,
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"5442b0ed-343b-41ed-b7fc-f5baf0e5991c": {
+			"path": "5442b0ed-343b-41ed-b7fc-f5baf0e5991c",
+			"fileName": "5442b0ed-343b-41ed-b7fc-f5baf0e5991c",
+			"cellName": "Pass Data\nto Core\nInterpolation Logic",
+			"cellId": "5442b0ed-343b-41ed-b7fc-f5baf0e5991c",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-ec97fde2-3851-40bf-be8a-598def3c9285-5442b0ed-343b-41ed-b7fc-f5baf0e5991c": {
+			"path": "generated-edge-simstep-ec97fde2-3851-40bf-be8a-598def3c9285-5442b0ed-343b-41ed-b7fc-f5baf0e5991c",
+			"fileName": "util.rs",
+			"cellName": "Pass Data to Core Interpolation Logic",
+			"cellId": "5442b0ed-343b-41ed-b7fc-f5baf0e5991c",
+			"visible": true,
+			"startLine": 449,
+			"endLine": 455,
+			"parentPath": "crates/printer/src/util.rs"
+		},
+		"50dbd73e-3872-4462-8540-93e549529ef2": {
+			"path": "50dbd73e-3872-4462-8540-93e549529ef2",
+			"fileName": "50dbd73e-3872-4462-8540-93e549529ef2",
+			"cellName": "Return Replaced\nText",
+			"cellId": "50dbd73e-3872-4462-8540-93e549529ef2",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-d4a50acf-c118-4c92-b8a8-e02e8b362453-50dbd73e-3872-4462-8540-93e549529ef2": {
+			"path": "generated-edge-simstep-d4a50acf-c118-4c92-b8a8-e02e8b362453-50dbd73e-3872-4462-8540-93e549529ef2",
+			"fileName": "interpolate.rs",
+			"cellName": "Return Replaced Text",
+			"cellId": "50dbd73e-3872-4462-8540-93e549529ef2",
+			"visible": true,
+			"startLine": 114,
+			"endLine": 117,
+			"parentPath": "crates/matcher/src/interpolate.rs"
+		},
+		"349e4381-82c9-490b-bfdd-bdc9bb872c75": {
+			"path": "349e4381-82c9-490b-bfdd-bdc9bb872c75",
+			"fileName": "349e4381-82c9-490b-bfdd-bdc9bb872c75",
+			"cellName": "Data for\nFinal Print",
+			"cellId": "349e4381-82c9-490b-bfdd-bdc9bb872c75",
+			"visible": true,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550"
+		},
+		"generated-edge-simstep-0b9d9c56-54ba-4399-8a63-331359e80d04-349e4381-82c9-490b-bfdd-bdc9bb872c75": {
+			"path": "generated-edge-simstep-0b9d9c56-54ba-4399-8a63-331359e80d04-349e4381-82c9-490b-bfdd-bdc9bb872c75",
+			"fileName": "standard.rs",
+			"cellName": "Data for Final Print",
+			"cellId": "349e4381-82c9-490b-bfdd-bdc9bb872c75",
+			"visible": true,
+			"startLine": 912,
+			"endLine": 912,
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"cd38b9ee-aec0-4a28-87fb-462f8ec364c2": {
+			"path": "cd38b9ee-aec0-4a28-87fb-462f8ec364c2",
+			"fileName": "cd38b9ee-aec0-4a28-87fb-462f8ec364c2",
+			"cellName": "process.rs",
+			"cellId": "cd38b9ee-aec0-4a28-87fb-462f8ec364c2",
+			"visible": true,
+			"parentCellId": "bbd871fb-2a85-4f90-b28d-abc336580454"
+		},
+		"371cba6e-4f3e-43f1-a988-edb4f54e2c44": {
+			"path": "371cba6e-4f3e-43f1-a988-edb4f54e2c44",
+			"fileName": "371cba6e-4f3e-43f1-a988-edb4f54e2c44",
+			"cellName": "Parse Preprocessor CLI Arguments - defs.rs:L5528-5542",
+			"cellId": "371cba6e-4f3e-43f1-a988-edb4f54e2c44",
+			"visible": true,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb"
+		},
+		"crates/core/flags/defs.rs-simstep-ac7d4e6d-0c1f-4f09-835e-15a57c688ef7": {
+			"path": "crates/core/flags/defs.rs-simstep-ac7d4e6d-0c1f-4f09-835e-15a57c688ef7",
+			"fileName": "defs.rs",
+			"wiki": "Ripgrep starts by parsing the command-line arguments. The `--pre` flag specifies the preprocessor command, and `--pre-glob` provides the glob patterns to select files for preprocessing. These arguments are stored in a low-level arguments struct.",
+			"cellName": "Parse Preprocessor CLI Arguments - defs.rs:L5528-5542",
+			"cellId": "371cba6e-4f3e-43f1-a988-edb4f54e2c44",
+			"visible": true,
+			"startLine": 5528,
+			"endLine": 5542,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"dad1acc0-24c5-45ef-8a24-7b84a04f3620": {
+			"path": "dad1acc0-24c5-45ef-8a24-7b84a04f3620",
+			"fileName": "dad1acc0-24c5-45ef-8a24-7b84a04f3620",
+			"cellName": "Compile Preprocessor Globs - hiargs.rs:L1226-1238",
+			"cellId": "dad1acc0-24c5-45ef-8a24-7b84a04f3620",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"crates/core/flags/hiargs.rs-simstep-358073c2-ed72-4198-91b7-b96779ef1070": {
+			"path": "crates/core/flags/hiargs.rs-simstep-358073c2-ed72-4198-91b7-b96779ef1070",
+			"fileName": "hiargs.rs",
+			"wiki": "The `--pre-glob` string patterns are compiled into an `ignore::overrides::Override` object. This structure allows for efficient matching of file paths against the specified globs during the directory traversal.",
+			"cellName": "Compile Preprocessor Globs - hiargs.rs:L1226-1238",
+			"cellId": "dad1acc0-24c5-45ef-8a24-7b84a04f3620",
+			"visible": true,
+			"startLine": 1226,
+			"endLine": 1238,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"41c68e49-b2b4-463f-b7e9-444a1f388ede": {
+			"path": "41c68e49-b2b4-463f-b7e9-444a1f388ede",
+			"fileName": "41c68e49-b2b4-463f-b7e9-444a1f388ede",
+			"cellName": "Configure Search Worker - search.rs:L96-118",
+			"cellId": "41c68e49-b2b4-463f-b7e9-444a1f388ede",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"crates/core/search.rs-simstep-b5e56eed-3eaf-41fc-8ace-df49b7975aa0": {
+			"path": "crates/core/search.rs-simstep-b5e56eed-3eaf-41fc-8ace-df49b7975aa0",
+			"fileName": "search.rs",
+			"wiki": "The `SearchWorkerBuilder` configures a `SearchWorker` instance. It resolves the absolute path to the preprocessor binary and stores it along with the compiled globs in the worker's configuration.",
+			"cellName": "Configure Search Worker - search.rs:L96-118",
+			"cellId": "41c68e49-b2b4-463f-b7e9-444a1f388ede",
+			"visible": true,
+			"startLine": 96,
+			"endLine": 118,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"parentPath": "crates/core/search.rs"
+		},
+		"661242fb-a028-49ef-8a40-665bdc8f8b9a": {
+			"path": "661242fb-a028-49ef-8a40-665bdc8f8b9a",
+			"fileName": "661242fb-a028-49ef-8a40-665bdc8f8b9a",
+			"cellName": "Check if File Matches Preprocessor Globs - search.rs:L285-295",
+			"cellId": "661242fb-a028-49ef-8a40-665bdc8f8b9a",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"crates/core/search.rs-simstep-804852c5-f087-4553-a287-f0b4309ea273": {
+			"path": "crates/core/search.rs-simstep-804852c5-f087-4553-a287-f0b4309ea273",
+			"fileName": "search.rs",
+			"wiki": "For each file found (e.g., `docs/research.pdf`), the `should_preprocess` method checks if it matches the compiled `--pre-glob` patterns. If it matches, the method returns `true`, signaling that the preprocessor should be used.",
+			"cellName": "Check if File Matches Preprocessor Globs - search.rs:L285-295",
+			"cellId": "661242fb-a028-49ef-8a40-665bdc8f8b9a",
+			"visible": true,
+			"startLine": 285,
+			"endLine": 295,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"parentPath": "crates/core/search.rs"
+		},
+		"84432abe-73a2-46dd-aa06-178ca2b62ff8": {
+			"path": "84432abe-73a2-46dd-aa06-178ca2b62ff8",
+			"fileName": "84432abe-73a2-46dd-aa06-178ca2b62ff8",
+			"cellName": "Execute Preprocessor Command - search.rs:L299-321",
+			"cellId": "84432abe-73a2-46dd-aa06-178ca2b62ff8",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"crates/core/search.rs-simstep-d3f25c6a-769a-46e8-8b8d-bbdc9e2a2f86": {
+			"path": "crates/core/search.rs-simstep-d3f25c6a-769a-46e8-8b8d-bbdc9e2a2f86",
+			"fileName": "search.rs",
+			"wiki": "The `search_preprocessor` method spawns the specified command (e.g., `pdftotext`). It passes the file path as an argument and pipes the file's contents to the command's standard input. Ripgrep then captures the command's standard output as a readable stream.",
+			"cellName": "Execute Preprocessor Command - search.rs:L299-321",
+			"cellId": "84432abe-73a2-46dd-aa06-178ca2b62ff8",
+			"visible": true,
+			"startLine": 299,
+			"endLine": 321,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"parentPath": "crates/core/search.rs"
+		},
+		"fa7bdd21-d61e-497f-9427-eda4d39438cd": {
+			"path": "fa7bdd21-d61e-497f-9427-eda4d39438cd",
+			"fileName": "fa7bdd21-d61e-497f-9427-eda4d39438cd",
+			"cellName": "Search Preprocessed Stream - search.rs:L349-357",
+			"cellId": "fa7bdd21-d61e-497f-9427-eda4d39438cd",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"crates/core/search.rs-simstep-26355175-5341-488d-a476-30e2f796176c": {
+			"path": "crates/core/search.rs-simstep-26355175-5341-488d-a476-30e2f796176c",
+			"fileName": "search.rs",
+			"wiki": "The `search_reader` method consumes the text stream from the preprocessor's output and applies the user's regex pattern to find matches.",
+			"cellName": "Search Preprocessed Stream - search.rs:L349-357",
+			"cellId": "fa7bdd21-d61e-497f-9427-eda4d39438cd",
+			"visible": true,
+			"startLine": 349,
+			"endLine": 357,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"parentPath": "crates/core/search.rs"
+		},
+		"fd865b14-7ee5-4b22-afc0-f1642849edd8": {
+			"path": "fd865b14-7ee5-4b22-afc0-f1642849edd8",
+			"fileName": "fd865b14-7ee5-4b22-afc0-f1642849edd8",
+			"cellName": "Format and Print Match - standard.rs:L1178-1188",
+			"cellId": "fd865b14-7ee5-4b22-afc0-f1642849edd8",
+			"visible": true,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550"
+		},
+		"crates/printer/src/standard.rs-simstep-4ff85d42-34c0-41f3-a939-2eca1f58810d": {
+			"path": "crates/printer/src/standard.rs-simstep-4ff85d42-34c0-41f3-a939-2eca1f58810d",
+			"fileName": "standard.rs",
+			"wiki": "The printer receives the match data and formats it for display. This includes adding the file path, line number, and color highlighting before writing the final output to standard output.",
+			"cellName": "Format and Print Match - standard.rs:L1178-1188",
+			"cellId": "fd865b14-7ee5-4b22-afc0-f1642849edd8",
+			"visible": true,
+			"startLine": 1178,
+			"endLine": 1188,
+			"parentCellId": "a9db5f77-0d04-41dd-9ce4-9aa04b7b6550",
+			"parentPath": "crates/printer/src/standard.rs"
+		},
+		"e2b512be-0da5-4e08-a8f0-4d5271c56bec": {
+			"path": "e2b512be-0da5-4e08-a8f0-4d5271c56bec",
+			"fileName": "e2b512be-0da5-4e08-a8f0-4d5271c56bec",
+			"cellName": "Pass Raw\nArguments for\nCompilation",
+			"cellId": "e2b512be-0da5-4e08-a8f0-4d5271c56bec",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-cb082c95-721e-4c17-be86-42145855c6d4-e2b512be-0da5-4e08-a8f0-4d5271c56bec": {
+			"path": "generated-edge-simstep-cb082c95-721e-4c17-be86-42145855c6d4-e2b512be-0da5-4e08-a8f0-4d5271c56bec",
+			"fileName": "defs.rs",
+			"cellName": "Pass Raw Arguments for Compilation",
+			"cellId": "e2b512be-0da5-4e08-a8f0-4d5271c56bec",
+			"visible": true,
+			"startLine": 111,
+			"endLine": 111,
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"aacee49a-819e-4c4f-b165-f5c39c9c867f": {
+			"path": "aacee49a-819e-4c4f-b165-f5c39c9c867f",
+			"fileName": "aacee49a-819e-4c4f-b165-f5c39c9c867f",
+			"cellName": "Pass Compiled\nArguments to\nWorker Builder",
+			"cellId": "aacee49a-819e-4c4f-b165-f5c39c9c867f",
+			"visible": true,
+			"parentCellId": "debf18dd-047e-44e4-9016-2ee07faaf18b"
+		},
+		"generated-edge-simstep-f0d155fc-0913-45bd-b53b-656dd6c98833-aacee49a-819e-4c4f-b165-f5c39c9c867f": {
+			"path": "generated-edge-simstep-f0d155fc-0913-45bd-b53b-656dd6c98833-aacee49a-819e-4c4f-b165-f5c39c9c867f",
+			"fileName": "hiargs.rs",
+			"cellName": "Pass Compiled Arguments to Worker Builder",
+			"cellId": "aacee49a-819e-4c4f-b165-f5c39c9c867f",
+			"visible": true,
+			"startLine": 696,
+			"endLine": 696,
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"10918ee4-422b-453e-bb5d-05d55fe40fd2": {
+			"path": "10918ee4-422b-453e-bb5d-05d55fe40fd2",
+			"fileName": "10918ee4-422b-453e-bb5d-05d55fe40fd2",
+			"cellName": "Initiate File\nSearch",
+			"cellId": "10918ee4-422b-453e-bb5d-05d55fe40fd2",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"generated-edge-simstep-e7df3fcb-604f-4fa7-afa6-385deec4fd46-10918ee4-422b-453e-bb5d-05d55fe40fd2": {
+			"path": "generated-edge-simstep-e7df3fcb-604f-4fa7-afa6-385deec4fd46-10918ee4-422b-453e-bb5d-05d55fe40fd2",
+			"fileName": "search.rs",
+			"cellName": "Initiate File Search",
+			"cellId": "10918ee4-422b-453e-bb5d-05d55fe40fd2",
+			"visible": true,
+			"startLine": 233,
+			"endLine": 233,
+			"parentPath": "crates/core/search.rs"
+		},
+		"e6ad1c9e-fb02-48a3-91ce-1920e842ae43": {
+			"path": "e6ad1c9e-fb02-48a3-91ce-1920e842ae43",
+			"fileName": "e6ad1c9e-fb02-48a3-91ce-1920e842ae43",
+			"cellName": "Signal for\nPreprocessing",
+			"cellId": "e6ad1c9e-fb02-48a3-91ce-1920e842ae43",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"generated-edge-simstep-cbb156bb-8a73-4ff5-9275-3f2820b75bbc-e6ad1c9e-fb02-48a3-91ce-1920e842ae43": {
+			"path": "generated-edge-simstep-cbb156bb-8a73-4ff5-9275-3f2820b75bbc-e6ad1c9e-fb02-48a3-91ce-1920e842ae43",
+			"fileName": "search.rs",
+			"cellName": "Signal for Preprocessing",
+			"cellId": "e6ad1c9e-fb02-48a3-91ce-1920e842ae43",
+			"visible": true,
+			"startLine": 259,
+			"endLine": 262,
+			"parentPath": "crates/core/search.rs"
+		},
+		"ed97f725-0d09-4009-8626-5bafe4b0f4bd": {
+			"path": "ed97f725-0d09-4009-8626-5bafe4b0f4bd",
+			"fileName": "ed97f725-0d09-4009-8626-5bafe4b0f4bd",
+			"cellName": "Stream Preprocessed\nData",
+			"cellId": "ed97f725-0d09-4009-8626-5bafe4b0f4bd",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"generated-edge-simstep-318d899e-9197-4e1f-a2c6-301ac52bc43a-ed97f725-0d09-4009-8626-5bafe4b0f4bd": {
+			"path": "generated-edge-simstep-318d899e-9197-4e1f-a2c6-301ac52bc43a-ed97f725-0d09-4009-8626-5bafe4b0f4bd",
+			"fileName": "search.rs",
+			"cellName": "Stream Preprocessed Data",
+			"cellId": "ed97f725-0d09-4009-8626-5bafe4b0f4bd",
+			"visible": true,
+			"startLine": 259,
+			"endLine": 266,
+			"parentPath": "crates/core/search.rs"
+		},
+		"bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d": {
+			"path": "bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d",
+			"fileName": "bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d",
+			"cellName": "Pass Match\nData to\nPrinter",
+			"cellId": "bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d",
+			"visible": true,
+			"parentCellId": "8a94384e-eb61-4ed4-a50e-c29adaa6a4fa"
+		},
+		"generated-edge-simstep-00bfe31b-8a1e-445d-a4a8-f09f69bb4965-bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d": {
+			"path": "generated-edge-simstep-00bfe31b-8a1e-445d-a4a8-f09f69bb4965-bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d",
+			"fileName": "search.rs",
+			"cellName": "Pass Match Data to Printer",
+			"cellId": "bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d",
+			"visible": true,
+			"startLine": 456,
+			"endLine": 463,
+			"parentPath": "crates/core/search.rs"
+		},
+		"23cc6e15-ec4f-467a-9e19-4cca7bad4056": {
+			"path": "23cc6e15-ec4f-467a-9e19-4cca7bad4056",
+			"fileName": "23cc6e15-ec4f-467a-9e19-4cca7bad4056",
+			"cellName": "parse.rs",
+			"cellId": "23cc6e15-ec4f-467a-9e19-4cca7bad4056",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"7715a01b-ffc3-4e46-8446-5f55b158012e": {
+			"path": "7715a01b-ffc3-4e46-8446-5f55b158012e",
+			"fileName": "7715a01b-ffc3-4e46-8446-5f55b158012e",
+			"cellName": "config.rs",
+			"cellId": "7715a01b-ffc3-4e46-8446-5f55b158012e",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"f762e7b2-4ed1-4ae0-8746-b958e16b2499": {
+			"path": "f762e7b2-4ed1-4ae0-8746-b958e16b2499",
+			"fileName": "f762e7b2-4ed1-4ae0-8746-b958e16b2499",
+			"cellName": "Start Execution and Parse Arguments - parse.rs:L71-75",
+			"cellId": "f762e7b2-4ed1-4ae0-8746-b958e16b2499",
+			"visible": true,
+			"parentCellId": "23cc6e15-ec4f-467a-9e19-4cca7bad4056"
+		},
+		"crates/core/flags/parse.rs-simstep-480456a6-14e2-435f-a647-f548b7db9da2": {
+			"path": "crates/core/flags/parse.rs-simstep-480456a6-14e2-435f-a647-f548b7db9da2",
+			"fileName": "parse.rs",
+			"wiki": "Execution starts in the `main` function which calls `flags::parse()` to handle command-line arguments. This function performs an initial parse of the arguments provided directly to the process and checks for special flags like `--no-config` or `--help`.",
+			"cellName": "Start Execution and Parse Arguments - parse.rs:L71-75",
+			"cellId": "f762e7b2-4ed1-4ae0-8746-b958e16b2499",
+			"visible": true,
+			"startLine": 71,
+			"endLine": 75,
+			"parentCellId": "23cc6e15-ec4f-467a-9e19-4cca7bad4056",
+			"parentPath": "crates/core/flags/parse.rs"
+		},
+		"dbfee10c-86e3-476f-86f0-7e2ca77cc529": {
+			"path": "dbfee10c-86e3-476f-86f0-7e2ca77cc529",
+			"fileName": "dbfee10c-86e3-476f-86f0-7e2ca77cc529",
+			"cellName": "Parse Configuration File - config.rs:L65-72",
+			"cellId": "dbfee10c-86e3-476f-86f0-7e2ca77cc529",
+			"visible": true,
+			"parentCellId": "7715a01b-ffc3-4e46-8446-5f55b158012e"
+		},
+		"crates/core/flags/config.rs-simstep-feb6f7e3-8788-40e3-9408-fc32898d04e0": {
+			"path": "crates/core/flags/config.rs-simstep-feb6f7e3-8788-40e3-9408-fc32898d04e0",
+			"fileName": "config.rs",
+			"wiki": "If a configuration file path is found, the file is opened and parsed. Each line that is not a comment or empty is treated as a single command-line argument. These arguments are collected into a list.",
+			"cellName": "Parse Configuration File - config.rs:L65-72",
+			"cellId": "dbfee10c-86e3-476f-86f0-7e2ca77cc529",
+			"visible": true,
+			"startLine": 65,
+			"endLine": 72,
+			"parentCellId": "7715a01b-ffc3-4e46-8446-5f55b158012e",
+			"parentPath": "crates/core/flags/config.rs"
+		},
+		"0ea2e988-76a8-4989-9841-0c4c130de7a9": {
+			"path": "0ea2e988-76a8-4989-9841-0c4c130de7a9",
+			"fileName": "0ea2e988-76a8-4989-9841-0c4c130de7a9",
+			"cellName": "Merge and Re-parse All Arguments - parse.rs:L96-104",
+			"cellId": "0ea2e988-76a8-4989-9841-0c4c130de7a9",
+			"visible": true,
+			"parentCellId": "23cc6e15-ec4f-467a-9e19-4cca7bad4056"
+		},
+		"crates/core/flags/parse.rs-simstep-6f8fc4cd-ab98-4f17-8883-d5938b953bf4": {
+			"path": "crates/core/flags/parse.rs-simstep-6f8fc4cd-ab98-4f17-8883-d5938b953bf4",
+			"fileName": "parse.rs",
+			"wiki": "The arguments from the config file are prepended to the arguments from the command line. The parser runs a second time on this combined set of arguments. During this pass, the `update` method for the `--type-add` flag is called, which adds the custom file type definition to the `type_changes` field in the `LowArgs` struct.",
+			"cellName": "Merge and Re-parse All Arguments - parse.rs:L96-104",
+			"cellId": "0ea2e988-76a8-4989-9841-0c4c130de7a9",
+			"visible": true,
+			"startLine": 96,
+			"endLine": 104,
+			"parentCellId": "23cc6e15-ec4f-467a-9e19-4cca7bad4056",
+			"parentPath": "crates/core/flags/parse.rs"
+		},
+		"0cfd7f6c-1a85-422b-9ea8-8c1dcf0467c1": {
+			"path": "0cfd7f6c-1a85-422b-9ea8-8c1dcf0467c1",
+			"fileName": "0cfd7f6c-1a85-422b-9ea8-8c1dcf0467c1",
+			"cellName": "Build High-Level Arguments - defs.rs:L6973-6978",
+			"cellId": "0cfd7f6c-1a85-422b-9ea8-8c1dcf0467c1",
+			"visible": true,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb"
+		},
+		"crates/core/flags/defs.rs-simstep-1e1e2b32-f650-47f5-b13d-e8b6a6f9c47e": {
+			"path": "crates/core/flags/defs.rs-simstep-1e1e2b32-f650-47f5-b13d-e8b6a6f9c47e",
+			"fileName": "defs.rs",
+			"wiki": "The `LowArgs` struct is converted into a `HiArgs` struct. This process involves interpreting the `type_changes` field. A `TypesBuilder` from the `ignore` crate is initialized with default file types, and then the custom 'web' type definition (`web:*.{html,css,js}`) is added to it. The final `Types` object is stored in `HiArgs`.",
+			"cellName": "Build High-Level Arguments - defs.rs:L6973-6978",
+			"cellId": "0cfd7f6c-1a85-422b-9ea8-8c1dcf0467c1",
+			"visible": true,
+			"startLine": 6973,
+			"endLine": 6978,
+			"parentCellId": "01b02a5d-8a91-4b33-a33f-91a5c96f3cdb",
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"02cc98f2-4801-485b-b0ee-9780bcee6344": {
+			"path": "02cc98f2-4801-485b-b0ee-9780bcee6344",
+			"fileName": "02cc98f2-4801-485b-b0ee-9780bcee6344",
+			"cellName": "Configure Directory Walker - hiargs.rs:L863-871",
+			"cellId": "02cc98f2-4801-485b-b0ee-9780bcee6344",
+			"visible": true,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c"
+		},
+		"crates/core/flags/hiargs.rs-simstep-487a5b7a-65d2-4fdf-9a73-2911d82b7f61": {
+			"path": "crates/core/flags/hiargs.rs-simstep-487a5b7a-65d2-4fdf-9a73-2911d82b7f61",
+			"fileName": "hiargs.rs",
+			"wiki": "A `WalkBuilder` from the `ignore` crate is created and configured using the `HiArgs`. The custom `Types` object is passed to the walker. If the user specified `-t web` on the command line, the walker will now use the definition of 'web' (from the config file) to include only files matching `*.html`, `*.css`, or `*.js` in its traversal.",
+			"cellName": "Configure Directory Walker - hiargs.rs:L863-871",
+			"cellId": "02cc98f2-4801-485b-b0ee-9780bcee6344",
+			"visible": true,
+			"startLine": 863,
+			"endLine": 871,
+			"parentCellId": "898b7926-b1c0-43cf-80c2-b06695d8fe1c",
+			"parentPath": "crates/core/flags/hiargs.rs"
+		},
+		"f922a6d3-7cbf-48ac-b204-399522834fe1": {
+			"path": "f922a6d3-7cbf-48ac-b204-399522834fe1",
+			"fileName": "f922a6d3-7cbf-48ac-b204-399522834fe1",
+			"cellName": "Execute Search on Filtered Files - search.rs:L245-255",
+			"cellId": "f922a6d3-7cbf-48ac-b204-399522834fe1",
+			"visible": true,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45"
+		},
+		"crates/core/search.rs-simstep-cd58a6a2-35b8-4bee-9a79-e6419ea3942d": {
+			"path": "crates/core/search.rs-simstep-cd58a6a2-35b8-4bee-9a79-e6419ea3942d",
+			"fileName": "search.rs",
+			"wiki": "For each file path yielded by the walker, the `SearchWorker` executes the search. Since the walker has already filtered the files based on the custom type defined in the configuration file, ripgrep only searches the files that the user intended.",
+			"cellName": "Execute Search on Filtered Files - search.rs:L245-255",
+			"cellId": "f922a6d3-7cbf-48ac-b204-399522834fe1",
+			"visible": true,
+			"startLine": 245,
+			"endLine": 255,
+			"parentCellId": "fbd72afc-9b46-46a0-a2f0-c3757937fd45",
+			"parentPath": "crates/core/search.rs"
+		},
+		"fadf13c2-4eee-46a9-945d-a0a12855832b": {
+			"path": "fadf13c2-4eee-46a9-945d-a0a12855832b",
+			"fileName": "fadf13c2-4eee-46a9-945d-a0a12855832b",
+			"cellName": "Check for\nConfiguration File",
+			"cellId": "fadf13c2-4eee-46a9-945d-a0a12855832b",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-14c535f9-7ea4-4433-9c51-6ea91fec4304-fadf13c2-4eee-46a9-945d-a0a12855832b": {
+			"path": "generated-edge-simstep-14c535f9-7ea4-4433-9c51-6ea91fec4304-fadf13c2-4eee-46a9-945d-a0a12855832b",
+			"fileName": "parse.rs",
+			"cellName": "Check for Configuration File",
+			"cellId": "fadf13c2-4eee-46a9-945d-a0a12855832b",
+			"visible": true,
+			"startLine": 13,
+			"endLine": 22,
+			"parentPath": "crates/core/flags/parse.rs"
+		},
+		"fc568437-30b2-4ab2-a1f0-876eec72e1db": {
+			"path": "fc568437-30b2-4ab2-a1f0-876eec72e1db",
+			"fileName": "fc568437-30b2-4ab2-a1f0-876eec72e1db",
+			"cellName": "Transmit Parsed\nConfig Arguments",
+			"cellId": "fc568437-30b2-4ab2-a1f0-876eec72e1db",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-3ebae179-adbb-4ac1-b010-1ce0e0476a58-fc568437-30b2-4ab2-a1f0-876eec72e1db": {
+			"path": "generated-edge-simstep-3ebae179-adbb-4ac1-b010-1ce0e0476a58-fc568437-30b2-4ab2-a1f0-876eec72e1db",
+			"fileName": "config.rs",
+			"cellName": "Transmit Parsed Config Arguments",
+			"cellId": "fc568437-30b2-4ab2-a1f0-876eec72e1db",
+			"visible": true,
+			"startLine": 92,
+			"endLine": 92,
+			"parentPath": "crates/core/flags/config.rs"
+		},
+		"e7a3ab74-74b5-4476-9b14-836f04678cc7": {
+			"path": "e7a3ab74-74b5-4476-9b14-836f04678cc7",
+			"fileName": "e7a3ab74-74b5-4476-9b14-836f04678cc7",
+			"cellName": "Transmit Low-Level\nArguments",
+			"cellId": "e7a3ab74-74b5-4476-9b14-836f04678cc7",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-4f1ea281-b9b0-4651-9e19-3f834dd2c885-e7a3ab74-74b5-4476-9b14-836f04678cc7": {
+			"path": "generated-edge-simstep-4f1ea281-b9b0-4651-9e19-3f834dd2c885-e7a3ab74-74b5-4476-9b14-836f04678cc7",
+			"fileName": "parse.rs",
+			"cellName": "Transmit Low-Level Arguments",
+			"cellId": "e7a3ab74-74b5-4476-9b14-836f04678cc7",
+			"visible": true,
+			"startLine": 1133,
+			"endLine": 1141,
+			"parentPath": "crates/core/flags/parse.rs"
+		},
+		"d07f3a20-1f28-42d6-8f89-d63f5372b039": {
+			"path": "d07f3a20-1f28-42d6-8f89-d63f5372b039",
+			"fileName": "d07f3a20-1f28-42d6-8f89-d63f5372b039",
+			"cellName": "Transmit High-Level\nConfiguration",
+			"cellId": "d07f3a20-1f28-42d6-8f89-d63f5372b039",
+			"visible": true,
+			"parentCellId": "5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e"
+		},
+		"generated-edge-simstep-86b94dae-4068-4544-8ed8-46daf73755e8-d07f3a20-1f28-42d6-8f89-d63f5372b039": {
+			"path": "generated-edge-simstep-86b94dae-4068-4544-8ed8-46daf73755e8-d07f3a20-1f28-42d6-8f89-d63f5372b039",
+			"fileName": "defs.rs",
+			"cellName": "Transmit High-Level Configuration",
+			"cellId": "d07f3a20-1f28-42d6-8f89-d63f5372b039",
+			"visible": true,
+			"startLine": 863,
+			"endLine": 871,
+			"parentPath": "crates/core/flags/defs.rs"
+		},
+		"b72ce07f-2387-40a1-90ba-4deafeeb4793": {
+			"path": "b72ce07f-2387-40a1-90ba-4deafeeb4793",
+			"fileName": "b72ce07f-2387-40a1-90ba-4deafeeb4793",
+			"cellName": "Yield Matching\nFiles",
+			"cellId": "b72ce07f-2387-40a1-90ba-4deafeeb4793",
+			"visible": true,
+			"parentCellId": "debf18dd-047e-44e4-9016-2ee07faaf18b"
+		},
+		"generated-edge-simstep-bcf37e0f-c3e9-44fd-bb74-a4501dd7b5d2-b72ce07f-2387-40a1-90ba-4deafeeb4793": {
+			"path": "generated-edge-simstep-bcf37e0f-c3e9-44fd-bb74-a4501dd7b5d2-b72ce07f-2387-40a1-90ba-4deafeeb4793",
+			"fileName": "hiargs.rs",
+			"cellName": "Yield Matching Files",
+			"cellId": "b72ce07f-2387-40a1-90ba-4deafeeb4793",
+			"visible": true,
+			"startLine": 449,
+			"endLine": 464,
+			"parentPath": "crates/core/flags/hiargs.rs"
+		}
+	},
+	"simulations": {
+		"Perform high-speed, parallel, recursive searches for regular expression patterns in a directory tree.": {
+			"name": "Perform high-speed, parallel, recursive searches for regular expression patterns in a directory tree.",
+			"simSteps": [
+				{
+					"simStepId": "89b90516-5fbf-4f93-bc07-ad7b9c73c8ac",
+					"diagramNodeId": "f571f13d-a5b1-4696-810d-016af864988b",
+					"simStepLabel": "Start Parallel Search",
+					"simStepDescription": "The main 'run' function determines that a parallel search is required based on the command-line arguments (e.g., thread count > 1). It then invokes the 'search_parallel' function to handle the multithreaded search execution.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/main.rs",
+						"startLine": "86",
+						"endLine": "90",
+						"relevantVariables": [
+							"args",
+							"search_parallel"
+						]
+					},
+					"inputDataExample": "{\"args\": [\"rg\", \"Searcher\", \".\", \"--threads\", \"8\"]}",
+					"outputDataExample": "{\"HiArgs\": {\"pattern\": \"Searcher\", \"paths\": [\"./\"], \"threads\": 8, \"mode\": \"Search\"}}"
+				},
+				{
+					"simStepId": "ac3640cf-d344-4813-869f-a260233103d5",
+					"diagramNodeId": "7789b62c-d2f3-4540-aa1a-a737a35b60c8",
+					"simStepLabel": "Pass Arguments to Parallel Search",
+					"simStepDescription": "The high-level argument configuration object 'HiArgs' and the 'SearchMode' are passed to the 'search_parallel' function to orchestrate the directory walk and searching.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/main.rs",
+						"startLine": "88",
+						"endLine": "88",
+						"relevantVariables": [
+							"args",
+							"mode"
+						]
+					},
+					"inputDataExample": "{\"HiArgs\": {\"pattern\": \"Searcher\", \"paths\": [\"./\"], \"threads\": 8, \"mode\": \"Search\"}}",
+					"outputDataExample": "{\"HiArgs\": {\"pattern\": \"Searcher\", \"paths\": [\"./\"], \"threads\": 8, \"mode\": \"Search\"}}"
+				},
+				{
+					"simStepId": "74f2428a-8ad9-4ee1-9186-810db6e72b63",
+					"diagramNodeId": "bdea59c2-5355-45cb-babe-67dfd0c2717e",
+					"simStepLabel": "Configure Parallel Directory Walker",
+					"simStepDescription": "The 'search_parallel' function constructs a 'WalkParallel' instance from the 'ignore' crate. This walker is configured to respect ignore files (.gitignore, .ignore) and other filtering rules. It also prepares a 'SearchWorker' which encapsulates the compiled regex matcher, searcher, and printer. The 'run' method is then called on the walker with a closure that defines the work to be done by each thread.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/main.rs",
+						"startLine": "185",
+						"endLine": "187",
+						"relevantVariables": [
+							"args",
+							"searcher",
+							"walk_builder",
+							"build_parallel",
+							"run"
+						]
+					},
+					"inputDataExample": "{\"HiArgs\": {\"pattern\": \"Searcher\", \"paths\": [\"./\"], \"threads\": 8}}",
+					"outputDataExample": "{\"WalkParallel\": {\"threads\": 8, \"ignore_rules\": true}}"
+				},
+				{
+					"simStepId": "5161ea00-fede-4558-b465-a301e1f26076",
+					"diagramNodeId": "590b160d-861c-4b10-a432-28127a3d547b",
+					"simStepLabel": "Dispatch Directory Entries to Worker Threads",
+					"simStepDescription": "The 'WalkParallel' instance begins traversing the directory tree. For each file that is not filtered by ignore rules, it sends a 'DirEntry' object to a work queue, where it is picked up by an available worker thread.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/ignore/src/walk.rs",
+						"startLine": "1507",
+						"endLine": "1511",
+						"relevantVariables": [
+							"work",
+							"self.get_work",
+							"self.run_one"
+						]
+					},
+					"inputDataExample": "{\"path\": \"./crates/searcher/src/lib.rs\", \"is_dir\": false, \"metadata\": {\"len\": 919}}",
+					"outputDataExample": "{\"path\": \"./crates/searcher/src/lib.rs\", \"is_dir\": false, \"metadata\": {\"len\": 919}}"
+				},
+				{
+					"simStepId": "4b7da167-9174-4295-83bc-b069e9331106",
+					"diagramNodeId": "2196ff9f-2695-4b8a-8a75-d5702b89371f",
+					"simStepLabel": "Worker Thread Processes a File Entry",
+					"simStepDescription": "A worker thread receives a 'DirEntry' result from the work queue. It builds a 'Haystack' object (a representation of the thing to be searched) and invokes 'searcher.search()' to perform the search on that specific file, using its own cloned instance of the 'SearchWorker'.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/main.rs",
+						"startLine": "193",
+						"endLine": "200",
+						"relevantVariables": [
+							"haystack_builder",
+							"searcher",
+							"search_result"
+						]
+					},
+					"inputDataExample": "{\"result\": {\"Ok\": {\"path\": \"./crates/searcher/src/lib.rs\"}}}",
+					"outputDataExample": "{\"search_result\": {\"has_match\": true, \"stats\": {\"matches\": 5, \"lines\": 2, \"searches\": 1}}}"
+				},
+				{
+					"simStepId": "15ce35a6-7ce6-4bea-aeb6-05d2a5f5cda1",
+					"diagramNodeId": "5c3f5839-6758-4eaf-98b1-71868c95b20d",
+					"simStepLabel": "Pass File Path and Sink to Searcher",
+					"simStepDescription": "The 'SearchWorker' calls 'searcher.search_path', passing the compiled 'Matcher' for the regex pattern, the path of the file to be searched, and a 'Sink' implementation (e.g., 'StandardSink') that will handle any matches found.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "377",
+						"endLine": "385",
+						"relevantVariables": [
+							"matcher",
+							"searcher",
+							"printer",
+							"path",
+							"search_path",
+							"sink_with_path"
+						]
+					},
+					"inputDataExample": "{\"path\": \"./crates/searcher/src/lib.rs\", \"matcher\": \"RegexMatcher\", \"sink\": \"StandardSink\"}",
+					"outputDataExample": "{\"path\": \"./crates/searcher/src/lib.rs\", \"matcher\": \"RegexMatcher\", \"sink\": \"StandardSink\"}"
+				},
+				{
+					"simStepId": "886efe56-50a7-4387-99c3-a460e0a03834",
+					"diagramNodeId": "32bcfcb7-b4b6-4993-893c-1676d6ecaf77",
+					"simStepLabel": "Choose Search Strategy (Mmap vs. Incremental)",
+					"simStepDescription": "The 'Searcher' checks its configuration and the file metadata to decide on the optimal search strategy. For high performance on single files, it often chooses to memory-map the file, which allows searching it directly in memory as a byte slice.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/mod.rs",
+						"startLine": "699",
+						"endLine": "702",
+						"relevantVariables": [
+							"self.config.mmap",
+							"mmap",
+							"self.search_slice"
+						]
+					},
+					"inputDataExample": "{\"path\": \"./crates/searcher/src/lib.rs\", \"file_metadata\": {\"len\": 919}}",
+					"outputDataExample": "{\"strategy\": \"mmap\", \"mmap_slice_ptr\": \"0x...\"}"
+				},
+				{
+					"simStepId": "c67074c1-8a09-479c-b153-ead7b0fa19d9",
+					"diagramNodeId": "0c2fcc7e-11d6-43a5-ae89-13180aed99eb",
+					"simStepLabel": "Pass File Content Slice to Search Routine",
+					"simStepDescription": "The memory-mapped byte slice of the entire file is passed to the slice-based search routine, 'search_slice', for processing.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/mod.rs",
+						"startLine": "702",
+						"endLine": "702",
+						"relevantVariables": [
+							"mmap",
+							"search_slice"
+						]
+					},
+					"inputDataExample": "{\"slice\": \"...bytes of crates/searcher/src/lib.rs...\"}",
+					"outputDataExample": "{\"slice\": \"...bytes of crates/searcher/src/lib.rs...\"}"
+				},
+				{
+					"simStepId": "bb853ccd-0b47-4741-ae7c-abfd7d75fa92",
+					"diagramNodeId": "b4d3b26e-19e7-477d-979f-702fb33ff014",
+					"simStepLabel": "Execute Fast Line-by-Line Search",
+					"simStepDescription": "The search routine for slices ('SliceByLine') iterates through the byte slice. It uses a highly optimized 'fast path' that leverages literal extraction from the regex pattern to quickly find candidate lines, skipping non-matching lines without invoking the full regex engine. Once a candidate is found, the regex match is confirmed.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/core.rs",
+						"startLine": "479",
+						"endLine": "497",
+						"relevantVariables": [
+							"buf",
+							"self.matcher.find_candidate_line",
+							"LineMatchKind::Confirmed",
+							"self.is_match"
+						]
+					},
+					"inputDataExample": "{\"slice\": \"...bytes of crates/searcher/src/lib.rs...\"}",
+					"outputDataExample": "{\"match\": {\"line_bytes\": \"A `Searcher` is responsible for reading...\", \"line_number\": 8}}"
+				},
+				{
+					"simStepId": "ad8a1176-c06c-41ec-92c0-7b64a8079bc1",
+					"diagramNodeId": "87179a07-e417-4140-99b7-02a9f9a02887",
+					"simStepLabel": "Pass Confirmed Match to Sink",
+					"simStepDescription": "Once a line is confirmed to contain a match, the core search logic packages the information (line content, absolute offset, line number) into a 'SinkMatch' object and calls the 'matched' method on the provided 'Sink' implementation.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/core.rs",
+						"startLine": "531",
+						"endLine": "544",
+						"relevantVariables": [
+							"self.sink.matched",
+							"SinkMatch"
+						]
+					},
+					"inputDataExample": "{\"type\": \"SinkMatch\", \"bytes\": \"A `Searcher` is responsible for reading bytes...\", \"line_number\": 8, \"absolute_byte_offset\": 200}",
+					"outputDataExample": "{\"type\": \"SinkMatch\", \"bytes\": \"A `Searcher` is responsible for reading bytes...\", \"line_number\": 8, \"absolute_byte_offset\": 200}"
+				},
+				{
+					"simStepId": "c346a2e8-331c-4d3f-a2cb-9e1afcbc7ac1",
+					"diagramNodeId": "31b67024-80a9-4f66-9e16-50d98e7d05c7",
+					"simStepLabel": "Format Match in Sink",
+					"simStepDescription": "The 'StandardSink' receives the 'SinkMatch'. It increments its internal match count and invokes its implementation logic to format the output. This includes prepending the file path and line number, and applying colors for highlighting the matched text.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "769",
+						"endLine": "788",
+						"relevantVariables": [
+							"mat",
+							"self.match_count",
+							"self.record_matches",
+							"StandardImpl::from_match"
+						]
+					},
+					"inputDataExample": "{\"type\": \"SinkMatch\", \"bytes\": \"A `Searcher` is responsible for reading bytes...\", \"line_number\": 8, \"absolute_byte_offset\": 200}",
+					"outputDataExample": "{\"formatted_line\": \"crates/searcher/src/lib.rs:8:A `Searcher` is responsible for reading bytes...\"}"
+				},
+				{
+					"simStepId": "ea8511c5-6417-49e1-8dd0-ff2555007454",
+					"diagramNodeId": "347bc957-3191-4e20-94e9-4e1901111130",
+					"simStepLabel": "Transmit Formatted Output to Buffer",
+					"simStepDescription": "The formatted line, complete with path, line number, and color codes, is written to a thread-local buffer.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "931",
+						"endLine": "935",
+						"relevantVariables": [
+							"self.write_search_prelude",
+							"self.sink_slow",
+							"self.sink_fast"
+						]
+					},
+					"inputDataExample": "{\"formatted_line\": \"crates/searcher/src/lib.rs:8:A `Searcher` is responsible for reading bytes...\"}",
+					"outputDataExample": "{\"formatted_line\": \"crates/searcher/src/lib.rs:8:A `Searcher` is responsible for reading bytes...\"}"
+				},
+				{
+					"simStepId": "32e761c6-06c3-4e7d-85a8-5a944e48aea5",
+					"diagramNodeId": "f6322f9f-f154-481a-a997-75b09226c146",
+					"simStepLabel": "Consolidate and Print Buffered Output",
+					"simStepDescription": "After searching a file, the worker thread's closure takes the formatted content from its local printer buffer and writes it to a shared, thread-safe writer. This ensures that output from different files is printed atomically without being interleaved, preserving the integrity of the search results.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/main.rs",
+						"startLine": "204",
+						"endLine": "211",
+						"relevantVariables": [
+							"bufwtr",
+							"searcher.printer",
+							"WalkState"
+						]
+					},
+					"inputDataExample": "{\"buffer_content\": \"crates/searcher/src/lib.rs:8:A `Searcher` is responsible...\\ncrates/searcher/src/lib.rs:15:a `Matcher`...\"}",
+					"outputDataExample": "null"
+				},
+				{
+					"simStepId": "5db3b846-cbc9-4272-b024-6ada2be69cce",
+					"diagramNodeId": "5f9ee588-f79d-40bd-bb72-9ec3368ab21f",
+					"simStepLabel": "Return Search Result Statistics",
+					"simStepDescription": "The 'search' method returns a 'SearchResult' object containing statistics (number of matches, lines, etc.) and a boolean indicating whether a match was found in the file.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/main.rs",
+						"startLine": "197",
+						"endLine": "197",
+						"relevantVariables": [
+							"search_result"
+						]
+					},
+					"inputDataExample": "{\"has_match\": true, \"stats\": {\"matches\": 5, \"matched_lines\": 2, \"total\": {\"bytes_searched\": 919}}}",
+					"outputDataExample": "{\"has_match\": true, \"stats\": {\"matches\": 5, \"matched_lines\": 2, \"total\": {\"bytes_searched\": 919}}}"
+				},
+				{
+					"simStepId": "eef7e6fb-0baf-47db-8786-cbef119a75c6",
+					"diagramNodeId": "344c1f2c-d241-4b5f-a686-7c1ea7037c5c",
+					"simStepLabel": "Aggregate Final Results",
+					"simStepDescription": "After all worker threads complete, the main thread aggregates the results. It combines statistics from all searches into a final summary (if requested) and determines the final exit code based on whether 'has_match' was true for any file searched.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/main.rs",
+						"startLine": "220",
+						"endLine": "228",
+						"relevantVariables": [
+							"searched",
+							"stats",
+							"matched"
+						]
+					},
+					"inputDataExample": "[{\"has_match\": true, \"stats\": {\"matches\": 5}}, {\"has_match\": false, \"stats\": {\"matches\": 0}}]",
+					"outputDataExample": "{\"final_matched_status\": true, \"final_stats\": {\"matches\": 5}}"
+				}
+			],
+			"description": "<ul><li>Recursively searches the current directory by default for a given regex pattern</li><li>Leverages parallelism across multiple CPU cores for directory traversal and file searching to achieve high performance</li><li>Built on a fast finite automata-based regex engine from Rust's <code>regex</code> crate</li><li>Automatically chooses the best search strategy (memory maps for single files, incremental for directories)</li></ul>",
+			"simulationNodesAndEdges": {
+				"f571f13d-a5b1-4696-810d-016af864988b": {
+					"simStepIds": [
+						"89b90516-5fbf-4f93-bc07-ad7b9c73c8ac"
+					]
+				},
+				"bdea59c2-5355-45cb-babe-67dfd0c2717e": {
+					"simStepIds": [
+						"74f2428a-8ad9-4ee1-9186-810db6e72b63"
+					]
+				},
+				"2196ff9f-2695-4b8a-8a75-d5702b89371f": {
+					"simStepIds": [
+						"4b7da167-9174-4295-83bc-b069e9331106"
+					]
+				},
+				"32bcfcb7-b4b6-4993-893c-1676d6ecaf77": {
+					"simStepIds": [
+						"886efe56-50a7-4387-99c3-a460e0a03834"
+					]
+				},
+				"b4d3b26e-19e7-477d-979f-702fb33ff014": {
+					"simStepIds": [
+						"bb853ccd-0b47-4741-ae7c-abfd7d75fa92"
+					]
+				},
+				"31b67024-80a9-4f66-9e16-50d98e7d05c7": {
+					"simStepIds": [
+						"c346a2e8-331c-4d3f-a2cb-9e1afcbc7ac1"
+					]
+				},
+				"f6322f9f-f154-481a-a997-75b09226c146": {
+					"simStepIds": [
+						"32e761c6-06c3-4e7d-85a8-5a944e48aea5"
+					]
+				},
+				"344c1f2c-d241-4b5f-a686-7c1ea7037c5c": {
+					"simStepIds": [
+						"eef7e6fb-0baf-47db-8786-cbef119a75c6"
+					]
+				},
+				"7789b62c-d2f3-4540-aa1a-a737a35b60c8": {
+					"simStepIds": [
+						"ac3640cf-d344-4813-869f-a260233103d5"
+					]
+				},
+				"590b160d-861c-4b10-a432-28127a3d547b": {
+					"simStepIds": [
+						"5161ea00-fede-4558-b465-a301e1f26076"
+					]
+				},
+				"5c3f5839-6758-4eaf-98b1-71868c95b20d": {
+					"simStepIds": [
+						"15ce35a6-7ce6-4bea-aeb6-05d2a5f5cda1"
+					]
+				},
+				"0c2fcc7e-11d6-43a5-ae89-13180aed99eb": {
+					"simStepIds": [
+						"c67074c1-8a09-479c-b153-ead7b0fa19d9"
+					]
+				},
+				"87179a07-e417-4140-99b7-02a9f9a02887": {
+					"simStepIds": [
+						"ad8a1176-c06c-41ec-92c0-7b64a8079bc1"
+					]
+				},
+				"347bc957-3191-4e20-94e9-4e1901111130": {
+					"simStepIds": [
+						"ea8511c5-6417-49e1-8dd0-ff2555007454"
+					]
+				},
+				"5f9ee588-f79d-40bd-bb72-9ec3368ab21f": {
+					"simStepIds": [
+						"5db3b846-cbc9-4272-b024-6ada2be69cce"
+					]
+				}
+			},
+			"isAIGenerated": true,
+			"keywords": "search_parallel, Searcher, Matcher",
+			"generationPrompt": "Perform high-speed, parallel, recursive searches for regular expression patterns in a directory tree.",
+			"generationKeywords": "search_parallel, Searcher, Matcher"
+		},
+		"Automatically filter search results by respecting `.gitignore` files and skipping hidden/binary files.": {
+			"name": "Automatically filter search results by respecting `.gitignore` files and skipping hidden/binary files.",
+			"simSteps": [
+				{
+					"simStepId": "9e34d9f4-60cf-49dd-9881-81338f158b78",
+					"diagramNodeId": "06b0a86e-bf34-4e78-b2d3-0b1442aef61e",
+					"simStepLabel": "Initializing the Directory Walker",
+					"simStepDescription": "The `WalkBuilder` is instantiated for the search paths. It is configured with default filtering options, which include respecting `.gitignore` and `.ignore` files, skipping hidden files, and traversing parent directories for ignore files. These settings are controlled by command-line arguments, with the defaults enabling smart filtering.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/ignore/src/walk.rs",
+						"startLine": "520",
+						"endLine": "530",
+						"relevantVariables": [
+							"WalkBuilder",
+							"new",
+							"IgnoreBuilder"
+						]
+					},
+					"inputDataExample": "{\n  \"paths\": [\"./\"],\n  \"cli_args\": {\n    \"hidden\": false,\n    \"no_ignore\": false,\n    \"no_ignore_parent\": false\n  }\n}",
+					"outputDataExample": "{\n  \"walkBuilder\": {\n    \"paths\": [\"./\"],\n    \"ig_builder\": {\n      \"opts\": {\n        \"hidden\": true,\n        \"parents\": true,\n        \"ignore\": true,\n        \"git_ignore\": true,\n        \"git_global\": true,\n        \"git_exclude\": true\n      }\n    },\n    \"max_depth\": null\n  }\n}"
+				},
+				{
+					"simStepId": "95bc5326-9e38-43a4-b4a8-970c33b57d4b",
+					"diagramNodeId": "8179e991-1e79-4612-abe1-b15ebc81ee7a",
+					"simStepLabel": "Directory Walker Begins Traversal",
+					"simStepDescription": "The configured `WalkBuilder` is used to create a `Walk` iterator by calling `.build()`. This iterator begins traversing the file system from the specified starting paths.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/ignore/src/walk.rs",
+						"startLine": "939",
+						"endLine": "939",
+						"relevantVariables": [
+							"WalkBuilder::new(path).build()"
+						]
+					},
+					"inputDataExample": "{\n  \"walkBuilder\": {\n    \"paths\": [\"./\"],\n    \"ig_builder\": {\n      \"opts\": {\n        \"hidden\": true,\n        \"parents\": true,\n        \"ignore\": true,\n        \"git_ignore\": true\n      }\n    }\n  }\n}",
+					"outputDataExample": "{\n  \"walkBuilder\": {\n    \"paths\": [\"./\"],\n    \"ig_builder\": {\n      \"opts\": {\n        \"hidden\": true,\n        \"parents\": true,\n        \"ignore\": true,\n        \"git_ignore\": true\n      }\n    }\n  }\n}"
+				},
+				{
+					"simStepId": "1b894775-da3b-4578-b6d2-484f23e1ec50",
+					"diagramNodeId": "d3448e0e-d81f-476d-aff3-3bd9ab26026d",
+					"simStepLabel": "Parsing `.gitignore` File",
+					"simStepDescription": "As the walker traverses directories, it discovers ignore files like `.gitignore`. It opens the file, reads it line by line, and parses each line into a glob pattern. Comments (starting with `#`) and empty lines are skipped. The UTF-8 BOM is also handled.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/ignore/src/gitignore.rs",
+						"startLine": "391",
+						"endLine": "416",
+						"relevantVariables": [
+							"GitignoreBuilder::add",
+							"File::open",
+							"rdr.lines()",
+							"add_line"
+						]
+					},
+					"inputDataExample": "{\n  \"filePath\": \"./.gitignore\",\n  \"fileContent\": \"# Ignore build artifacts\\n/target/\\n\\n# Ignore logs\\n*.log\\n!important.log\"\n}",
+					"outputDataExample": "{\n  \"parsedGlobs\": [\n    {\n      \"original\": \"/target/\",\n      \"is_whitelist\": false\n    },\n    {\n      \"original\": \"*.log\",\n      \"is_whitelist\": false\n    },\n    {\n      \"original\": \"!important.log\",\n      \"is_whitelist\": true\n    }\n  ]\n}"
+				},
+				{
+					"simStepId": "fc573a17-a164-4433-8631-85e9d9a86d05",
+					"diagramNodeId": "643dc76d-7619-485d-812b-937f5adb8ad9",
+					"simStepLabel": "Transferring Compiled Globs",
+					"simStepDescription": "The parsed globs are compiled into an efficient matching structure (`GlobSet`) and stored within a `Gitignore` object. This object is then associated with the directory where the `.gitignore` file was found.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/ignore/src/gitignore.rs",
+						"startLine": "335",
+						"endLine": "347",
+						"relevantVariables": [
+							"GitignoreBuilder::build",
+							"GlobSetBuilder::build",
+							"Gitignore"
+						]
+					},
+					"inputDataExample": "{\n  \"globSetBuilder\": {\n    \"globs\": [\n      \"**/target/\",\n      \"**/.*.log\",\n      \"**/important.log\"\n    ]\n  }\n}",
+					"outputDataExample": "{\n  \"gitignoreMatcher\": {\n    \"root\": \"./\",\n    \"set\": \"<Compiled GlobSet>\",\n    \"num_ignores\": 2,\n    \"num_whitelists\": 1\n  }\n}"
+				},
+				{
+					"simStepId": "025792a2-a063-4347-ac2f-5978300032d4",
+					"diagramNodeId": "7abfc016-6e09-4293-9c51-8be0e01bd020",
+					"simStepLabel": "Applying Filtering Rules to a Path",
+					"simStepDescription": "For each file or directory encountered (`DirEntry`), the walker applies all relevant filters. First, it checks if the path is hidden (starts with '.'). Then, it consults the `Ignore` matcher, which checks against globs from all applicable sources (`.ignore`, `.gitignore`, global git config, etc.) in the correct order of precedence, from the current directory up to the repository root.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/ignore/src/dir.rs",
+						"startLine": "396",
+						"endLine": "544",
+						"relevantVariables": [
+							"Ignore::matched",
+							"is_hidden",
+							"m_override",
+							"m_ignore",
+							"m_gi",
+							"m_global",
+							"m_explicit"
+						]
+					},
+					"inputDataExample": "{\n  \"path\": \"./target/debug/ripgrep\",\n  \"is_dir\": false\n}",
+					"outputDataExample": "{\n  \"matchResult\": \"Ignore\",\n  \"reason\": \"Matched glob '/target/' from ./.gitignore\"\n}"
+				},
+				{
+					"simStepId": "dcb8f230-7cf4-471b-b2ee-4b2ea0afe105",
+					"diagramNodeId": "b37077b4-3a28-4e20-8572-adb309282e6e",
+					"simStepLabel": "Yielding a Valid File Path",
+					"simStepDescription": "If a path is not filtered by any of the active rules (hidden, gitignore, etc.), the `DirEntry` is yielded by the iterator, making it available for the next stage of processing: searching.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/ignore/src/walk.rs",
+						"startLine": "1056",
+						"endLine": "1056",
+						"relevantVariables": [
+							"Walk::next",
+							"return Some(Ok(dent))"
+						]
+					},
+					"inputDataExample": "{\n  \"path\": \"./src/main.rs\",\n  \"is_dir\": false,\n  \"filteringDecision\": \"Yield\"\n}",
+					"outputDataExample": "{\n  \"dirEntry\": {\n    \"path\": \"./src/main.rs\",\n    \"file_type\": \"File\"\n  }\n}"
+				},
+				{
+					"simStepId": "5e4d02cc-50e4-40ab-a1f4-cd11b845f582",
+					"diagramNodeId": "2f67c4c9-54b4-4da2-9448-5bfa18537099",
+					"simStepLabel": "Configuring Searcher for Binary Detection",
+					"simStepDescription": "For each file to be searched, a `Searcher` is configured. The `BinaryDetection` strategy is set based on command-line flags. For automatic recursive searching, the default is `quit(b'\\x00')`, which stops searching a file as soon as a NUL byte is found.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/mod.rs",
+						"startLine": "503",
+						"endLine": "510",
+						"relevantVariables": [
+							"SearcherBuilder",
+							"binary_detection",
+							"BinaryDetection"
+						]
+					},
+					"inputDataExample": "{\n  \"cli_args\": {\n    \"unrestricted_count\": 0\n  }\n}",
+					"outputDataExample": "{\n  \"searcherConfig\": {\n    \"binary_detection\": \"Quit(0)\"\n  }\n}"
+				},
+				{
+					"simStepId": "fba70f94-ac0e-47a2-8d50-5a6a733e996b",
+					"diagramNodeId": "b04390e9-6b12-4665-9c2d-4afc76a8be4b",
+					"simStepLabel": "Reading File Contents into Buffer",
+					"simStepDescription": "The `Searcher` begins reading the contents of the yielded file into an internal line buffer for processing.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/line_buffer.rs",
+						"startLine": "415",
+						"endLine": "415",
+						"relevantVariables": [
+							"rdr.read(&mut self.buf[self.end..])"
+						]
+					},
+					"inputDataExample": "{\n  \"filePath\": \"./tests/data/sherlock-nul.txt\"\n}",
+					"outputDataExample": "{\n  \"bufferContent\": \"For the Doctor Watsons of this world...\\x00...\"\n}"
+				},
+				{
+					"simStepId": "722f695f-377d-448e-9b44-9265ca920a1c",
+					"diagramNodeId": "b80fd0a4-3357-49c4-baf5-2fa06862eb09",
+					"simStepLabel": "Detecting NUL Byte",
+					"simStepDescription": "As the line buffer is filled with new data from the file, it is scanned for the binary detection byte (NUL, `\\x00`). If the byte is found, the buffer's end is marked at the position of the byte, the binary offset is recorded, and the fill operation stops.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/line_buffer.rs",
+						"startLine": "436",
+						"endLine": "443",
+						"relevantVariables": [
+							"BinaryDetection::Quit",
+							"newbytes.find_byte(byte)",
+							"self.binary_byte_offset",
+							"self.end"
+						]
+					},
+					"inputDataExample": "{\n  \"bufferChunk\": \"Holmeses, success...\\x00...must always be\",\n  \"binaryDetectionMode\": \"Quit(0)\"\n}",
+					"outputDataExample": "{\n  \"binary_byte_offset\": 212,\n  \"buffer_end\": 212\n}"
+				},
+				{
+					"simStepId": "57c81d35-e9c1-4342-b7aa-da6ade908b5a",
+					"diagramNodeId": "66a36773-5189-4bc2-909a-0d5ce55eb772",
+					"simStepLabel": "Signaling Binary File Detection",
+					"simStepDescription": "The `Searcher` receives the result from the buffer fill operation, which includes the offset of the detected NUL byte. This signals that the file is binary and should not be searched further.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/core.rs",
+						"startLine": "216",
+						"endLine": "225",
+						"relevantVariables": [
+							"self.binary_byte_offset",
+							"self.config.binary",
+							"BinaryDetection::Quit"
+						]
+					},
+					"inputDataExample": "{\n  \"binary_byte_offset\": 212\n}",
+					"outputDataExample": "{\n  \"binary_byte_offset\": 212\n}"
+				},
+				{
+					"simStepId": "10c3a95e-70bc-4232-9eb2-d16a22ee39cb",
+					"diagramNodeId": "723470cf-d7a8-443a-8713-f4840c0ae560",
+					"simStepLabel": "Skipping Binary File",
+					"simStepDescription": "Upon receiving the binary detection signal, the search logic for the current file is terminated. The printer is notified via the `SinkFinish` call, which includes the binary offset. Depending on the output format, a message like 'Binary file matches' may be printed, but the file's contents are not, effectively filtering it from the results.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/summary.rs",
+						"startLine": "724",
+						"endLine": "739",
+						"relevantVariables": [
+							"Sink::finish",
+							"searcher.binary_detection().quit_byte()",
+							"self.binary_byte_offset",
+							"self.match_count = 0"
+						]
+					},
+					"inputDataExample": "{\n  \"filePath\": \"./tests/data/sherlock-nul.txt\",\n  \"binary_byte_offset\": 212\n}",
+					"outputDataExample": "{\n  \"action\": \"AbortSearch\",\n  \"output\": \"Binary file ./tests/data/sherlock-nul.txt matches\"\n}"
+				}
+			],
+			"description": "<ul><li>By default, <code>ripgrep</code> does not search files or directories that match patterns in <code></li><li>gitignore</code>, <code></li><li>ignore</code>, or global git config files</li><li>Hidden files and directories (those starting with a <code></li><li></code>) are automatically skipped</li><li>Binary files (heuristically detected by the presence of a <code>NUL</code> byte) are skipped to avoid printing garbage to the terminal</li><li>This smart filtering can be progressively disabled with the <code>-u</code>/<code>--unrestricted</code> flag</li></ul>",
+			"simulationNodesAndEdges": {
+				"06b0a86e-bf34-4e78-b2d3-0b1442aef61e": {
+					"simStepIds": [
+						"9e34d9f4-60cf-49dd-9881-81338f158b78"
+					]
+				},
+				"d3448e0e-d81f-476d-aff3-3bd9ab26026d": {
+					"simStepIds": [
+						"1b894775-da3b-4578-b6d2-484f23e1ec50"
+					]
+				},
+				"7abfc016-6e09-4293-9c51-8be0e01bd020": {
+					"simStepIds": [
+						"025792a2-a063-4347-ac2f-5978300032d4"
+					]
+				},
+				"2f67c4c9-54b4-4da2-9448-5bfa18537099": {
+					"simStepIds": [
+						"5e4d02cc-50e4-40ab-a1f4-cd11b845f582"
+					]
+				},
+				"b80fd0a4-3357-49c4-baf5-2fa06862eb09": {
+					"simStepIds": [
+						"722f695f-377d-448e-9b44-9265ca920a1c"
+					]
+				},
+				"723470cf-d7a8-443a-8713-f4840c0ae560": {
+					"simStepIds": [
+						"10c3a95e-70bc-4232-9eb2-d16a22ee39cb"
+					]
+				},
+				"8179e991-1e79-4612-abe1-b15ebc81ee7a": {
+					"simStepIds": [
+						"95bc5326-9e38-43a4-b4a8-970c33b57d4b"
+					]
+				},
+				"643dc76d-7619-485d-812b-937f5adb8ad9": {
+					"simStepIds": [
+						"fc573a17-a164-4433-8631-85e9d9a86d05"
+					]
+				},
+				"b37077b4-3a28-4e20-8572-adb309282e6e": {
+					"simStepIds": [
+						"dcb8f230-7cf4-471b-b2ee-4b2ea0afe105"
+					]
+				},
+				"b04390e9-6b12-4665-9c2d-4afc76a8be4b": {
+					"simStepIds": [
+						"fba70f94-ac0e-47a2-8d50-5a6a733e996b"
+					]
+				},
+				"66a36773-5189-4bc2-909a-0d5ce55eb772": {
+					"simStepIds": [
+						"57c81d35-e9c1-4342-b7aa-da6ade908b5a"
+					]
+				}
+			},
+			"isAIGenerated": true,
+			"keywords": "WalkBuilder, Gitignore, BinaryDetection",
+			"generationPrompt": "Automatically filter search results by respecting `.gitignore` files and skipping hidden/binary files.",
+			"generationKeywords": "WalkBuilder, Gitignore, BinaryDetection"
+		},
+		"Manually include or exclude files from a search using glob patterns and pre-defined file types.": {
+			"name": "Manually include or exclude files from a search using glob patterns and pre-defined file types.",
+			"simSteps": [
+				{
+					"simStepId": "8cdd9622-d34d-456c-8cbd-df9939e9ea65",
+					"diagramNodeId": "cb3a4534-fcff-4d6e-a249-7dc152bd9a32",
+					"simStepLabel": "Flow 1: Parse '--glob' Flag",
+					"simStepDescription": "The command-line parser encounters the '-g' or '--glob' flag and its value. This value is stored as a raw string in the `globs` vector within a low-level arguments struct for later processing.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/defs.rs",
+						"startLine": "2555",
+						"endLine": "2558",
+						"relevantVariables": [
+							"Glob",
+							"v",
+							"args.globs"
+						]
+					},
+					"inputDataExample": "{\"argv\": [\"rg\", \"-g\", \"*.rs\", \"-g\", \"!src/vendor/*\", \"my_pattern\"]}",
+					"outputDataExample": "{\"globs\": [\"*.rs\", \"!src/vendor/*\"]}"
+				},
+				{
+					"simStepId": "03e12913-6e17-41ca-aa86-096355546fab",
+					"diagramNodeId": "2b3fde20-eac5-4250-b825-23b44081ba08",
+					"simStepLabel": "Flow 1: Transmit Glob Patterns",
+					"simStepDescription": "The collected glob patterns are passed from the low-level argument parsing stage to the high-level argument builder, which will compile them into a matcher.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "152",
+						"endLine": "152",
+						"relevantVariables": [
+							"low.globs",
+							"globs"
+						]
+					},
+					"inputDataExample": "{\"globs\": [\"*.rs\", \"!src/vendor/*\"]}",
+					"outputDataExample": "{\"globs\": [\"*.rs\", \"!src/vendor/*\"]}"
+				},
+				{
+					"simStepId": "1c3b6417-4da9-4192-a8da-70e0f7079d88",
+					"diagramNodeId": "fbfa66cf-8419-4584-8997-3dcb1520343c",
+					"simStepLabel": "Flow 1: Build Glob Override Matcher",
+					"simStepDescription": "The raw glob patterns are compiled into an efficient `Override` matcher. This function initializes an `OverrideBuilder`, adds each glob pattern, and then builds the final `Override` object. This matcher uses `globset` internally for fast, simultaneous matching of multiple globs.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "1205",
+						"endLine": "1225",
+						"relevantVariables": [
+							"ignore::overrides::OverrideBuilder",
+							"low.globs",
+							"builder.add",
+							"builder.build"
+						]
+					},
+					"inputDataExample": "{\"cwd\": \"/path/to/project\", \"globs\": [\"*.rs\", \"!src/vendor/*\"], \"iglobs\": [], \"glob_case_insensitive\": false}",
+					"outputDataExample": "{\"Override\": \"object with compiled globs: *.rs, !src/vendor/*\"}"
+				},
+				{
+					"simStepId": "bb850076-72a4-403a-be38-e533ecc251ad",
+					"diagramNodeId": "ba4298a3-e951-4215-a0b0-55c94dffc690",
+					"simStepLabel": "Flow 1: Configure Walker with Override Matcher",
+					"simStepDescription": "The compiled `Override` matcher is passed to the `WalkBuilder` to be used for filtering files during directory traversal. This matcher has the highest precedence.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "892",
+						"endLine": "892",
+						"relevantVariables": [
+							"self.globs",
+							"overrides"
+						]
+					},
+					"inputDataExample": "{\"Override\": \"object with compiled globs: *.rs, !src/vendor/*\"}",
+					"outputDataExample": "{\"Override\": \"object with compiled globs: *.rs, !src/vendor/*\"}"
+				},
+				{
+					"simStepId": "18eead12-d6f4-4f5d-82f5-979a40c61c6b",
+					"diagramNodeId": "8570a0fe-3867-4504-8509-b48052799065",
+					"simStepLabel": "Flow 1: Filter Path with Override Matcher",
+					"simStepDescription": "During directory traversal, for each path encountered, the `Override` matcher is checked first. If a path matches a glob, a decision to include (whitelist) or exclude (ignore) it is made immediately, taking precedence over all other ignore rules like .gitignore or file types.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/ignore/src/dir.rs",
+						"startLine": "381",
+						"endLine": "389",
+						"relevantVariables": [
+							"self.0.overrides",
+							"self.0.overrides.matched"
+						]
+					},
+					"inputDataExample": "{\"path\": \"src/main.rs\", \"is_dir\": false}",
+					"outputDataExample": "{\"match_result\": \"Whitelist\"}"
+				},
+				{
+					"simStepId": "87114100-cc4e-473c-8213-577fe0eed9e4",
+					"diagramNodeId": "38526dce-9250-40d1-8e4b-b6489562aee3",
+					"simStepLabel": "Flow 2: Parse File Type Flags",
+					"simStepDescription": "The parser processes flags like '-t' (type), '-T' (type-not), '--type-add', and '--type-clear'. These are converted into a structured `TypeChange` enum and collected in a list for later processing.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/defs.rs",
+						"startLine": "6901",
+						"endLine": "7126",
+						"relevantVariables": [
+							"Type",
+							"TypeNot",
+							"TypeAdd",
+							"TypeClear",
+							"TypeChange"
+						]
+					},
+					"inputDataExample": "{\"argv\": [\"rg\", \"-trust\", \"--type-add\", \"web:*.{html,css}\", \"-Tjs\", \"my_pattern\"]}",
+					"outputDataExample": "{\"type_changes\": [{\"Select\": {\"name\": \"rust\"}}, {\"Add\": {\"def\": \"web:*.{html,css}\"}}, {\"Negate\": {\"name\": \"js\"}}]}"
+				},
+				{
+					"simStepId": "6c28187f-874c-462c-a17c-e5c547ed0812",
+					"diagramNodeId": "1279f8bf-17d7-4a0a-a789-6f364aa3e5cf",
+					"simStepLabel": "Flow 2: Transmit Type Changes",
+					"simStepDescription": "The list of `TypeChange` operations is passed from the low-level argument parser to the high-level argument builder, which will construct the final file type matcher.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "151",
+						"endLine": "151",
+						"relevantVariables": [
+							"low.type_changes",
+							"types"
+						]
+					},
+					"inputDataExample": "{\"type_changes\": [{\"Select\": {\"name\": \"rust\"}}, {\"Add\": {\"def\": \"web:*.{html,css}\"}}, {\"Negate\": {\"name\": \"js\"}}]}",
+					"outputDataExample": "{\"type_changes\": [{\"Select\": {\"name\": \"rust\"}}, {\"Add\": {\"def\": \"web:*.{html,css}\"}}, {\"Negate\": {\"name\": \"js\"}}]}"
+				},
+				{
+					"simStepId": "9b9b64e8-bf1a-43f6-aefa-f2bad985f294",
+					"diagramNodeId": "c6ed14cf-fad1-4551-b5c4-ddfa4af6afe0",
+					"simStepLabel": "Flow 2: Build File Type Matcher",
+					"simStepDescription": "A `TypesBuilder` is created and populated with default file type definitions. It's then modified according to the user's `TypeChange` requests (e.g., adding a 'web' type, selecting 'rust', and negating 'js'). Finally, a `Types` matcher is built, which compiles the necessary globs into a `globset::GlobSet` for efficient matching.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "1180",
+						"endLine": "1202",
+						"relevantVariables": [
+							"ignore::types::TypesBuilder",
+							"builder.add_defaults",
+							"builder.clear",
+							"builder.add_def",
+							"builder.select",
+							"builder.negate",
+							"builder.build"
+						]
+					},
+					"inputDataExample": "{\"type_changes\": [{\"Select\": {\"name\": \"rust\"}}, {\"Add\": {\"def\": \"web:*.{html,css}\"}}, {\"Negate\": {\"name\": \"js\"}}]}",
+					"outputDataExample": "{\"Types\": \"object containing compiled globsets for selected and negated types\"}"
+				},
+				{
+					"simStepId": "0e14c00a-6383-43b4-9285-b35fe6261f7a",
+					"diagramNodeId": "f44a0aa4-4205-4ea4-9d80-5a62385e2307",
+					"simStepLabel": "Flow 2: Configure Walker with Type Matcher",
+					"simStepDescription": "The compiled `Types` matcher is passed to the `WalkBuilder` to be used for filtering files during directory traversal.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "893",
+						"endLine": "893",
+						"relevantVariables": [
+							"self.types",
+							"types"
+						]
+					},
+					"inputDataExample": "{\"Types\": \"object containing compiled globsets for selected and negated types\"}",
+					"outputDataExample": "{\"Types\": \"object containing compiled globsets for selected and negated types\"}"
+				},
+				{
+					"simStepId": "c47913bd-2425-4d97-b7c3-c66f5e6a084c",
+					"diagramNodeId": "1280e475-b2ba-4864-964c-5ce2738208ab",
+					"simStepLabel": "Flow 2: Filter Path with Type Matcher",
+					"simStepDescription": "During directory traversal, if a path is not filtered by a glob override or other ignore rules, the `Types` matcher is checked. It determines if the file matches a selected type (whitelisted), a negated type (ignored), or if it should be ignored because it doesn't match any of the selected types.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/ignore/src/dir.rs",
+						"startLine": "396",
+						"endLine": "406",
+						"relevantVariables": [
+							"self.0.types",
+							"self.0.types.matched"
+						]
+					},
+					"inputDataExample": "{\"path\": \"src/main.js\", \"is_dir\": false}",
+					"outputDataExample": "{\"match_result\": \"Ignore\"}"
+				}
+			],
+			"description": "<ul><li>Users can limit searches to specific files using glob patterns with the <code>-g</code>/<code>--glob</code> flag (e</li><li>g</li><li>, <code>-g '<em></li><li>rs'</code>)</li><li>Globs can also be used for exclusion (e</li><li>g</li><li>, <code>-g '!</em></li><li>md'</code>)</li><li>Provides built-in file type definitions for common languages, allowing users to search by type (e</li><li>g</li><li>, <code>-trust</code> to search Rust files or <code>-Tjs</code> to exclude JavaScript)</li><li>Users can define their own custom file types with <code>--type-add</code></li></ul>",
+			"simulationNodesAndEdges": {
+				"cb3a4534-fcff-4d6e-a249-7dc152bd9a32": {
+					"simStepIds": [
+						"8cdd9622-d34d-456c-8cbd-df9939e9ea65"
+					]
+				},
+				"fbfa66cf-8419-4584-8997-3dcb1520343c": {
+					"simStepIds": [
+						"1c3b6417-4da9-4192-a8da-70e0f7079d88"
+					]
+				},
+				"8570a0fe-3867-4504-8509-b48052799065": {
+					"simStepIds": [
+						"18eead12-d6f4-4f5d-82f5-979a40c61c6b"
+					]
+				},
+				"38526dce-9250-40d1-8e4b-b6489562aee3": {
+					"simStepIds": [
+						"87114100-cc4e-473c-8213-577fe0eed9e4"
+					]
+				},
+				"c6ed14cf-fad1-4551-b5c4-ddfa4af6afe0": {
+					"simStepIds": [
+						"9b9b64e8-bf1a-43f6-aefa-f2bad985f294"
+					]
+				},
+				"1280e475-b2ba-4864-964c-5ce2738208ab": {
+					"simStepIds": [
+						"c47913bd-2425-4d97-b7c3-c66f5e6a084c"
+					]
+				},
+				"2b3fde20-eac5-4250-b825-23b44081ba08": {
+					"simStepIds": [
+						"03e12913-6e17-41ca-aa86-096355546fab"
+					]
+				},
+				"ba4298a3-e951-4215-a0b0-55c94dffc690": {
+					"simStepIds": [
+						"bb850076-72a4-403a-be38-e533ecc251ad"
+					]
+				},
+				"1279f8bf-17d7-4a0a-a789-6f364aa3e5cf": {
+					"simStepIds": [
+						"6c28187f-874c-462c-a17c-e5c547ed0812"
+					]
+				},
+				"f44a0aa4-4205-4ea4-9d80-5a62385e2307": {
+					"simStepIds": [
+						"0e14c00a-6383-43b4-9285-b35fe6261f7a"
+					]
+				}
+			},
+			"isAIGenerated": true,
+			"keywords": "glob, type, Override",
+			"generationPrompt": "Manually include or exclude files from a search using glob patterns and pre-defined file types.",
+			"generationKeywords": "glob, type, Override"
+		},
+		"Customize search result presentation with context, line/column numbers, color, and JSON output.": {
+			"name": "Customize search result presentation with context, line/column numbers, color, and JSON output.",
+			"simSteps": [
+				{
+					"simStepId": "a234a4fc-6910-49ab-9692-3629e7029a19",
+					"diagramNodeId": "8e2b5abc-ba17-4126-8196-2d863574dd03",
+					"simStepLabel": "Standard Output Flow: Parse Context and Formatting Flags",
+					"simStepDescription": "Ripgrep's command-line interface parses arguments to configure the search output. Flags like `-A` (after-context), `-B` (before-context), `-C` (context), `--column` (show column numbers), and `-b` (show byte offset) are processed. These flags determine how search results will be formatted for human-readable output.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/defs.rs",
+						"startLine": "995",
+						"endLine": "1024",
+						"relevantVariables": [
+							"Context",
+							"AfterContext",
+							"BeforeContext"
+						]
+					},
+					"inputDataExample": "{\"args\": [\"rg\", \"-C\", \"1\", \"--column\", \"-b\", \"Holmes\", \"sherlock.txt\"]}",
+					"outputDataExample": "{\"LowArgs\": {\"context\": {\"both\": 1}, \"column\": true, \"byte_offset\": true, \"patterns\": [\"Holmes\"], \"paths\": [\"sherlock.txt\"]}}"
+				},
+				{
+					"simStepId": "a17d799e-12b0-470a-8e98-5ec9ed6bd1b3",
+					"diagramNodeId": "66e9ca05-7027-45f5-a953-d9fa1ff7f1a0",
+					"simStepLabel": "Standard Output Flow: Transmit Parsed Arguments",
+					"simStepDescription": "The parsed low-level arguments, stored in a `LowArgs` struct, are passed to a higher-level argument processor that resolves conflicts and sets final configuration values.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "119",
+						"endLine": "122",
+						"relevantVariables": [
+							"HiArgs",
+							"LowArgs"
+						]
+					},
+					"inputDataExample": "{\"LowArgs\": {\"context\": {\"both\": 1}, \"column\": true, \"byte_offset\": true, \"patterns\": [\"Holmes\"], \"paths\": [\"sherlock.txt\"]}}",
+					"outputDataExample": "{\"LowArgs\": {\"context\": {\"both\": 1}, \"column\": true, \"byte_offset\": true, \"patterns\": [\"Holmes\"], \"paths\": [\"sherlock.txt\"]}}"
+				},
+				{
+					"simStepId": "3e717203-9460-44e7-835e-49cd8340dbc6",
+					"diagramNodeId": "8a7a07f1-7758-4c90-9a3b-f49dc60d12f1",
+					"simStepLabel": "Standard Output Flow: Configure Searcher and Printer",
+					"simStepDescription": "The high-level arguments are used to configure the `Searcher` and the `Standard` printer. The `SearcherBuilder` is configured with context line settings (`before_context`, `after_context`), while the `StandardBuilder` is configured with formatting options like `byte_offset` and `column`.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "599",
+						"endLine": "633",
+						"relevantVariables": [
+							"printer_standard",
+							"StandardBuilder",
+							"builder"
+						]
+					},
+					"inputDataExample": "{\"HiArgs\": {\"context\": {\"Limited\": {\"both\": 1}}, \"column\": true, \"byte_offset\": true}}",
+					"outputDataExample": "{\"SearcherBuilder\": {\"before_context\": 1, \"after_context\": 1}, \"StandardBuilder\": {\"byte_offset\": true, \"column\": true}}"
+				},
+				{
+					"simStepId": "73c3f672-dfe3-460c-905d-c6bd9eddbd55",
+					"diagramNodeId": "3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a",
+					"simStepLabel": "Standard Output Flow: Transmit Configured Searcher and Printer",
+					"simStepDescription": "The fully configured `Searcher` and `Standard` printer instances are passed to the main search execution logic, which will coordinate the search and printing process.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "380",
+						"endLine": "383",
+						"relevantVariables": [
+							"search_path_printer",
+							"searcher",
+							"printer"
+						]
+					},
+					"inputDataExample": "{\"Searcher\": {}, \"Printer::Standard\": {}}",
+					"outputDataExample": "{\"Searcher\": {}, \"Printer::Standard\": {}}"
+				},
+				{
+					"simStepId": "127bdb74-45b0-4569-b7be-89b9b808c24b",
+					"diagramNodeId": "7d6a3f10-0382-4eaa-8a62-e3492e6000c2",
+					"simStepLabel": "Standard Output Flow: Execute Search and Sink Results",
+					"simStepDescription": "The `Searcher` iterates through the input file, finds matches, and identifies any surrounding context lines. For each match or context line, it calls the corresponding method (`matched` or `context`) on the `StandardSink`, which is responsible for printing.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "764",
+						"endLine": "823",
+						"relevantVariables": [
+							"Sink",
+							"StandardSink",
+							"matched",
+							"context"
+						]
+					},
+					"inputDataExample": "{\"haystack\": \"...Sherlock Holmes...\", \"matcher\": \"Holmes\"}",
+					"outputDataExample": "{\"SinkMatch\": {\"line_number\": 2, \"bytes\": \"Holmeses, success in the province of detective work must always\\n\"}}"
+				},
+				{
+					"simStepId": "35e70e93-56f9-4ae9-a4e0-d4eb08246f4b",
+					"diagramNodeId": "262b607f-db42-4642-91b9-abd5a1108374",
+					"simStepLabel": "Standard Output Flow: Transmit Match and Context Data",
+					"simStepDescription": "Data about each match and context line, encapsulated in `SinkMatch` and `SinkContext` objects, is passed from the searcher core to the sink's implementation. This data includes the line content, line number, and absolute byte offset.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/sink.rs",
+						"startLine": "126",
+						"endLine": "132",
+						"relevantVariables": [
+							"Sink",
+							"matched",
+							"SinkMatch"
+						]
+					},
+					"inputDataExample": "{\"SinkContext\": {\"kind\": \"Before\", \"line_number\": 1, \"bytes\": \"For the Doctor Watsons of this world, as opposed to the Sherlock\\n\"}}",
+					"outputDataExample": "{\"SinkContext\": {\"kind\": \"Before\", \"line_number\": 1, \"bytes\": \"For the Doctor Watsons of this world, as opposed to the Sherlock\\n\"}}"
+				},
+				{
+					"simStepId": "89d044cb-ba97-423b-b877-e022fd3aadc5",
+					"diagramNodeId": "b7e5cc9d-83e0-44e5-bcd8-0f7886685f38",
+					"simStepLabel": "Standard Output Flow: Format Human-Readable Output",
+					"simStepDescription": "The `StandardSink` uses a helper, `StandardImpl`, to format the output. It consults the printer's configuration to decide whether to include line numbers, column numbers, byte offsets, context separators, and colors, then assembles the final output string for each line.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "871",
+						"endLine": "929",
+						"relevantVariables": [
+							"StandardImpl",
+							"from_match",
+							"from_context"
+						]
+					},
+					"inputDataExample": "{\"SinkMatch\": {\"line_number\": 2, \"bytes\": \"Holmeses...\"}, \"Config\": {\"column\": true, \"byte_offset\": true}}",
+					"outputDataExample": "{\"FormattedLine\": \"sherlock.txt:2:1:65:Holmeses, success in the province of detective work must always\\n\"}"
+				},
+				{
+					"simStepId": "15986b7a-0256-4f61-97b4-61e8c654b7e4",
+					"diagramNodeId": "81663818-d2d6-4cfe-8a71-7b37237f7f95",
+					"simStepLabel": "Standard Output Flow: Write Formatted String to stdout",
+					"simStepDescription": "The final, formatted string for each matching or contextual line is written to the standard output stream. A specialized writer is used to handle terminal coloring and appropriate buffering for performance.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/cli/src/wtr.rs",
+						"startLine": "66",
+						"endLine": "74",
+						"relevantVariables": [
+							"StandardStream",
+							"write"
+						]
+					},
+					"inputDataExample": "{\"FormattedLine\": \"sherlock.txt:2:1:65:Holmeses, success in the province of detective work must always\\n\"}",
+					"outputDataExample": "{\"FormattedLine\": \"sherlock.txt:2:1:65:Holmeses, success in the province of detective work must always\\n\"}"
+				},
+				{
+					"simStepId": "b94bbc3b-921b-4dcf-8678-da515f9752ad",
+					"diagramNodeId": "dc9f30d5-6599-4494-867c-a5f5726f7aa2",
+					"simStepLabel": "JSON Output Flow: Parse --json Flag",
+					"simStepDescription": "The application starts by parsing the `--json` command-line flag. When this flag is present, it sets the application's output mode to `SearchMode::JSON`, fundamentally changing how results are presented.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/defs.rs",
+						"startLine": "3429",
+						"endLine": "3512",
+						"relevantVariables": [
+							"JSON",
+							"update"
+						]
+					},
+					"inputDataExample": "{\"args\": [\"rg\", \"--json\", \"Watson\", \"sherlock.txt\"]}",
+					"outputDataExample": "{\"LowArgs\": {\"mode\": \"SearchMode::JSON\", \"patterns\": [\"Watson\"], \"paths\": [\"sherlock.txt\"]}}"
+				},
+				{
+					"simStepId": "60bc2812-8cec-4cf7-888d-7566c874c9dd",
+					"diagramNodeId": "b054dd02-8e6a-4e42-be4a-7e082e6187d9",
+					"simStepLabel": "JSON Output Flow: Transmit Parsed Arguments",
+					"simStepDescription": "The parsed `LowArgs` struct, now indicating JSON output mode, is passed to the high-level argument processor.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "119",
+						"endLine": "122",
+						"relevantVariables": [
+							"HiArgs",
+							"from_lowargs"
+						]
+					},
+					"inputDataExample": "{\"LowArgs\": {\"mode\": \"SearchMode::JSON\", \"patterns\": [\"Watson\"], \"paths\": [\"sherlock.txt\"]}}",
+					"outputDataExample": "{\"LowArgs\": {\"mode\": \"SearchMode::JSON\", \"patterns\": [\"Watson\"], \"paths\": [\"sherlock.txt\"]}}"
+				},
+				{
+					"simStepId": "f9ec9573-13f1-41ea-8286-d86c8bb66a3f",
+					"diagramNodeId": "aedf481e-7a26-4f1a-8f80-e270d31af954",
+					"simStepLabel": "JSON Output Flow: Select and Build JSON Printer",
+					"simStepDescription": "The high-level argument processor checks the search mode. Since it's `SearchMode::JSON`, it selects and constructs a `JSON` printer using the `JSONBuilder`. This printer is specifically designed to output results in a machine-readable JSON Lines format.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "586",
+						"endLine": "596",
+						"relevantVariables": [
+							"printer",
+							"printer_json",
+							"SearchMode::JSON"
+						]
+					},
+					"inputDataExample": "{\"SearchMode\": \"JSON\"}",
+					"outputDataExample": "{\"Printer\": \"JSON\"}"
+				},
+				{
+					"simStepId": "a46b12aa-0542-4121-b024-209610723a23",
+					"diagramNodeId": "6bb72882-9525-4207-88b9-9573f7a6b654",
+					"simStepLabel": "JSON Output Flow: Transmit Configured JSON Printer",
+					"simStepDescription": "The newly created `JSON` printer instance is passed to the main search execution logic.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "210",
+						"endLine": "213",
+						"relevantVariables": [
+							"Printer",
+							"JSON"
+						]
+					},
+					"inputDataExample": "{\"Printer\": \"JSON\"}",
+					"outputDataExample": "{\"Printer\": \"JSON\"}"
+				},
+				{
+					"simStepId": "081da804-e09a-472d-b815-dae4ad93407a",
+					"diagramNodeId": "9078ceb1-5c41-402c-867a-d9960eb41e6e",
+					"simStepLabel": "JSON Output Flow: Execute Search and Sink to JSON Printer",
+					"simStepDescription": "The `Searcher` finds matches and context lines, then calls the `matched` or `context` methods on the `JSONSink`. The sink is responsible for converting these search events into JSON objects.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/json.rs",
+						"startLine": "722",
+						"endLine": "785",
+						"relevantVariables": [
+							"JSONSink",
+							"matched",
+							"context"
+						]
+					},
+					"inputDataExample": "{\"haystack\": \"...Doctor Watson...\", \"matcher\": \"Watson\"}",
+					"outputDataExample": "{\"SinkMatch\": {\"line_number\": 5, \"bytes\": \"but Doctor Watson has to have it taken out for him and dusted,\\n\"}}"
+				},
+				{
+					"simStepId": "eefd4073-c00d-49d2-96ce-793146d1a1ce",
+					"diagramNodeId": "605d4cc4-7749-425e-8ba5-e12c6b23d1a3",
+					"simStepLabel": "JSON Output Flow: Transmit Match and Context Data",
+					"simStepDescription": "The `SinkMatch` and `SinkContext` objects, containing raw data about search results, are passed from the searcher to the `JSONSink`.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/sink.rs",
+						"startLine": "126",
+						"endLine": "132",
+						"relevantVariables": [
+							"Sink",
+							"matched",
+							"SinkMatch"
+						]
+					},
+					"inputDataExample": "{\"SinkMatch\": {\"line_number\": 5, \"absolute_byte_offset\": 258, \"bytes\": \"but Doctor Watson has to have it taken out for him and dusted,\\n\"}}",
+					"outputDataExample": "{\"SinkMatch\": {\"line_number\": 5, \"absolute_byte_offset\": 258, \"bytes\": \"but Doctor Watson has to have it taken out for him and dusted,\\n\"}}"
+				},
+				{
+					"simStepId": "d4b5b12e-dfcb-4663-9015-fe99a6c72b8a",
+					"diagramNodeId": "b0962b62-8b3f-4dae-a197-aed83fe5a827",
+					"simStepLabel": "JSON Output Flow: Construct and Serialize JSON Messages",
+					"simStepDescription": "The `JSONSink` receives the search result data and constructs structured message objects (`begin`, `match`, `context`, `end`). These objects contain details like file paths, line numbers, match offsets, and the text content (base64 encoded if not valid UTF-8). Each message is then serialized into a JSON string.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/jsont.rs",
+						"startLine": "11",
+						"endLine": "44",
+						"relevantVariables": [
+							"Message",
+							"Begin",
+							"End",
+							"Match",
+							"Context"
+						]
+					},
+					"inputDataExample": "{\"SinkMatch\": {\"line_number\": 5, \"absolute_byte_offset\": 258, \"bytes\": \"but Doctor Watson has to have it taken out for him and dusted,\\n\"}}",
+					"outputDataExample": "{\"type\":\"match\",\"data\":{\"path\":{\"text\":\"sherlock.txt\"},\"lines\":{\"text\":\"but Doctor Watson has to have it taken out for him and dusted,\\n\"},\"line_number\":5,\"absolute_offset\":258,\"submatches\":[{\"match\":{\"text\":\"Watson\"},\"start\":11,\"end\":17}]}}"
+				},
+				{
+					"simStepId": "0f6f0c11-7dac-4a15-88fe-ec4442ebe476",
+					"diagramNodeId": "",
+					"simStepLabel": "JSON Output Flow: Write JSON Lines to stdout",
+					"simStepDescription": "Each serialized JSON message string is written to the standard output stream, followed by a newline character. This creates the JSON Lines format, which is ideal for streaming and processing by other tools.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/json.rs",
+						"startLine": "548",
+						"endLine": "560",
+						"relevantVariables": [
+							"write_message",
+							"json::to_writer",
+							"wtr"
+						]
+					},
+					"inputDataExample": "{\"json_string\": \"{\\\"type\\\":\\\"match\\\", ... }\\n\"}",
+					"outputDataExample": "{\"json_string\": \"{\\\"type\\\":\\\"match\\\", ... }\\n\"}"
+				}
+			],
+			"description": "<ul><li>Display contextual lines around matches using <code>-A</code> (after), <code>-B</code> (before), and <code>-C</code> (context)</li><li>Show line numbers (<code>-n</code>), column numbers (<code>--column</code>), and byte offsets (<code>-b</code>)</li><li>Provides rich, customizable color highlighting for file paths, line numbers, and matched text</li><li>Offers a machine-readable JSON Lines output format (<code>--json</code>) for easy integration with other tools and scripts</li></ul>",
+			"simulationNodesAndEdges": {
+				"8e2b5abc-ba17-4126-8196-2d863574dd03": {
+					"simStepIds": [
+						"a234a4fc-6910-49ab-9692-3629e7029a19"
+					]
+				},
+				"8a7a07f1-7758-4c90-9a3b-f49dc60d12f1": {
+					"simStepIds": [
+						"3e717203-9460-44e7-835e-49cd8340dbc6"
+					]
+				},
+				"7d6a3f10-0382-4eaa-8a62-e3492e6000c2": {
+					"simStepIds": [
+						"127bdb74-45b0-4569-b7be-89b9b808c24b"
+					]
+				},
+				"b7e5cc9d-83e0-44e5-bcd8-0f7886685f38": {
+					"simStepIds": [
+						"89d044cb-ba97-423b-b877-e022fd3aadc5"
+					]
+				},
+				"dc9f30d5-6599-4494-867c-a5f5726f7aa2": {
+					"simStepIds": [
+						"b94bbc3b-921b-4dcf-8678-da515f9752ad"
+					]
+				},
+				"aedf481e-7a26-4f1a-8f80-e270d31af954": {
+					"simStepIds": [
+						"f9ec9573-13f1-41ea-8286-d86c8bb66a3f"
+					]
+				},
+				"9078ceb1-5c41-402c-867a-d9960eb41e6e": {
+					"simStepIds": [
+						"081da804-e09a-472d-b815-dae4ad93407a"
+					]
+				},
+				"b0962b62-8b3f-4dae-a197-aed83fe5a827": {
+					"simStepIds": [
+						"d4b5b12e-dfcb-4663-9015-fe99a6c72b8a"
+					]
+				},
+				"66e9ca05-7027-45f5-a953-d9fa1ff7f1a0": {
+					"simStepIds": [
+						"a17d799e-12b0-470a-8e98-5ec9ed6bd1b3"
+					]
+				},
+				"3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a": {
+					"simStepIds": [
+						"73c3f672-dfe3-460c-905d-c6bd9eddbd55"
+					]
+				},
+				"262b607f-db42-4642-91b9-abd5a1108374": {
+					"simStepIds": [
+						"35e70e93-56f9-4ae9-a4e0-d4eb08246f4b"
+					]
+				},
+				"81663818-d2d6-4cfe-8a71-7b37237f7f95": {
+					"simStepIds": [
+						"15986b7a-0256-4f61-97b4-61e8c654b7e4"
+					]
+				},
+				"b054dd02-8e6a-4e42-be4a-7e082e6187d9": {
+					"simStepIds": [
+						"60bc2812-8cec-4cf7-888d-7566c874c9dd"
+					]
+				},
+				"6bb72882-9525-4207-88b9-9573f7a6b654": {
+					"simStepIds": [
+						"a46b12aa-0542-4121-b024-209610723a23"
+					]
+				},
+				"605d4cc4-7749-425e-8ba5-e12c6b23d1a3": {
+					"simStepIds": [
+						"eefd4073-c00d-49d2-96ce-793146d1a1ce"
+					]
+				}
+			},
+			"isAIGenerated": true,
+			"keywords": "Standard, JSON, context",
+			"generationPrompt": "Customize search result presentation with context, line/column numbers, color, and JSON output.",
+			"generationKeywords": "Standard, JSON, context"
+		},
+		"Use the powerful PCRE2 regex engine for patterns with look-around and backreferences.": {
+			"name": "Use the powerful PCRE2 regex engine for patterns with look-around and backreferences.",
+			"simSteps": [
+				{
+					"simStepId": "2d298238-6bc9-4690-a137-78749b0e824e",
+					"diagramNodeId": "6825dcae-96a0-412f-ab1b-8e65b339933d",
+					"simStepLabel": "Parse PCRE2 Command-Line Flag",
+					"simStepDescription": "The user invokes `ripgrep` with the `-P` or `--pcre2` flag to explicitly enable the PCRE2 regex engine. The argument parsing logic recognizes this flag and sets the engine choice configuration to `PCRE2`. This step is the entry point for using advanced regex features like look-around and backreferences.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/defs.rs",
+						"startLine": "5381",
+						"endLine": "5387",
+						"relevantVariables": [
+							"PCRE2",
+							"Flag::update",
+							"args.engine",
+							"EngineChoice::PCRE2"
+						]
+					},
+					"inputDataExample": "{\"args\": [\"rg\", \"-P\", \"(?<=\\\\w)\\\\d+\"]}",
+					"outputDataExample": "{\"engine_choice\": \"PCRE2\"}"
+				},
+				{
+					"simStepId": "c48cab01-3dac-4912-ba64-6cc02c44dd4f",
+					"diagramNodeId": "030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d",
+					"simStepLabel": "Engine Choice Configuration Passed",
+					"simStepDescription": "The parsed configuration, indicating that the PCRE2 engine has been selected, is passed to the part of the application responsible for building the regex matcher.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/defs.rs",
+						"startLine": "5382",
+						"endLine": "5385",
+						"relevantVariables": [
+							"args.engine",
+							"EngineChoice::PCRE2"
+						]
+					},
+					"inputDataExample": "{\"engine_choice\": \"PCRE2\", \"patterns\": [\"(?<=\\\\w)\\\\d+\"], \"case_mode\": \"Sensitive\"}",
+					"outputDataExample": "{\"engine_choice\": \"PCRE2\", \"patterns\": [\"(?<=\\\\w)\\\\d+\"], \"case_mode\": \"Sensitive\"}"
+				},
+				{
+					"simStepId": "74c81953-d698-4cf4-8ed6-8324c078e7ff",
+					"diagramNodeId": "019eb844-4613-490c-9b1a-5743aa71aeb4",
+					"simStepLabel": "Select PCRE2 Regex Matcher",
+					"simStepDescription": "Based on the `EngineChoice::PCRE2` configuration, the application logic selects the PCRE2 matcher builder. If the user had specified `--engine=auto` or `--auto-hybrid-regex`, this step would first attempt to use the default engine and then fall back to PCRE2 if the pattern compilation failed (e.g., due to unsupported features like look-around).",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "370",
+						"endLine": "380",
+						"relevantVariables": [
+							"HiArgs::matcher",
+							"self.args.engine",
+							"EngineChoice::PCRE2",
+							"self.matcher_pcre2()"
+						]
+					},
+					"inputDataExample": "{\"engine_choice\": \"PCRE2\"}",
+					"outputDataExample": "{\"selected_matcher_builder\": \"PCRE2\"}"
+				},
+				{
+					"simStepId": "9dd7d4c1-48f3-446f-bf14-16a43e174654",
+					"diagramNodeId": "85dfd805-df63-4482-a789-93fa055a046c",
+					"simStepLabel": "Invoke PCRE2 Matcher Builder",
+					"simStepDescription": "The application invokes the builder for the PCRE2 matcher, passing along the regex patterns and other configuration options such as case sensitivity and whether to enable the Just-In-Time (JIT) compiler for performance.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "374",
+						"endLine": "374",
+						"relevantVariables": [
+							"self.matcher_pcre2()"
+						]
+					},
+					"inputDataExample": "{\"patterns\": [\"(?<=\\\\w)\\\\d+\"], \"fixed_strings\": false, \"case_mode\": \"Sensitive\", \"jit_if_available\": true}",
+					"outputDataExample": "{\"patterns\": [\"(?<=\\\\w)\\\\d+\"], \"fixed_strings\": false, \"case_mode\": \"Sensitive\", \"jit_if_available\": true}"
+				},
+				{
+					"simStepId": "54b70a6d-b1ee-42e1-87f2-ac6a947ac7cc",
+					"diagramNodeId": "c2791749-9b9a-4275-990a-a2c2319735f9",
+					"simStepLabel": "Build PCRE2 Matcher",
+					"simStepDescription": "The PCRE2 matcher builder compiles the given regex pattern. This involves using the `grep-pcre2` crate, which in turn calls the underlying PCRE2 C library. If the `pcre2` feature was not compiled into `ripgrep`, this step will fail. JIT compilation is enabled if available to speed up matching.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "405",
+						"endLine": "454",
+						"relevantVariables": [
+							"HiArgs::matcher_pcre2",
+							"grep::pcre2::RegexMatcherBuilder",
+							"builder.jit_if_available",
+							"builder.build_many",
+							"PatternMatcher::PCRE2"
+						]
+					},
+					"inputDataExample": "{\"patterns\": [\"(?<=\\\\w)\\\\d+\"]}",
+					"outputDataExample": "{\"matcher_object\": \"PatternMatcher::PCRE2(grep::pcre2::RegexMatcher)\"}"
+				},
+				{
+					"simStepId": "06fef420-4852-48e4-bc61-08ec1c756d79",
+					"diagramNodeId": "94bf3581-9419-46ea-9a55-94598c438500",
+					"simStepLabel": "Compiled PCRE2 Matcher Passed to Searcher",
+					"simStepDescription": "The successfully compiled PCRE2 matcher object is encapsulated in the `PatternMatcher` enum and passed to the search worker, which will use it to execute the search.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "442",
+						"endLine": "443",
+						"relevantVariables": [
+							"m",
+							"PatternMatcher::PCRE2(m)"
+						]
+					},
+					"inputDataExample": "{\"matcher_object\": \"PatternMatcher::PCRE2(grep::pcre2::RegexMatcher)\"}",
+					"outputDataExample": "{\"matcher_object\": \"PatternMatcher::PCRE2(grep::pcre2::RegexMatcher)\"}"
+				},
+				{
+					"simStepId": "7151f213-e403-4b2d-ad9f-112e4d69af4e",
+					"diagramNodeId": "1c3b00d3-1533-4f77-855a-0a5ae9d0abd1",
+					"simStepLabel": "Execute Search with PCRE2 Matcher",
+					"simStepDescription": "The search worker receives the `PatternMatcher::PCRE2` instance. It then reads the target files and uses the PCRE2 matcher's methods to find lines that match the pattern, including patterns with look-around or backreferences.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "341",
+						"endLine": "350",
+						"relevantVariables": [
+							"Worker::search_path",
+							"self.matcher",
+							"PatternMatcher::PCRE2",
+							"search_path"
+						]
+					},
+					"inputDataExample": "{\"matcher\": \"PatternMatcher::PCRE2(...)\", \"file_path\": \"/path/to/file.log\", \"file_content\": \"error C42: failed\"}",
+					"outputDataExample": "{\"match_result\": {\"path\": \"/path/to/file.log\", \"line_number\": 1, \"line\": \"error C42: failed\", \"matches\": [{\"start\": 8, \"end\": 10}]}}"
+				}
+			],
+			"description": "<ul><li>Opt-in to using the PCRE2 regex engine with the <code>-P</code>/<code>--pcre2</code> flag</li><li>Enables support for advanced regex features not available in the default engine, such as look-around (<code>(?<=</li><li>)</code>) and backreferences (<code>\\1</code>)</li><li>Can automatically switch to PCRE2 only when a pattern requires it using <code>--auto-hybrid-regex</code></li></ul>",
+			"simulationNodesAndEdges": {
+				"6825dcae-96a0-412f-ab1b-8e65b339933d": {
+					"simStepIds": [
+						"2d298238-6bc9-4690-a137-78749b0e824e"
+					]
+				},
+				"019eb844-4613-490c-9b1a-5743aa71aeb4": {
+					"simStepIds": [
+						"74c81953-d698-4cf4-8ed6-8324c078e7ff"
+					]
+				},
+				"c2791749-9b9a-4275-990a-a2c2319735f9": {
+					"simStepIds": [
+						"54b70a6d-b1ee-42e1-87f2-ac6a947ac7cc"
+					]
+				},
+				"1c3b00d3-1533-4f77-855a-0a5ae9d0abd1": {
+					"simStepIds": [
+						"7151f213-e403-4b2d-ad9f-112e4d69af4e"
+					]
+				},
+				"030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d": {
+					"simStepIds": [
+						"c48cab01-3dac-4912-ba64-6cc02c44dd4f"
+					]
+				},
+				"85dfd805-df63-4482-a789-93fa055a046c": {
+					"simStepIds": [
+						"9dd7d4c1-48f3-446f-bf14-16a43e174654"
+					]
+				},
+				"94bf3581-9419-46ea-9a55-94598c438500": {
+					"simStepIds": [
+						"06fef420-4852-48e4-bc61-08ec1c756d79"
+					]
+				}
+			},
+			"isAIGenerated": true,
+			"keywords": "pcre2, auto-hybrid-regex, fancy",
+			"generationPrompt": "Use the powerful PCRE2 regex engine for patterns with look-around and backreferences.",
+			"generationKeywords": "pcre2, auto-hybrid-regex, fancy"
+		},
+		"Transparently search inside compressed files without manual decompression.": {
+			"name": "Transparently search inside compressed files without manual decompression.",
+			"simSteps": [
+				{
+					"simStepId": "028f086b-a018-4564-82a0-7069685c5fe6",
+					"diagramNodeId": "b5bf4086-9be8-40aa-a51f-b67c6f172778",
+					"simStepLabel": "Parse '--search-zip' Flag",
+					"simStepDescription": "The command-line argument parser processes the input flags provided by the user. When '-z' or '--search-zip' is detected, it updates the internal arguments configuration to enable searching within compressed files.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/defs.rs",
+						"startLine": "6097",
+						"endLine": "6103",
+						"relevantVariables": [
+							"v",
+							"args",
+							"args.search_zip",
+							"args.pre"
+						]
+					},
+					"inputDataExample": "{\"command_line_args\": [\"rg\", \"-z\", \"error\", \"/var/log\"]}",
+					"outputDataExample": "{\"parsed_args\": {\"search_zip\": true, \"pre\": null}}"
+				},
+				{
+					"simStepId": "6703644c-54a4-44ac-9a0f-9e491ae74fb8",
+					"diagramNodeId": "acb6f4f0-b4fe-475e-9f15-96bff8ad5f13",
+					"simStepLabel": "Transmit Low-Level Arguments",
+					"simStepDescription": "The raw parsed argument, a boolean flag indicating `search_zip` is enabled, is stored in the `LowArgs` struct, which represents the initial, unprocessed configuration.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/lowargs.rs",
+						"startLine": "100",
+						"endLine": "100",
+						"relevantVariables": [
+							"search_zip"
+						]
+					},
+					"inputDataExample": "{\"LowArgs\": {\"search_zip\": true}}",
+					"outputDataExample": "{\"LowArgs\": {\"search_zip\": true}}"
+				},
+				{
+					"simStepId": "978bc900-d4de-4d46-a790-971e589fa824",
+					"diagramNodeId": "3e247a17-fe8e-4353-bc30-5ea6711f2d85",
+					"simStepLabel": "Build High-Level Arguments",
+					"simStepDescription": "The `LowArgs` struct is transformed into a `HiArgs` struct. This conversion process consolidates and refines the arguments into a more structured format, carrying over the `search_zip` setting.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "310",
+						"endLine": "310",
+						"relevantVariables": [
+							"low.search_zip"
+						]
+					},
+					"inputDataExample": "{\"LowArgs\": {\"search_zip\": true}}",
+					"outputDataExample": "{\"HiArgs\": {\"search_zip\": true}}"
+				},
+				{
+					"simStepId": "5dfb2af4-d179-418b-ba1a-b3b4057951a7",
+					"diagramNodeId": "57f135d9-c844-4467-9dce-d84057fd5869",
+					"simStepLabel": "Pass Config to Search Worker Builder",
+					"simStepDescription": "The `search_zip` flag from the high-level arguments is passed to the `SearchWorkerBuilder` to configure the search process.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "701",
+						"endLine": "701",
+						"relevantVariables": [
+							"self.search_zip",
+							"builder.search_zip"
+						]
+					},
+					"inputDataExample": "{\"search_zip_flag\": true}",
+					"outputDataExample": "{\"search_zip_flag\": true}"
+				},
+				{
+					"simStepId": "b53b5e9f-939c-4ee5-a88c-437397bbe57f",
+					"diagramNodeId": "cadc0775-86e8-4e88-bd26-61f174b086eb",
+					"simStepLabel": "Configure Search Worker for Decompression",
+					"simStepDescription": "The `SearchWorkerBuilder` receives the `search_zip` flag and stores it in its internal configuration. This builder is also initialized with a `DecompressionReaderBuilder` that contains default rules for matching compressed file types (e.g., *.gz, *.bz2).",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "127",
+						"endLine": "134",
+						"relevantVariables": [
+							"self",
+							"yes",
+							"self.config.search_zip"
+						]
+					},
+					"inputDataExample": "{\"yes\": true}",
+					"outputDataExample": "{\"SearchWorkerBuilder.config\": {\"search_zip\": true}}"
+				},
+				{
+					"simStepId": "cb703e0d-2a54-42ed-93b9-0648e42f39e2",
+					"diagramNodeId": "a5c04342-f30c-4b03-88ef-fd5d5cc6dec5",
+					"simStepLabel": "Transmit File Path for Decompression Check",
+					"simStepDescription": "As the directory walker finds files, each file path is sent to the search worker to determine how it should be handled. Here, a compressed log file is identified.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "275",
+						"endLine": "275",
+						"relevantVariables": [
+							"path"
+						]
+					},
+					"inputDataExample": "{\"path\": \"/var/log/nginx/access.log.1.gz\"}",
+					"outputDataExample": "{\"path\": \"/var/log/nginx/access.log.1.gz\"}"
+				},
+				{
+					"simStepId": "bbe67bc0-80ec-4573-af90-99a3044945be",
+					"diagramNodeId": "36ea22a2-80cb-4c97-b055-b14052750de7",
+					"simStepLabel": "Check if Decompression is Needed",
+					"simStepDescription": "The search worker's `should_decompress` method checks two conditions: 1) if the `search_zip` config is enabled, and 2) if the file path matches a known decompression rule (e.g., ends with '.gz'). Both are true, so it decides to decompress.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "275",
+						"endLine": "280",
+						"relevantVariables": [
+							"self",
+							"path",
+							"self.config.search_zip",
+							"self.decomp_builder.get_matcher()"
+						]
+					},
+					"inputDataExample": "{\"path\": \"/var/log/nginx/access.log.1.gz\", \"config\": {\"search_zip\": true}}",
+					"outputDataExample": "{\"should_decompress\": true}"
+				},
+				{
+					"simStepId": "9d428183-5928-4541-bff7-2f3399eb9f9d",
+					"diagramNodeId": "a2c78834-0693-40f4-91ad-076a6600ec8e",
+					"simStepLabel": "Request Decompressed Stream",
+					"simStepDescription": "Based on the positive check, the file path is passed to the `DecompressionReaderBuilder` to construct a reader that will provide the decompressed file content.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/cli/src/decompress.rs",
+						"startLine": "221",
+						"endLine": "224",
+						"relevantVariables": [
+							"path"
+						]
+					},
+					"inputDataExample": "{\"path\": \"/var/log/nginx/access.log.1.gz\"}",
+					"outputDataExample": "{\"path\": \"/var/log/nginx/access.log.1.gz\"}"
+				},
+				{
+					"simStepId": "8e6d5c6c-f294-4dae-901e-1f74837d5791",
+					"diagramNodeId": "626197b8-ae20-4c15-9110-5e97703d7612",
+					"simStepLabel": "Create Decompression Process",
+					"simStepDescription": "The `DecompressionReaderBuilder` finds the command associated with the '.gz' extension (e.g., 'gzip'), spawns it as a child process (`gzip -d -c /path/to/file`), and creates a `DecompressionReader` that reads from the child process's standard output.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/cli/src/decompress.rs",
+						"startLine": "221",
+						"endLine": "245",
+						"relevantVariables": [
+							"path",
+							"cmd",
+							"self.matcher",
+							"self.command_builder",
+							"DecompressionReader"
+						]
+					},
+					"inputDataExample": "{\"path\": \"/var/log/nginx/access.log.1.gz\"}",
+					"outputDataExample": "{\"DecompressionReader\": {\"rdr\": \"Ok(CommandReader)\"}, \"spawned_command\": \"gzip -d -c /var/log/nginx/access.log.1.gz\"}"
+				},
+				{
+					"simStepId": "3c0c4cad-0e48-4247-be8a-6c45e41015bf",
+					"diagramNodeId": "e5d149ac-77cd-44b7-adaf-e71df369fe88",
+					"simStepLabel": "Return Reader Interface",
+					"simStepDescription": "The newly created `DecompressionReader` is returned to the main searcher. This object conforms to the standard `io::Read` trait, abstracting away the fact that data is coming from a separate process rather than directly from a file.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/cli/src/decompress.rs",
+						"startLine": "388",
+						"endLine": "388",
+						"relevantVariables": [
+							"DecompressionReader"
+						]
+					},
+					"inputDataExample": "{\"DecompressionReader\": \"<reader_object>\"}",
+					"outputDataExample": "{\"DecompressionReader\": \"<reader_object>\"}"
+				},
+				{
+					"simStepId": "d8c3b0bc-3ff0-4aee-bf11-5653be83ea9b",
+					"diagramNodeId": "88dd5a3a-40c2-43e3-ac59-ec2e806c3825",
+					"simStepLabel": "Search Decompressed Stream",
+					"simStepDescription": "The core search logic reads data chunk by chunk from the `DecompressionReader`. It is completely unaware of the underlying decompression; it simply receives plain text data from the `read` method and applies the regex pattern to find matches.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/cli/src/decompress.rs",
+						"startLine": "389",
+						"endLine": "395",
+						"relevantVariables": [
+							"self.rdr",
+							"buf",
+							"rdr.read(buf)"
+						]
+					},
+					"inputDataExample": "{\"pattern\": \"HTTP/1.1\\\" 500\"}",
+					"outputDataExample": "{\"match_found\": {\"line\": \"127.0.0.1 - - [10/Oct/2023:10:00:00 +0000] \\\"POST /login HTTP/1.1\\\" 500 20\\n\"}}"
+				}
+			],
+			"description": "<ul><li>When the <code>-z</code>/<code>--search-zip</code> flag is used, <code>ripgrep</code> automatically decompresses and searches files with common extensions like <code></li><li>gz</code>, <code></li><li>bz2</code>, <code></li><li>xz</code>, <code></li><li>lz4</code>, <code></li><li>zst</code></li><li>This feature works by shelling out to the corresponding command-line decompression tools (e</li><li>g</li><li>, <code>gzip</code>, <code>xz</code>)</li><li>Provides a seamless experience for searching through compressed log files or archives</li></ul>",
+			"simulationNodesAndEdges": {
+				"b5bf4086-9be8-40aa-a51f-b67c6f172778": {
+					"simStepIds": [
+						"028f086b-a018-4564-82a0-7069685c5fe6"
+					]
+				},
+				"3e247a17-fe8e-4353-bc30-5ea6711f2d85": {
+					"simStepIds": [
+						"978bc900-d4de-4d46-a790-971e589fa824"
+					]
+				},
+				"cadc0775-86e8-4e88-bd26-61f174b086eb": {
+					"simStepIds": [
+						"b53b5e9f-939c-4ee5-a88c-437397bbe57f"
+					]
+				},
+				"36ea22a2-80cb-4c97-b055-b14052750de7": {
+					"simStepIds": [
+						"bbe67bc0-80ec-4573-af90-99a3044945be"
+					]
+				},
+				"626197b8-ae20-4c15-9110-5e97703d7612": {
+					"simStepIds": [
+						"8e6d5c6c-f294-4dae-901e-1f74837d5791"
+					]
+				},
+				"88dd5a3a-40c2-43e3-ac59-ec2e806c3825": {
+					"simStepIds": [
+						"d8c3b0bc-3ff0-4aee-bf11-5653be83ea9b"
+					]
+				},
+				"acb6f4f0-b4fe-475e-9f15-96bff8ad5f13": {
+					"simStepIds": [
+						"6703644c-54a4-44ac-9a0f-9e491ae74fb8"
+					]
+				},
+				"57f135d9-c844-4467-9dce-d84057fd5869": {
+					"simStepIds": [
+						"5dfb2af4-d179-418b-ba1a-b3b4057951a7"
+					]
+				},
+				"a5c04342-f30c-4b03-88ef-fd5d5cc6dec5": {
+					"simStepIds": [
+						"cb703e0d-2a54-42ed-93b9-0648e42f39e2"
+					]
+				},
+				"a2c78834-0693-40f4-91ad-076a6600ec8e": {
+					"simStepIds": [
+						"9d428183-5928-4541-bff7-2f3399eb9f9d"
+					]
+				},
+				"e5d149ac-77cd-44b7-adaf-e71df369fe88": {
+					"simStepIds": [
+						"3c0c4cad-0e48-4247-be8a-6c45e41015bf"
+					]
+				}
+			},
+			"isAIGenerated": true,
+			"keywords": "search_zip, DecompressionReader, DecompressionMatcher",
+			"generationPrompt": "Transparently search inside compressed files without manual decompression.",
+			"generationKeywords": "search_zip, DecompressionReader, DecompressionMatcher"
+		},
+		"Find regex matches that span across multiple lines.": {
+			"name": "Find regex matches that span across multiple lines.",
+			"simSteps": [
+				{
+					"simStepId": "0548c99b-847a-422e-98ee-68d9d8e74274",
+					"diagramNodeId": "65e6f10c-354e-430e-8920-63ca301b13f6",
+					"simStepLabel": "Parse Multiline Flag",
+					"simStepDescription": "The application starts by parsing the command-line arguments. When the user provides `-U` or `--multiline`, the `Multiline` flag struct is processed. Its `update` method sets the `multiline` boolean to `true` in the `LowArgs` struct, which stores the initial parsed arguments. This also disables the `stop-on-nonmatch` feature, as it's incompatible with multiline searching.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/defs.rs",
+						"startLine": "4184",
+						"endLine": "4190",
+						"relevantVariables": [
+							"Multiline",
+							"update",
+							"args",
+							"v",
+							"args.multiline",
+							"args.stop_on_nonmatch"
+						]
+					},
+					"inputDataExample": "{\"argv\": [\"rg\", \"-U\", \"of this world.+detective work\", \"sherlock.txt\"]}",
+					"outputDataExample": "{\"LowArgs\": {\"multiline\": true, \"stop_on_nonmatch\": false, \"patterns\": [\"of this world.+detective work\"], \"paths\":[\"sherlock.txt\"]}}"
+				},
+				{
+					"simStepId": "73978832-90e0-47df-9c70-60f5ecf6dbcb",
+					"diagramNodeId": "bcc616ab-4fd0-4234-9d6c-9b29eda63456",
+					"simStepLabel": "Configuration Transfer",
+					"simStepDescription": "The parsed `LowArgs` are converted into a `HiArgs` struct, which represents a higher-level, validated configuration. The `multiline` and `multiline_dotall` boolean flags are directly copied over.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "288",
+						"endLine": "289",
+						"relevantVariables": [
+							"low.multiline",
+							"low.multiline_dotall"
+						]
+					},
+					"inputDataExample": "{\"LowArgs\": {\"multiline\": true, \"multiline_dotall\": false, \"patterns\": [\"...\"], \"paths\":[\"...\"]}}",
+					"outputDataExample": "{\"HiArgs\": {\"multiline\": true, \"multiline_dotall\": false, \"patterns\": [\"...\"], \"paths\":[\"...\"]}}"
+				},
+				{
+					"simStepId": "f93bf41d-9482-4e31-8513-5f150b8839e1",
+					"diagramNodeId": "a03b1238-c735-4679-a3e8-782afc9e93e0",
+					"simStepLabel": "Configure Regex Engine",
+					"simStepDescription": "Based on the `HiArgs` configuration, the regex engine builder is configured. If `multiline` is true, it sets options to allow patterns to match across line terminators. Specifically, `dot_matches_new_line` is enabled if `multiline_dotall` is also true, and the default line terminator is removed, allowing patterns like `\\n` to match.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "478",
+						"endLine": "482",
+						"relevantVariables": [
+							"self.multiline",
+							"self.multiline_dotall",
+							"builder.dot_matches_new_line",
+							"builder.crlf",
+							"builder.line_terminator"
+						]
+					},
+					"inputDataExample": "{\"HiArgs\": {\"multiline\": true, \"multiline_dotall\": true, \"crlf\": false}}",
+					"outputDataExample": "{\"RegexBuilderConfig\": {\"dot_matches_new_line\": true, \"line_terminator\": null, \"crlf\": true}}"
+				},
+				{
+					"simStepId": "d0d166ef-3aad-4ea4-8186-939165e650d1",
+					"diagramNodeId": "8e2520f4-89df-4244-9f53-91795625ca10",
+					"simStepLabel": "Matcher Sent to Searcher",
+					"simStepDescription": "The fully configured `RegexMatcher` object is passed to the `Searcher` to perform the search operation.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/mod.rs",
+						"startLine": "786",
+						"endLine": "786",
+						"relevantVariables": [
+							"self.search_reader",
+							"matcher"
+						]
+					},
+					"inputDataExample": "{\"matcher\": \"Object<RegexMatcher>\"}",
+					"outputDataExample": "{\"matcher\": \"Object<RegexMatcher>\"}"
+				},
+				{
+					"simStepId": "cc78378e-da78-43a0-926d-0c40f5ca294d",
+					"diagramNodeId": "d77e8ea1-2850-488f-af80-6417c53c8099",
+					"simStepLabel": "Select Multiline Search Strategy",
+					"simStepDescription": "The `Searcher` checks if the provided matcher requires multiline support. Since the `-U` flag was used, `multi_line_with_matcher` returns true. This triggers the searcher to read the entire file's contents into an in-memory buffer (`multi_line_buffer`) before starting the search, as matches can span arbitrary lines and cannot be processed incrementally.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/mod.rs",
+						"startLine": "700",
+						"endLine": "707",
+						"relevantVariables": [
+							"self.multi_line_with_matcher",
+							"self.fill_multi_line_buffer_from_file",
+							"MultiLine::new",
+							"self.multi_line_buffer"
+						]
+					},
+					"inputDataExample": "{\"matcher\": \"Object<RegexMatcher>\", \"path\": \"sherlock.txt\"}",
+					"outputDataExample": "{\"decision\": \"Use MultiLine strategy\", \"buffer_status\": \"File content loaded to heap\"}"
+				},
+				{
+					"simStepId": "351fecf5-1670-436c-abcc-5460f7ad0bbf",
+					"diagramNodeId": "0a935202-428b-429e-a4c4-b1dd464e4bda",
+					"simStepLabel": "Buffer Passed to MultiLine Searcher",
+					"simStepDescription": "The complete file content, now in `multi_line_buffer`, is passed as a byte slice to the `MultiLine` search implementation.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/glue.rs",
+						"startLine": "153",
+						"endLine": "155",
+						"relevantVariables": [
+							"MultiLine::new",
+							"slice"
+						]
+					},
+					"inputDataExample": "{\"multi_line_buffer\": \"For the Doctor Watsons of this world, as opposed to the Sherlock\\nHolmeses, success...\"}",
+					"outputDataExample": "{\"multi_line_buffer\": \"For the Doctor Watsons of this world, as opposed to the Sherlock\\nHolmeses, success...\"}"
+				},
+				{
+					"simStepId": "a0a4371e-e74e-4fa4-b643-6f351759a477",
+					"diagramNodeId": "b8833d1c-74e5-4db9-9775-056216d25c47",
+					"simStepLabel": "Execute Search on Buffer",
+					"simStepDescription": "The `MultiLine` searcher executes the regex against the entire in-memory byte slice. It finds all non-overlapping matches. For each match, it determines the start and end byte offsets and sends this information to the designated `Sink` for processing.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/glue.rs",
+						"startLine": "146",
+						"endLine": "162",
+						"relevantVariables": [
+							"MultiLine",
+							"Core",
+							"searcher.multi_line_with_matcher"
+						]
+					},
+					"inputDataExample": "{\"slice\": \"...For the Doctor Watsons...\", \"matcher\": \"Object<RegexMatcher>\"}",
+					"outputDataExample": "{\"SinkMatch\": {\"bytes\": \"...\", \"absolute_byte_offset\": 62, \"lines\": \"...\", \"original_match\": {\"start\": 45, \"end\": 115}}}"
+				},
+				{
+					"simStepId": "00c8ea3d-7f7f-46d3-b700-5ee54ccb6c18",
+					"diagramNodeId": "7f305131-1f1e-4245-8dd4-d27e022f994a",
+					"simStepLabel": "Matches Sent to Sink",
+					"simStepDescription": "The raw match data, including the byte slice of the match and its context, is sent from the `MultiLine` searcher's `Core` component to the `Sink` implementation, which is typically the `Standard` printer.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/core.rs",
+						"startLine": "9",
+						"endLine": "11",
+						"relevantVariables": [
+							"Sink",
+							"SinkMatch",
+							"SinkContext"
+						]
+					},
+					"inputDataExample": "{\"SinkMatch\": {\"bytes\": \"of this world, as opposed to the Sherlock\\nHolmeses, success in the province of detective work\", \"absolute_byte_offset\": 62, \"lines\": \"2-4\"}}",
+					"outputDataExample": "{\"SinkMatch\": {\"bytes\": \"of this world, as opposed to the Sherlock\\nHolmeses, success in the province of detective work\", \"absolute_byte_offset\": 62, \"lines\": \"2-4\"}}"
+				},
+				{
+					"simStepId": "30500bdd-89dc-4b27-917c-7c554ca5ec5a",
+					"diagramNodeId": "1f3ae57d-ae3d-4633-be82-877091353aa6",
+					"simStepLabel": "Format and Print Match",
+					"simStepDescription": "The `Standard` printer receives the `SinkMatch`. Because the match can span multiple lines, it uses a `LineStep` iterator to break the matched byte slice into individual lines. It then prints each line, prepending the line number and applying any relevant coloring or formatting.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "1044",
+						"endLine": "1049",
+						"relevantVariables": [
+							"stepper",
+							"LineStep",
+							"stepper.next",
+							"self.write_prelude",
+							"self.write_line"
+						]
+					},
+					"inputDataExample": "{\"SinkMatch\": {\"bytes\": \"of this world, as opposed to the Sherlock\\nHolmeses, success in the province of detective work\", \"absolute_byte_offset\": 62}}",
+					"outputDataExample": "{\"stdout\": \"2:of this world, as opposed to the Sherlock\\n3:Holmeses, success in the province of detective work\\n\"}"
+				}
+			],
+			"description": "<ul><li>The <code>-U</code>/<code>--multiline</code> flag enables a search mode where matches can begin on one line and end on a subsequent line</li><li>Crucial for searching for patterns in code, stack traces, or structured text that spans multiple lines</li><li>Can be combined with <code>--multiline-dotall</code> to allow <code></li><li></code> to match newline characters</li></ul>",
+			"simulationNodesAndEdges": {
+				"65e6f10c-354e-430e-8920-63ca301b13f6": {
+					"simStepIds": [
+						"0548c99b-847a-422e-98ee-68d9d8e74274"
+					]
+				},
+				"a03b1238-c735-4679-a3e8-782afc9e93e0": {
+					"simStepIds": [
+						"f93bf41d-9482-4e31-8513-5f150b8839e1"
+					]
+				},
+				"d77e8ea1-2850-488f-af80-6417c53c8099": {
+					"simStepIds": [
+						"cc78378e-da78-43a0-926d-0c40f5ca294d"
+					]
+				},
+				"b8833d1c-74e5-4db9-9775-056216d25c47": {
+					"simStepIds": [
+						"a0a4371e-e74e-4fa4-b643-6f351759a477"
+					]
+				},
+				"1f3ae57d-ae3d-4633-be82-877091353aa6": {
+					"simStepIds": [
+						"30500bdd-89dc-4b27-917c-7c554ca5ec5a"
+					]
+				},
+				"bcc616ab-4fd0-4234-9d6c-9b29eda63456": {
+					"simStepIds": [
+						"73978832-90e0-47df-9c70-60f5ecf6dbcb"
+					]
+				},
+				"8e2520f4-89df-4244-9f53-91795625ca10": {
+					"simStepIds": [
+						"d0d166ef-3aad-4ea4-8186-939165e650d1"
+					]
+				},
+				"0a935202-428b-429e-a4c4-b1dd464e4bda": {
+					"simStepIds": [
+						"351fecf5-1670-436c-abcc-5460f7ad0bbf"
+					]
+				},
+				"7f305131-1f1e-4245-8dd4-d27e022f994a": {
+					"simStepIds": [
+						"00c8ea3d-7f7f-46d3-b700-5ee54ccb6c18"
+					]
+				}
+			},
+			"isAIGenerated": true,
+			"keywords": "multiline, LineStep, dotall",
+			"generationPrompt": "Find regex matches that span across multiple lines.",
+			"generationKeywords": "multiline, LineStep, dotall"
+		},
+		"Preview text replacements in the output based on regex matches and capture groups.": {
+			"name": "Preview text replacements in the output based on regex matches and capture groups.",
+			"simSteps": [
+				{
+					"simStepId": "6c3035dc-c539-474d-9d08-380371747982",
+					"diagramNodeId": "4fd8d6c1-cc49-4bfe-a852-ab24cffcf443",
+					"simStepLabel": "Parse '--replace' Argument",
+					"simStepDescription": "The application parses the command-line arguments, identifying the `-r` or `--replace` flag. The provided replacement string is captured and stored in the `LowArgs` structure for later use.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/defs.rs",
+						"startLine": "6029",
+						"endLine": "6032",
+						"relevantVariables": [
+							"Replace",
+							"update",
+							"args.replace"
+						]
+					},
+					"inputDataExample": "{\"argv\": [\"rg\", \"--replace\", \"Dr. $1\", \"Doctor (\\\\w+)\", \"sherlock.txt\"]}",
+					"outputDataExample": "{\"LowArgs\": {\"replace\": \"Dr. $1\"}}"
+				},
+				{
+					"simStepId": "2d10ae06-aecd-4480-8826-c036f9a2f1c9",
+					"diagramNodeId": "205c10d8-385d-45c1-9829-2e59c67b8005",
+					"simStepLabel": "Propagate Replacement Argument",
+					"simStepDescription": "The parsed replacement string is transferred from the `LowArgs` struct to the `HiArgs` struct during argument processing, making it available for configuring the output printer.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "309",
+						"endLine": "309",
+						"relevantVariables": [
+							"replace: low.replace"
+						]
+					},
+					"inputDataExample": "{\"low_args\": {\"replace\": \"Dr. $1\"}}",
+					"outputDataExample": "{\"low_args\": {\"replace\": \"Dr. $1\"}}"
+				},
+				{
+					"simStepId": "0d5fe06c-3899-4862-b2a7-dcbeb7d70e78",
+					"diagramNodeId": "d10772ea-5a19-4c72-ad04-754a0208a213",
+					"simStepLabel": "Configure Printer with Replacement Text",
+					"simStepDescription": "The `HiArgs` containing the replacement string are used to build a printer (e.g., `Standard` or `JSON`). The replacement text is passed to the printer's builder, which stores it in its configuration.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "624",
+						"endLine": "624",
+						"relevantVariables": [
+							"self.replace",
+							"replacement"
+						]
+					},
+					"inputDataExample": "{\"hi_args\": {\"replace\": \"Dr. $1\"}}",
+					"outputDataExample": "{\"StandardBuilder\": {\"config\": {\"replacement\": \"Dr. $1\"}}}"
+				},
+				{
+					"simStepId": "c2eae192-e8c3-413a-8c95-fda6e860e445",
+					"diagramNodeId": "ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02",
+					"simStepLabel": "Create Printer Sink",
+					"simStepDescription": "When a search begins, the configured printer creates a `Sink` (e.g., `StandardSink`). The sink is initialized with a `Replacer` instance, and the replacement configuration is passed along to it.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "558",
+						"endLine": "566",
+						"relevantVariables": [
+							"StandardSink",
+							"replacer: Replacer::new()"
+						]
+					},
+					"inputDataExample": "{\"config\": {\"replacement\": \"Dr. $1\"}}",
+					"outputDataExample": "{\"config\": {\"replacement\": \"Dr. $1\"}}"
+				},
+				{
+					"simStepId": "bfb926ff-af12-4d27-8b74-1b216918243c",
+					"diagramNodeId": "2897d065-bc9c-47a0-935d-58720d432394",
+					"simStepLabel": "Process Match and Initiate Replacement",
+					"simStepDescription": "The `Searcher` finds a match in a file and invokes the `matched` method on the `StandardSink`. This method then calls its internal `replace` helper function to begin the replacement process for the matched line.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "777",
+						"endLine": "777",
+						"relevantVariables": [
+							"self.replace",
+							"searcher",
+							"mat.buffer()",
+							"mat.bytes_range_in_buffer()"
+						]
+					},
+					"inputDataExample": "{\"SinkMatch\": {\"bytes\": \"For the Doctor Watsons of this world...\", \"match_range_in_buffer\": [123, 158]}}",
+					"outputDataExample": "{\"status\": \"Calling self.replace()\"}"
+				},
+				{
+					"simStepId": "50975416-4977-4580-a765-b51dfbe4b983",
+					"diagramNodeId": "da844bfb-d742-4ee0-af58-61cd861b9350",
+					"simStepLabel": "Send Match Data to Replacer",
+					"simStepDescription": "The `StandardSink::replace` method calls `replacer.replace_all`, passing the full line content (`haystack`), the range of matched text within the line, and the replacement pattern string.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "752",
+						"endLine": "758",
+						"relevantVariables": [
+							"self.replacer.replace_all",
+							"replacement"
+						]
+					},
+					"inputDataExample": "{\"haystack\": \"...Doctor Watsons...\", \"range\": {\"start\": 8, \"end\": 22}, \"replacement\": \"Dr. $1\"}",
+					"outputDataExample": "{\"haystack\": \"...Doctor Watsons...\", \"range\": {\"start\": 8, \"end\": 22}, \"replacement\": \"Dr. $1\"}"
+				},
+				{
+					"simStepId": "7e01b0f6-7c2f-4578-8bcd-e92dff0173d8",
+					"diagramNodeId": "6f4daaff-ddca-41f0-ad53-d48d290d885b",
+					"simStepLabel": "Perform Replacement via Interpolation",
+					"simStepDescription": "The `Replacer::replace_all` method orchestrates the replacement. It finds all matches and uses `caps.interpolate` to handle capture groups (like `$1`) in the replacement string, building the new text in a buffer.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/util.rs",
+						"startLine": "87",
+						"endLine": "102",
+						"relevantVariables": [
+							"replace_with_captures_in_context",
+							"caps.interpolate",
+							"dst",
+							"matches"
+						]
+					},
+					"inputDataExample": "{\"haystack\": \"Doctor Watsons\", \"replacement_pattern\": \"Dr. $1\", \"captures\": [\"Doctor Watsons\", \"Watsons\"]}",
+					"outputDataExample": "{\"dst_buffer\": \"Dr. Watsons\"}"
+				},
+				{
+					"simStepId": "ec97fde2-3851-40bf-be8a-598def3c9285",
+					"diagramNodeId": "5442b0ed-343b-41ed-b7fc-f5baf0e5991c",
+					"simStepLabel": "Pass Data to Core Interpolation Logic",
+					"simStepDescription": "The `Captures::interpolate` method is a wrapper that passes the replacement pattern, original text, capture group data, and destination buffer to the core `interpolate` function.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/matcher/src/lib.rs",
+						"startLine": "449",
+						"endLine": "455",
+						"relevantVariables": [
+							"interpolate"
+						]
+					},
+					"inputDataExample": "{\"replacement\": \"Dr. $1\", \"haystack\": \"Doctor Watsons\", \"captures\": [\"Doctor Watsons\", \"Watsons\"]}",
+					"outputDataExample": "{\"replacement\": \"Dr. $1\", \"haystack\": \"Doctor Watsons\", \"captures\": [\"Doctor Watsons\", \"Watsons\"]}"
+				},
+				{
+					"simStepId": "86be35a1-d0f0-424f-9f87-9f3e7e924ed7",
+					"diagramNodeId": "778e8bbe-678f-4a3c-8911-52fab94d475b",
+					"simStepLabel": "Substitute Capture Groups",
+					"simStepDescription": "The `interpolate` function parses the replacement string for `$` characters. It identifies capture group references (e.g., `$1`, `$name`), looks up the corresponding captured text from the match, and writes the substituted string into the destination buffer.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/matcher/src/interpolate.rs",
+						"startLine": "14",
+						"endLine": "57",
+						"relevantVariables": [
+							"interpolate",
+							"memchr",
+							"find_cap_ref",
+							"append",
+							"dst"
+						]
+					},
+					"inputDataExample": "{\"replacement_pattern\": \"Dr. $1\", \"captured_text_for_$1\": \"Watsons\"}",
+					"outputDataExample": "{\"dst_buffer\": \"Dr. Watsons\"}"
+				},
+				{
+					"simStepId": "d4a50acf-c118-4c92-b8a8-e02e8b362453",
+					"diagramNodeId": "50dbd73e-3872-4462-8540-93e549529ef2",
+					"simStepLabel": "Return Replaced Text",
+					"simStepDescription": "The buffer containing the fully replaced text is now stored within the `Replacer` instance, ready to be retrieved by the `Sink`.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/util.rs",
+						"startLine": "114",
+						"endLine": "117",
+						"relevantVariables": [
+							"replacement",
+							"space.dst",
+							"space.matches"
+						]
+					},
+					"inputDataExample": "{\"replacer.space\": {\"dst\": \"Dr. Watsons\", \"matches\": [{\"start\": 0, \"end\": 11}]}}",
+					"outputDataExample": "{\"replacer.space\": {\"dst\": \"Dr. Watsons\", \"matches\": [{\"start\": 0, \"end\": 11}]}}"
+				},
+				{
+					"simStepId": "6506fc09-ffcb-4339-bd4a-e84253d0c1b6",
+					"diagramNodeId": "7138d741-53de-48fc-a962-99b13e1d7706",
+					"simStepLabel": "Construct Final Output Line",
+					"simStepDescription": "Back in `StandardSink::matched`, the replaced text is retrieved from the `Replacer`. It is then encapsulated in a `Sunk` object, which represents the matched context but with the replaced bytes, abstracting it for the final printing logic.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "906",
+						"endLine": "911",
+						"relevantVariables": [
+							"Sunk::from_sink_match",
+							"mat",
+							"sink.replacer.replacement()"
+						]
+					},
+					"inputDataExample": "{\"original_match_bytes\": \"Doctor Watsons\", \"replacement_bytes\": [\"Dr. Watsons\"]}",
+					"outputDataExample": "{\"Sunk\": {\"bytes\": \"Dr. Watsons\", \"matches\": [{\"start\": 0, \"end\": 11}]}}"
+				},
+				{
+					"simStepId": "0b9d9c56-54ba-4399-8a63-331359e80d04",
+					"diagramNodeId": "349e4381-82c9-490b-bfdd-bdc9bb872c75",
+					"simStepLabel": "Data for Final Print",
+					"simStepDescription": "The `Sunk` object containing the line with applied replacements is passed to the printing implementation, which will format it for display.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "912",
+						"endLine": "912",
+						"relevantVariables": [
+							"StandardImpl"
+						]
+					},
+					"inputDataExample": "{\"Sunk\": {\"bytes\": \"For the Dr. Watsons of this world...\"}}",
+					"outputDataExample": "{\"Sunk\": {\"bytes\": \"For the Dr. Watsons of this world...\"}}"
+				},
+				{
+					"simStepId": "0c6dc36c-3ce4-40c7-9fe0-91ab470855a5",
+					"diagramNodeId": "ee822001-55cc-47c3-8efc-295818547c1a",
+					"simStepLabel": "Write to Output Stream",
+					"simStepDescription": "The final printing logic takes the `Sunk` object, formats the line with any other required elements (like line numbers or colors), and writes the result to the designated output stream (e.g., stdout).",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "1647",
+						"endLine": "1651",
+						"relevantVariables": [
+							"StandardImpl",
+							"end",
+							"write_separator"
+						]
+					},
+					"inputDataExample": "{\"line_to_print\": \"1:For the Dr. Watsons of this world...\"}",
+					"outputDataExample": "{\"stdout\": \"1:For the Dr. Watsons of this world...\\n\"}"
+				}
+			],
+			"description": "<ul><li>The <code>-r</code>/<code>--replace</code> flag replaces the matched portion of text in the output with a given replacement string</li><li>Supports referencing capture groups from the pattern by index (e</li><li>g</li><li>, <code>$1</code>, <code>$2</code>) or by name (e</li><li>g</li><li>, <code>$name</code>)</li><li>While <code>ripgrep</code> never modifies files, this feature is useful for transforming output or previewing what a search-and-replace operation would do</li></ul>",
+			"simulationNodesAndEdges": {
+				"4fd8d6c1-cc49-4bfe-a852-ab24cffcf443": {
+					"simStepIds": [
+						"6c3035dc-c539-474d-9d08-380371747982"
+					]
+				},
+				"d10772ea-5a19-4c72-ad04-754a0208a213": {
+					"simStepIds": [
+						"0d5fe06c-3899-4862-b2a7-dcbeb7d70e78"
+					]
+				},
+				"2897d065-bc9c-47a0-935d-58720d432394": {
+					"simStepIds": [
+						"bfb926ff-af12-4d27-8b74-1b216918243c"
+					]
+				},
+				"6f4daaff-ddca-41f0-ad53-d48d290d885b": {
+					"simStepIds": [
+						"7e01b0f6-7c2f-4578-8bcd-e92dff0173d8"
+					]
+				},
+				"778e8bbe-678f-4a3c-8911-52fab94d475b": {
+					"simStepIds": [
+						"86be35a1-d0f0-424f-9f87-9f3e7e924ed7"
+					]
+				},
+				"7138d741-53de-48fc-a962-99b13e1d7706": {
+					"simStepIds": [
+						"6506fc09-ffcb-4339-bd4a-e84253d0c1b6"
+					]
+				},
+				"ee822001-55cc-47c3-8efc-295818547c1a": {
+					"simStepIds": [
+						"0c6dc36c-3ce4-40c7-9fe0-91ab470855a5"
+					]
+				},
+				"205c10d8-385d-45c1-9829-2e59c67b8005": {
+					"simStepIds": [
+						"2d10ae06-aecd-4480-8826-c036f9a2f1c9"
+					]
+				},
+				"ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02": {
+					"simStepIds": [
+						"c2eae192-e8c3-413a-8c95-fda6e860e445"
+					]
+				},
+				"da844bfb-d742-4ee0-af58-61cd861b9350": {
+					"simStepIds": [
+						"50975416-4977-4580-a765-b51dfbe4b983"
+					]
+				},
+				"5442b0ed-343b-41ed-b7fc-f5baf0e5991c": {
+					"simStepIds": [
+						"ec97fde2-3851-40bf-be8a-598def3c9285"
+					]
+				},
+				"50dbd73e-3872-4462-8540-93e549529ef2": {
+					"simStepIds": [
+						"d4a50acf-c118-4c92-b8a8-e02e8b362453"
+					]
+				},
+				"349e4381-82c9-490b-bfdd-bdc9bb872c75": {
+					"simStepIds": [
+						"0b9d9c56-54ba-4399-8a63-331359e80d04"
+					]
+				}
+			},
+			"isAIGenerated": true,
+			"keywords": "replace, Replacer, submatches",
+			"generationPrompt": "Preview text replacements in the output based on regex matches and capture groups.",
+			"generationKeywords": "replace, Replacer, submatches"
+		},
+		"Search any file format by defining a preprocessor command to convert it to text.": {
+			"name": "Search any file format by defining a preprocessor command to convert it to text.",
+			"simSteps": [
+				{
+					"simStepId": "ac7d4e6d-0c1f-4f09-835e-15a57c688ef7",
+					"diagramNodeId": "371cba6e-4f3e-43f1-a988-edb4f54e2c44",
+					"simStepLabel": "Parse Preprocessor CLI Arguments",
+					"simStepDescription": "Ripgrep starts by parsing the command-line arguments. The `--pre` flag specifies the preprocessor command, and `--pre-glob` provides the glob patterns to select files for preprocessing. These arguments are stored in a low-level arguments struct.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/defs.rs",
+						"startLine": "5528",
+						"endLine": "5542",
+						"relevantVariables": [
+							"Pre",
+							"PreGlob",
+							"Flag::update",
+							"args.pre",
+							"args.pre_glob"
+						]
+					},
+					"inputDataExample": "{\"args\": [\"rg\", \"--pre\", \"pdftotext\", \"--pre-glob\", \"*.pdf\", \"search_term\", \".\"]}",
+					"outputDataExample": "{\"pre\": \"pdftotext\", \"pre_glob\": [\"*.pdf\"]}"
+				},
+				{
+					"simStepId": "cb082c95-721e-4c17-be86-42145855c6d4",
+					"diagramNodeId": "e2b512be-0da5-4e08-a8f0-4d5271c56bec",
+					"simStepLabel": "Pass Raw Arguments for Compilation",
+					"simStepDescription": "The raw string arguments for the preprocessor command and associated globs are passed internally for validation and compilation into a more efficient format for matching.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "111",
+						"endLine": "111",
+						"relevantVariables": [
+							"LowArgs"
+						]
+					},
+					"inputDataExample": "{\"pre\": \"pdftotext\", \"pre_glob\": [\"*.pdf\"]}",
+					"outputDataExample": "{\"pre\": \"pdftotext\", \"pre_glob\": [\"*.pdf\"]}"
+				},
+				{
+					"simStepId": "358073c2-ed72-4198-91b7-b96779ef1070",
+					"diagramNodeId": "dad1acc0-24c5-45ef-8a24-7b84a04f3620",
+					"simStepLabel": "Compile Preprocessor Globs",
+					"simStepDescription": "The `--pre-glob` string patterns are compiled into an `ignore::overrides::Override` object. This structure allows for efficient matching of file paths against the specified globs during the directory traversal.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "1226",
+						"endLine": "1238",
+						"relevantVariables": [
+							"preprocessor_globs",
+							"ignore::overrides::OverrideBuilder",
+							"builder.add(glob)",
+							"builder.build()"
+						]
+					},
+					"inputDataExample": "{\"cwd\": \"/home/user/project\", \"globs\": [\"*.pdf\"]}",
+					"outputDataExample": "{\"pre_globs\": \"ignore::overrides::Override object for '*.pdf'\"}"
+				},
+				{
+					"simStepId": "f0d155fc-0913-45bd-b53b-656dd6c98833",
+					"diagramNodeId": "aacee49a-819e-4c4f-b165-f5c39c9c867f",
+					"simStepLabel": "Pass Compiled Arguments to Worker Builder",
+					"simStepDescription": "The high-level arguments, including the preprocessor command path and the compiled glob matcher, are passed to the `SearchWorkerBuilder` to configure the search process.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "696",
+						"endLine": "696",
+						"relevantVariables": [
+							"HiArgs"
+						]
+					},
+					"inputDataExample": "{\"pre\": \"pdftotext\", \"pre_globs\": \"ignore::overrides::Override object for '*.pdf'\"}",
+					"outputDataExample": "{\"pre\": \"pdftotext\", \"pre_globs\": \"ignore::overrides::Override object for '*.pdf'\"}"
+				},
+				{
+					"simStepId": "b5e56eed-3eaf-41fc-8ace-df49b7975aa0",
+					"diagramNodeId": "41c68e49-b2b4-463f-b7e9-444a1f388ede",
+					"simStepLabel": "Configure Search Worker",
+					"simStepDescription": "The `SearchWorkerBuilder` configures a `SearchWorker` instance. It resolves the absolute path to the preprocessor binary and stores it along with the compiled globs in the worker's configuration.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "96",
+						"endLine": "118",
+						"relevantVariables": [
+							"SearchWorkerBuilder::preprocessor",
+							"SearchWorkerBuilder::preprocessor_globs",
+							"grep::cli::resolve_binary"
+						]
+					},
+					"inputDataExample": "{\"pre_command_name\": \"pdftotext\", \"pre_globs\": \"ignore::overrides::Override object for '*.pdf'\"}",
+					"outputDataExample": "{\"SearchWorker.config\": {\"preprocessor\": \"/usr/bin/pdftotext\", \"preprocessor_globs\": \"ignore::overrides::Override object for '*.pdf'\"}}"
+				},
+				{
+					"simStepId": "e7df3fcb-604f-4fa7-afa6-385deec4fd46",
+					"diagramNodeId": "10918ee4-422b-453e-bb5d-05d55fe40fd2",
+					"simStepLabel": "Initiate File Search",
+					"simStepDescription": "The configured `SearchWorker` is used to start the directory traversal. For each file found, its path is passed to the worker to determine how it should be searched.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/main.rs",
+						"startLine": "233",
+						"endLine": "233",
+						"relevantVariables": [
+							"search_haystack"
+						]
+					},
+					"inputDataExample": "{\"filePath\": \"./docs/research.pdf\"}",
+					"outputDataExample": "{\"filePath\": \"./docs/research.pdf\"}"
+				},
+				{
+					"simStepId": "804852c5-f087-4553-a287-f0b4309ea273",
+					"diagramNodeId": "661242fb-a028-49ef-8a40-665bdc8f8b9a",
+					"simStepLabel": "Check if File Matches Preprocessor Globs",
+					"simStepDescription": "For each file found (e.g., `docs/research.pdf`), the `should_preprocess` method checks if it matches the compiled `--pre-glob` patterns. If it matches, the method returns `true`, signaling that the preprocessor should be used.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "285",
+						"endLine": "295",
+						"relevantVariables": [
+							"should_preprocess",
+							"self.config.preprocessor",
+							"self.config.preprocessor_globs.matched"
+						]
+					},
+					"inputDataExample": "{\"path\": \"./docs/research.pdf\"}",
+					"outputDataExample": "{\"should_preprocess\": true}"
+				},
+				{
+					"simStepId": "cbb156bb-8a73-4ff5-9275-3f2820b75bbc",
+					"diagramNodeId": "e6ad1c9e-fb02-48a3-91ce-1920e842ae43",
+					"simStepLabel": "Signal for Preprocessing",
+					"simStepDescription": "The boolean result from the glob check is used to decide whether to execute the preprocessor or search the file directly. A `true` value triggers the preprocessor path.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "259",
+						"endLine": "262",
+						"relevantVariables": [
+							"self.should_preprocess(path)"
+						]
+					},
+					"inputDataExample": "{\"should_preprocess\": true}",
+					"outputDataExample": "{\"should_preprocess\": true}"
+				},
+				{
+					"simStepId": "d3f25c6a-769a-46e8-8b8d-bbdc9e2a2f86",
+					"diagramNodeId": "84432abe-73a2-46dd-aa06-178ca2b62ff8",
+					"simStepLabel": "Execute Preprocessor Command",
+					"simStepDescription": "The `search_preprocessor` method spawns the specified command (e.g., `pdftotext`). It passes the file path as an argument and pipes the file's contents to the command's standard input. Ripgrep then captures the command's standard output as a readable stream.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "299",
+						"endLine": "321",
+						"relevantVariables": [
+							"search_preprocessor",
+							"std::process::Command::new",
+							"cmd.arg(path)",
+							"cmd.stdin(Stdio::from(File::open(path)?))",
+							"self.command_builder.build(&mut cmd)"
+						]
+					},
+					"inputDataExample": "{\"path\": \"./docs/research.pdf\", \"command\": \"/usr/bin/pdftotext\"}",
+					"outputDataExample": "{\"stdout_stream\": \"<readable_stream_of_text_from_pdf>\"}"
+				},
+				{
+					"simStepId": "318d899e-9197-4e1f-a2c6-301ac52bc43a",
+					"diagramNodeId": "ed97f725-0d09-4009-8626-5bafe4b0f4bd",
+					"simStepLabel": "Stream Preprocessed Data",
+					"simStepDescription": "The plain text output generated by the preprocessor command is streamed from its stdout buffer to ripgrep's internal searcher.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/cli/src/process.rs",
+						"startLine": "259",
+						"endLine": "266",
+						"relevantVariables": [
+							"CommandReader::read",
+							"stdout.read(buf)"
+						]
+					},
+					"inputDataExample": "{\"chunk\": \"The Commentz-Walter algorithm (and its variants) displayed more interesting behaviour...\"}",
+					"outputDataExample": "{\"chunk\": \"The Commentz-Walter algorithm (and its variants) displayed more interesting behaviour...\"}"
+				},
+				{
+					"simStepId": "26355175-5341-488d-a476-30e2f796176c",
+					"diagramNodeId": "fa7bdd21-d61e-497f-9427-eda4d39438cd",
+					"simStepLabel": "Search Preprocessed Stream",
+					"simStepDescription": "The `search_reader` method consumes the text stream from the preprocessor's output and applies the user's regex pattern to find matches.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "349",
+						"endLine": "357",
+						"relevantVariables": [
+							"search_reader",
+							"self.searcher.search_reader"
+						]
+					},
+					"inputDataExample": "{\"stream\": \"<readable_stream_of_text_from_pdf>\", \"pattern\": \"Commentz-Walter\"}",
+					"outputDataExample": "{\"match\": {\"path\": \"./docs/research.pdf\", \"lines\": \"The Commentz-Walter algorithm...\", \"line_number\": 17218}}"
+				},
+				{
+					"simStepId": "00bfe31b-8a1e-445d-a4a8-f09f69bb4965",
+					"diagramNodeId": "bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d",
+					"simStepLabel": "Pass Match Data to Printer",
+					"simStepDescription": "Once a match is found in the preprocessed text, its details (original file path, line number, line content, and submatches) are sent to the printer for formatting.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/searcher/src/searcher/core.rs",
+						"startLine": "456",
+						"endLine": "463",
+						"relevantVariables": [
+							"self.sink.matched"
+						]
+					},
+					"inputDataExample": "{\"match\": {\"path\": \"./docs/research.pdf\", \"lines\": \"The Commentz-Walter algorithm...\", \"line_number\": 17218, \"absolute_offset\": 123456}}",
+					"outputDataExample": "{\"match\": {\"path\": \"./docs/research.pdf\", \"lines\": \"The Commentz-Walter algorithm...\", \"line_number\": 17218, \"absolute_offset\": 123456}}"
+				},
+				{
+					"simStepId": "4ff85d42-34c0-41f3-a939-2eca1f58810d",
+					"diagramNodeId": "fd865b14-7ee5-4b22-afc0-f1642849edd8",
+					"simStepLabel": "Format and Print Match",
+					"simStepDescription": "The printer receives the match data and formats it for display. This includes adding the file path, line number, and color highlighting before writing the final output to standard output.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/printer/src/standard.rs",
+						"startLine": "1178",
+						"endLine": "1188",
+						"relevantVariables": [
+							"write_prelude",
+							"prelude.write_path()",
+							"prelude.write_line_number(line_number)"
+						]
+					},
+					"inputDataExample": "{\"match\": {\"path\": \"./docs/research.pdf\", \"lines\": \"The Commentz-Walter algorithm...\", \"line_number\": 17218, \"absolute_offset\": 123456}}",
+					"outputDataExample": "{\"stdout\": \"docs/research.pdf:17218:The Commentz-Walter algorithm...\"}"
+				}
+			],
+			"description": "<ul><li>The <code>--pre</code> flag specifies a command to run on each file before searching</li><li><code>ripgrep</code> then searches the standard output of this command</li><li>Enables searching within non-text formats like PDFs, Office documents, or encrypted files by using external conversion tools (<code>pdftotext</code>, <code>tika</code>, etc</li><li>)</li><li>The preprocessor can be conditionally applied to files matching specific globs using <code>--pre-glob</code> for better performance</li></ul>",
+			"simulationNodesAndEdges": {
+				"371cba6e-4f3e-43f1-a988-edb4f54e2c44": {
+					"simStepIds": [
+						"ac7d4e6d-0c1f-4f09-835e-15a57c688ef7"
+					]
+				},
+				"dad1acc0-24c5-45ef-8a24-7b84a04f3620": {
+					"simStepIds": [
+						"358073c2-ed72-4198-91b7-b96779ef1070"
+					]
+				},
+				"41c68e49-b2b4-463f-b7e9-444a1f388ede": {
+					"simStepIds": [
+						"b5e56eed-3eaf-41fc-8ace-df49b7975aa0"
+					]
+				},
+				"661242fb-a028-49ef-8a40-665bdc8f8b9a": {
+					"simStepIds": [
+						"804852c5-f087-4553-a287-f0b4309ea273"
+					]
+				},
+				"84432abe-73a2-46dd-aa06-178ca2b62ff8": {
+					"simStepIds": [
+						"d3f25c6a-769a-46e8-8b8d-bbdc9e2a2f86"
+					]
+				},
+				"fa7bdd21-d61e-497f-9427-eda4d39438cd": {
+					"simStepIds": [
+						"26355175-5341-488d-a476-30e2f796176c"
+					]
+				},
+				"fd865b14-7ee5-4b22-afc0-f1642849edd8": {
+					"simStepIds": [
+						"4ff85d42-34c0-41f3-a939-2eca1f58810d"
+					]
+				},
+				"e2b512be-0da5-4e08-a8f0-4d5271c56bec": {
+					"simStepIds": [
+						"cb082c95-721e-4c17-be86-42145855c6d4"
+					]
+				},
+				"aacee49a-819e-4c4f-b165-f5c39c9c867f": {
+					"simStepIds": [
+						"f0d155fc-0913-45bd-b53b-656dd6c98833"
+					]
+				},
+				"10918ee4-422b-453e-bb5d-05d55fe40fd2": {
+					"simStepIds": [
+						"e7df3fcb-604f-4fa7-afa6-385deec4fd46"
+					]
+				},
+				"e6ad1c9e-fb02-48a3-91ce-1920e842ae43": {
+					"simStepIds": [
+						"cbb156bb-8a73-4ff5-9275-3f2820b75bbc"
+					]
+				},
+				"ed97f725-0d09-4009-8626-5bafe4b0f4bd": {
+					"simStepIds": [
+						"318d899e-9197-4e1f-a2c6-301ac52bc43a"
+					]
+				},
+				"bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d": {
+					"simStepIds": [
+						"00bfe31b-8a1e-445d-a4a8-f09f69bb4965"
+					]
+				}
+			},
+			"isAIGenerated": true,
+			"keywords": "pre, preprocessor, CommandReader",
+			"generationPrompt": "Search any file format by defining a preprocessor command to convert it to text.",
+			"generationKeywords": "pre, preprocessor, CommandReader"
+		},
+		"Persist command-line options and custom file types in a configuration file.": {
+			"name": "Persist command-line options and custom file types in a configuration file.",
+			"simSteps": [
+				{
+					"simStepId": "480456a6-14e2-435f-a647-f548b7db9da2",
+					"diagramNodeId": "f762e7b2-4ed1-4ae0-8746-b958e16b2499",
+					"simStepLabel": "Start Execution and Parse Arguments",
+					"simStepDescription": "Execution starts in the `main` function which calls `flags::parse()` to handle command-line arguments. This function performs an initial parse of the arguments provided directly to the process and checks for special flags like `--no-config` or `--help`.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/parse.rs",
+						"startLine": "71",
+						"endLine": "75",
+						"relevantVariables": [
+							"parse",
+							"parser",
+							"low",
+							"std::env::args_os"
+						]
+					},
+					"inputDataExample": "{\"args\": [\"rg\", \"-t\", \"web\", \"title\"]}",
+					"outputDataExample": "{\"low_args_pass1\": {\"mode\": \"Search\", \"type_changes\": [], \"no_config\": false, \"paths\": [\"web\", \"title\"]}}"
+				},
+				{
+					"simStepId": "14c535f9-7ea4-4433-9c51-6ea91fec4304",
+					"diagramNodeId": "fadf13c2-4eee-46a9-945d-a0a12855832b",
+					"simStepLabel": "Check for Configuration File",
+					"simStepDescription": "The argument parser checks for the `RIPGREP_CONFIG_PATH` environment variable to locate the configuration file. If the variable is not set or is empty, config file loading is skipped.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/config.rs",
+						"startLine": "13",
+						"endLine": "22",
+						"relevantVariables": [
+							"args",
+							"RIPGREP_CONFIG_PATH",
+							"std::env::var_os"
+						]
+					},
+					"inputDataExample": "{\"RIPGREP_CONFIG_PATH\": \"/home/user/.ripgreprc\"}",
+					"outputDataExample": "{\"RIPGREP_CONFIG_PATH\": \"/home/user/.ripgreprc\"}"
+				},
+				{
+					"simStepId": "feb6f7e3-8788-40e3-9408-fc32898d04e0",
+					"diagramNodeId": "dbfee10c-86e3-476f-86f0-7e2ca77cc529",
+					"simStepLabel": "Parse Configuration File",
+					"simStepDescription": "If a configuration file path is found, the file is opened and parsed. Each line that is not a comment or empty is treated as a single command-line argument. These arguments are collected into a list.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/config.rs",
+						"startLine": "65",
+						"endLine": "72",
+						"relevantVariables": [
+							"parse",
+							"path",
+							"std::fs::File::open",
+							"parse_reader"
+						]
+					},
+					"inputDataExample": "{\n  \"config_file_content\": \"# Always use smart case searching\\n--smart-case\\n\\n# Add a custom 'web' file type\\n--type-add\\nweb:*.{html,css,js}\"\n}",
+					"outputDataExample": "{\"parsed_args\": [\"--smart-case\", \"--type-add\", \"web:*.{html,css,js}\"]}"
+				},
+				{
+					"simStepId": "3ebae179-adbb-4ac1-b010-1ce0e0476a58",
+					"diagramNodeId": "fc568437-30b2-4ab2-a1f0-876eec72e1db",
+					"simStepLabel": "Transmit Parsed Config Arguments",
+					"simStepDescription": "The list of arguments parsed from the configuration file is returned to the main parsing logic.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/parse.rs",
+						"startLine": "92",
+						"endLine": "92",
+						"relevantVariables": [
+							"config_args"
+						]
+					},
+					"inputDataExample": "{\"parsed_args\": [\"--smart-case\", \"--type-add\", \"web:*.{html,css,js}\"]}",
+					"outputDataExample": "{\"parsed_args\": [\"--smart-case\", \"--type-add\", \"web:*.{html,css,js}\"]}"
+				},
+				{
+					"simStepId": "6f8fc4cd-ab98-4f17-8883-d5938b953bf4",
+					"diagramNodeId": "0ea2e988-76a8-4989-9841-0c4c130de7a9",
+					"simStepLabel": "Merge and Re-parse All Arguments",
+					"simStepDescription": "The arguments from the config file are prepended to the arguments from the command line. The parser runs a second time on this combined set of arguments. During this pass, the `update` method for the `--type-add` flag is called, which adds the custom file type definition to the `type_changes` field in the `LowArgs` struct.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/parse.rs",
+						"startLine": "96",
+						"endLine": "104",
+						"relevantVariables": [
+							"final_args",
+							"config_args",
+							"low",
+							"parser.parse"
+						]
+					},
+					"inputDataExample": "{\"config_args\": [\"--smart-case\", \"--type-add\", \"web:*.{html,css,js}\"], \"cli_args\": [\"-t\", \"web\", \"title\"]}",
+					"outputDataExample": "{\"final_low_args\": {\"type_changes\": [\"Add { def: \\\"web:*.{html,css,js}\\\" }\"], \"smart_case\": true}}"
+				},
+				{
+					"simStepId": "4f1ea281-b9b0-4651-9e19-3f834dd2c885",
+					"diagramNodeId": "e7a3ab74-74b5-4476-9b14-836f04678cc7",
+					"simStepLabel": "Transmit Low-Level Arguments",
+					"simStepDescription": "The fully populated `LowArgs` struct, containing all configuration from both sources, is passed on to be converted into a high-level, structured representation.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "1133",
+						"endLine": "1141",
+						"relevantVariables": [
+							"HiArgs",
+							"LowArgs"
+						]
+					},
+					"inputDataExample": "{\"final_low_args\": {\"type_changes\": [\"Add { def: \\\"web:*.{html,css,js}\\\" }\"], \"smart_case\": true}}",
+					"outputDataExample": "{\"final_low_args\": {\"type_changes\": [\"Add { def: \\\"web:*.{html,css,js}\\\" }\"], \"smart_case\": true}}"
+				},
+				{
+					"simStepId": "1e1e2b32-f650-47f5-b13d-e8b6a6f9c47e",
+					"diagramNodeId": "0cfd7f6c-1a85-422b-9ea8-8c1dcf0467c1",
+					"simStepLabel": "Build High-Level Arguments",
+					"simStepDescription": "The `LowArgs` struct is converted into a `HiArgs` struct. This process involves interpreting the `type_changes` field. A `TypesBuilder` from the `ignore` crate is initialized with default file types, and then the custom 'web' type definition (`web:*.{html,css,js}`) is added to it. The final `Types` object is stored in `HiArgs`.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/defs.rs",
+						"startLine": "6973",
+						"endLine": "6978",
+						"relevantVariables": [
+							"TypeAdd::update",
+							"args.type_changes",
+							"TypeChange::Add"
+						]
+					},
+					"inputDataExample": "{\"low_args\": {\"type_changes\": [\"Add { def: \\\"web:*.{html,css,js}\\\" }\"]}}",
+					"outputDataExample": "{\"hi_args\": {\"types\": \"(built-in types + 'web' type)\"}}"
+				},
+				{
+					"simStepId": "86b94dae-4068-4544-8ed8-46daf73755e8",
+					"diagramNodeId": "d07f3a20-1f28-42d6-8f89-d63f5372b039",
+					"simStepLabel": "Transmit High-Level Configuration",
+					"simStepDescription": "The `HiArgs` object, containing the fully configured `Types` object (which now includes the custom 'web' type), is used to set up the search.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "863",
+						"endLine": "871",
+						"relevantVariables": [
+							"HiArgs::walk_builder"
+						]
+					},
+					"inputDataExample": "{\"hi_args\": {\"types\": \"(built-in types + 'web' type)\"}}",
+					"outputDataExample": "{\"hi_args\": {\"types\": \"(built-in types + 'web' type)\"}}"
+				},
+				{
+					"simStepId": "487a5b7a-65d2-4fdf-9a73-2911d82b7f61",
+					"diagramNodeId": "02cc98f2-4801-485b-b0ee-9780bcee6344",
+					"simStepLabel": "Configure Directory Walker",
+					"simStepDescription": "A `WalkBuilder` from the `ignore` crate is created and configured using the `HiArgs`. The custom `Types` object is passed to the walker. If the user specified `-t web` on the command line, the walker will now use the definition of 'web' (from the config file) to include only files matching `*.html`, `*.css`, or `*.js` in its traversal.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/flags/hiargs.rs",
+						"startLine": "863",
+						"endLine": "871",
+						"relevantVariables": [
+							"walk_builder",
+							"ignore::WalkBuilder"
+						]
+					},
+					"inputDataExample": "{\"hi_args\": {\"types\": \"(built-in types + 'web' type)\"}, \"cli_args\": {\"type_filter\": \"web\"}}",
+					"outputDataExample": "{\"walk_builder\": \"(configured with custom 'web' type filter)\"}"
+				},
+				{
+					"simStepId": "bcf37e0f-c3e9-44fd-bb74-a4501dd7b5d2",
+					"diagramNodeId": "b72ce07f-2387-40a1-90ba-4deafeeb4793",
+					"simStepLabel": "Yield Matching Files",
+					"simStepDescription": "The configured directory walker traverses the file system and yields `DirEntry` objects for files that match the filtering criteria, including the custom file type filters.",
+					"isEdge": 1,
+					"sourceCodeMapping": {
+						"filePath": "crates/ignore/src/walk.rs",
+						"startLine": "449",
+						"endLine": "464",
+						"relevantVariables": [
+							"WalkBuilder",
+							"ignore files",
+							"file type matching"
+						]
+					},
+					"inputDataExample": "{\"dir_entry\": \"./index.html\"}",
+					"outputDataExample": "{\"dir_entry\": \"./index.html\"}"
+				},
+				{
+					"simStepId": "cd58a6a2-35b8-4bee-9a79-e6419ea3942d",
+					"diagramNodeId": "f922a6d3-7cbf-48ac-b204-399522834fe1",
+					"simStepLabel": "Execute Search on Filtered Files",
+					"simStepDescription": "For each file path yielded by the walker, the `SearchWorker` executes the search. Since the walker has already filtered the files based on the custom type defined in the configuration file, ripgrep only searches the files that the user intended.",
+					"isEdge": 0,
+					"sourceCodeMapping": {
+						"filePath": "crates/core/search.rs",
+						"startLine": "245",
+						"endLine": "255",
+						"relevantVariables": [
+							"SearchWorker::search",
+							"haystack"
+						]
+					},
+					"inputDataExample": "{\"haystack_path\": \"./index.html\"}",
+					"outputDataExample": "{\"search_result\": \"1: <title>My Web Page</title>\"}"
+				}
+			],
+			"description": "<ul><li><code>ripgrep</code> can load default arguments from a configuration file specified by the <code>RIPGREP_CONFIG_PATH</code> environment variable</li><li>Allows users to set flags they always want to use, such as <code>--smart-case</code> or color settings</li><li>Custom file types defined with <code>--type-add</code> can be made permanent by adding them to the config file</li></ul>",
+			"simulationNodesAndEdges": {
+				"f762e7b2-4ed1-4ae0-8746-b958e16b2499": {
+					"simStepIds": [
+						"480456a6-14e2-435f-a647-f548b7db9da2"
+					]
+				},
+				"dbfee10c-86e3-476f-86f0-7e2ca77cc529": {
+					"simStepIds": [
+						"feb6f7e3-8788-40e3-9408-fc32898d04e0"
+					]
+				},
+				"0ea2e988-76a8-4989-9841-0c4c130de7a9": {
+					"simStepIds": [
+						"6f8fc4cd-ab98-4f17-8883-d5938b953bf4"
+					]
+				},
+				"0cfd7f6c-1a85-422b-9ea8-8c1dcf0467c1": {
+					"simStepIds": [
+						"1e1e2b32-f650-47f5-b13d-e8b6a6f9c47e"
+					]
+				},
+				"02cc98f2-4801-485b-b0ee-9780bcee6344": {
+					"simStepIds": [
+						"487a5b7a-65d2-4fdf-9a73-2911d82b7f61"
+					]
+				},
+				"f922a6d3-7cbf-48ac-b204-399522834fe1": {
+					"simStepIds": [
+						"cd58a6a2-35b8-4bee-9a79-e6419ea3942d"
+					]
+				},
+				"fadf13c2-4eee-46a9-945d-a0a12855832b": {
+					"simStepIds": [
+						"14c535f9-7ea4-4433-9c51-6ea91fec4304"
+					]
+				},
+				"fc568437-30b2-4ab2-a1f0-876eec72e1db": {
+					"simStepIds": [
+						"3ebae179-adbb-4ac1-b010-1ce0e0476a58"
+					]
+				},
+				"e7a3ab74-74b5-4476-9b14-836f04678cc7": {
+					"simStepIds": [
+						"4f1ea281-b9b0-4651-9e19-3f834dd2c885"
+					]
+				},
+				"d07f3a20-1f28-42d6-8f89-d63f5372b039": {
+					"simStepIds": [
+						"86b94dae-4068-4544-8ed8-46daf73755e8"
+					]
+				},
+				"b72ce07f-2387-40a1-90ba-4deafeeb4793": {
+					"simStepIds": [
+						"bcf37e0f-c3e9-44fd-bb74-a4501dd7b5d2"
+					]
+				}
+			},
+			"isAIGenerated": true,
+			"keywords": "RIPGREP_CONFIG_PATH, config, type-add",
+			"generationPrompt": "Persist command-line options and custom file types in a configuration file.",
+			"generationKeywords": "RIPGREP_CONFIG_PATH, config, type-add"
+		}
+	},
+	"cellToPath": {
+		"8a94384e-eb61-4ed4-a50e-c29adaa6a4fa": "crates",
+		"debf18dd-047e-44e4-9016-2ee07faaf18b": "crates/core",
+		"e66e9e2a-b18d-4361-a5a8-c389d3bb600e": "crates/ignore",
+		"50938285-d56a-4404-8807-f18ce4804f62": "crates/searcher",
+		"1e13c78f-707d-4438-9cb6-50f939de598d": "crates/printer",
+		"0508ecd1-fc1d-499a-8811-8cfff3245a53": "crates/core/main.rs",
+		"fbd72afc-9b46-46a0-a2f0-c3757937fd45": "crates/core/search.rs",
+		"71ab6f47-6fdc-4073-9554-d51e4844c87e": "crates/ignore/src",
+		"f08293c4-eb87-4446-8a1c-b208513e40bd": "crates/searcher/src",
+		"a9858ff0-4d39-4382-b671-fae85b74aaa3": "crates/printer/src",
+		"1280b1d7-f3fd-41aa-9a95-53e5509e82a0": "crates/ignore/src/walk.rs",
+		"7a2a4538-5e5a-4df6-85cc-b341c95545a1": "crates/searcher/src/searcher",
+		"a9db5f77-0d04-41dd-9ce4-9aa04b7b6550": "crates/printer/src/standard.rs",
+		"f05bde61-7d65-4d33-a433-141321ba0c95": "crates/searcher/src/searcher/mod.rs",
+		"d7cca382-50e5-4a19-a577-d94f1ea52683": "crates/searcher/src/searcher/core.rs",
+		"f571f13d-a5b1-4696-810d-016af864988b": "crates/core/main.rs-simstep-89b90516-5fbf-4f93-bc07-ad7b9c73c8ac",
+		"bdea59c2-5355-45cb-babe-67dfd0c2717e": "crates/core/main.rs-simstep-74f2428a-8ad9-4ee1-9186-810db6e72b63",
+		"2196ff9f-2695-4b8a-8a75-d5702b89371f": "crates/core/main.rs-simstep-4b7da167-9174-4295-83bc-b069e9331106",
+		"32bcfcb7-b4b6-4993-893c-1676d6ecaf77": "crates/searcher/src/searcher/mod.rs-simstep-886efe56-50a7-4387-99c3-a460e0a03834",
+		"b4d3b26e-19e7-477d-979f-702fb33ff014": "crates/searcher/src/searcher/core.rs-simstep-bb853ccd-0b47-4741-ae7c-abfd7d75fa92",
+		"31b67024-80a9-4f66-9e16-50d98e7d05c7": "crates/printer/src/standard.rs-simstep-c346a2e8-331c-4d3f-a2cb-9e1afcbc7ac1",
+		"f6322f9f-f154-481a-a997-75b09226c146": "crates/core/main.rs-simstep-32e761c6-06c3-4e7d-85a8-5a944e48aea5",
+		"344c1f2c-d241-4b5f-a686-7c1ea7037c5c": "crates/core/main.rs-simstep-eef7e6fb-0baf-47db-8786-cbef119a75c6",
+		"7789b62c-d2f3-4540-aa1a-a737a35b60c8": "generated-edge-simstep-ac3640cf-d344-4813-869f-a260233103d5-7789b62c-d2f3-4540-aa1a-a737a35b60c8",
+		"590b160d-861c-4b10-a432-28127a3d547b": "generated-edge-simstep-5161ea00-fede-4558-b465-a301e1f26076-590b160d-861c-4b10-a432-28127a3d547b",
+		"5c3f5839-6758-4eaf-98b1-71868c95b20d": "generated-edge-simstep-15ce35a6-7ce6-4bea-aeb6-05d2a5f5cda1-5c3f5839-6758-4eaf-98b1-71868c95b20d",
+		"0c2fcc7e-11d6-43a5-ae89-13180aed99eb": "generated-edge-simstep-c67074c1-8a09-479c-b153-ead7b0fa19d9-0c2fcc7e-11d6-43a5-ae89-13180aed99eb",
+		"87179a07-e417-4140-99b7-02a9f9a02887": "generated-edge-simstep-ad8a1176-c06c-41ec-92c0-7b64a8079bc1-87179a07-e417-4140-99b7-02a9f9a02887",
+		"347bc957-3191-4e20-94e9-4e1901111130": "generated-edge-simstep-ea8511c5-6417-49e1-8dd0-ff2555007454-347bc957-3191-4e20-94e9-4e1901111130",
+		"5f9ee588-f79d-40bd-bb72-9ec3368ab21f": "generated-edge-simstep-5db3b846-cbc9-4272-b024-6ada2be69cce-5f9ee588-f79d-40bd-bb72-9ec3368ab21f",
+		"6f90ad17-9829-4744-a1f0-1b721c6339ab": "crates/ignore/src/gitignore.rs",
+		"75eb0e51-195c-493c-a132-126ec4994742": "crates/ignore/src/dir.rs",
+		"4d08cdc3-7059-4f0e-b863-a2557475e192": "crates/searcher/src/line_buffer.rs",
+		"32eebe96-86ec-41f2-ac0d-3c5874bb3b44": "crates/printer/src/summary.rs",
+		"06b0a86e-bf34-4e78-b2d3-0b1442aef61e": "crates/ignore/src/walk.rs-simstep-9e34d9f4-60cf-49dd-9881-81338f158b78",
+		"d3448e0e-d81f-476d-aff3-3bd9ab26026d": "crates/ignore/src/gitignore.rs-simstep-1b894775-da3b-4578-b6d2-484f23e1ec50",
+		"7abfc016-6e09-4293-9c51-8be0e01bd020": "crates/ignore/src/dir.rs-simstep-025792a2-a063-4347-ac2f-5978300032d4",
+		"2f67c4c9-54b4-4da2-9448-5bfa18537099": "crates/searcher/src/searcher/mod.rs-simstep-5e4d02cc-50e4-40ab-a1f4-cd11b845f582",
+		"b80fd0a4-3357-49c4-baf5-2fa06862eb09": "crates/searcher/src/line_buffer.rs-simstep-722f695f-377d-448e-9b44-9265ca920a1c",
+		"723470cf-d7a8-443a-8713-f4840c0ae560": "crates/printer/src/summary.rs-simstep-10c3a95e-70bc-4232-9eb2-d16a22ee39cb",
+		"8179e991-1e79-4612-abe1-b15ebc81ee7a": "generated-edge-simstep-95bc5326-9e38-43a4-b4a8-970c33b57d4b-8179e991-1e79-4612-abe1-b15ebc81ee7a",
+		"643dc76d-7619-485d-812b-937f5adb8ad9": "generated-edge-simstep-fc573a17-a164-4433-8631-85e9d9a86d05-643dc76d-7619-485d-812b-937f5adb8ad9",
+		"b37077b4-3a28-4e20-8572-adb309282e6e": "generated-edge-simstep-dcb8f230-7cf4-471b-b2ee-4b2ea0afe105-b37077b4-3a28-4e20-8572-adb309282e6e",
+		"b04390e9-6b12-4665-9c2d-4afc76a8be4b": "generated-edge-simstep-fba70f94-ac0e-47a2-8d50-5a6a733e996b-b04390e9-6b12-4665-9c2d-4afc76a8be4b",
+		"66a36773-5189-4bc2-909a-0d5ce55eb772": "generated-edge-simstep-57c81d35-e9c1-4342-b7aa-da6ade908b5a-66a36773-5189-4bc2-909a-0d5ce55eb772",
+		"5ecfbdbb-b115-4d04-8a7e-ad062e54cb1e": "crates/core/flags",
+		"01b02a5d-8a91-4b33-a33f-91a5c96f3cdb": "crates/core/flags/defs.rs",
+		"898b7926-b1c0-43cf-80c2-b06695d8fe1c": "crates/core/flags/hiargs.rs",
+		"cb3a4534-fcff-4d6e-a249-7dc152bd9a32": "crates/core/flags/defs.rs-simstep-8cdd9622-d34d-456c-8cbd-df9939e9ea65",
+		"fbfa66cf-8419-4584-8997-3dcb1520343c": "crates/core/flags/hiargs.rs-simstep-1c3b6417-4da9-4192-a8da-70e0f7079d88",
+		"8570a0fe-3867-4504-8509-b48052799065": "crates/ignore/src/dir.rs-simstep-18eead12-d6f4-4f5d-82f5-979a40c61c6b",
+		"38526dce-9250-40d1-8e4b-b6489562aee3": "crates/core/flags/defs.rs-simstep-87114100-cc4e-473c-8213-577fe0eed9e4",
+		"c6ed14cf-fad1-4551-b5c4-ddfa4af6afe0": "crates/core/flags/hiargs.rs-simstep-9b9b64e8-bf1a-43f6-aefa-f2bad985f294",
+		"1280e475-b2ba-4864-964c-5ce2738208ab": "crates/ignore/src/dir.rs-simstep-c47913bd-2425-4d97-b7c3-c66f5e6a084c",
+		"2b3fde20-eac5-4250-b825-23b44081ba08": "generated-edge-simstep-03e12913-6e17-41ca-aa86-096355546fab-2b3fde20-eac5-4250-b825-23b44081ba08",
+		"ba4298a3-e951-4215-a0b0-55c94dffc690": "generated-edge-simstep-bb850076-72a4-403a-be38-e533ecc251ad-ba4298a3-e951-4215-a0b0-55c94dffc690",
+		"1279f8bf-17d7-4a0a-a789-6f364aa3e5cf": "generated-edge-simstep-6c28187f-874c-462c-a17c-e5c547ed0812-1279f8bf-17d7-4a0a-a789-6f364aa3e5cf",
+		"f44a0aa4-4205-4ea4-9d80-5a62385e2307": "generated-edge-simstep-0e14c00a-6383-43b4-9285-b35fe6261f7a-f44a0aa4-4205-4ea4-9d80-5a62385e2307",
+		"63a9d821-0a1b-4daf-9f0d-0482d2ded1a5": "crates/cli",
+		"bbd871fb-2a85-4f90-b28d-abc336580454": "crates/cli/src",
+		"f64da727-0b70-4f27-880c-862de575dd0a": "crates/printer/src/json.rs",
+		"0e8f4962-c836-4d7b-93b1-b8b18f64a725": "crates/printer/src/jsont.rs",
+		"548054c3-b0a3-4817-8e47-3dfac7999d27": "crates/searcher/src/sink.rs",
+		"3aa0bd2b-5f86-46a6-8763-2b5371ab045d": "crates/cli/src/wtr.rs",
+		"8e2b5abc-ba17-4126-8196-2d863574dd03": "crates/core/flags/defs.rs-simstep-a234a4fc-6910-49ab-9692-3629e7029a19",
+		"8a7a07f1-7758-4c90-9a3b-f49dc60d12f1": "crates/core/flags/hiargs.rs-simstep-3e717203-9460-44e7-835e-49cd8340dbc6",
+		"7d6a3f10-0382-4eaa-8a62-e3492e6000c2": "crates/printer/src/standard.rs-simstep-127bdb74-45b0-4569-b7be-89b9b808c24b",
+		"b7e5cc9d-83e0-44e5-bcd8-0f7886685f38": "crates/printer/src/standard.rs-simstep-89d044cb-ba97-423b-b877-e022fd3aadc5",
+		"dc9f30d5-6599-4494-867c-a5f5726f7aa2": "crates/core/flags/defs.rs-simstep-b94bbc3b-921b-4dcf-8678-da515f9752ad",
+		"aedf481e-7a26-4f1a-8f80-e270d31af954": "crates/core/flags/hiargs.rs-simstep-f9ec9573-13f1-41ea-8286-d86c8bb66a3f",
+		"9078ceb1-5c41-402c-867a-d9960eb41e6e": "crates/printer/src/json.rs-simstep-081da804-e09a-472d-b815-dae4ad93407a",
+		"b0962b62-8b3f-4dae-a197-aed83fe5a827": "crates/printer/src/jsont.rs-simstep-d4b5b12e-dfcb-4663-9015-fe99a6c72b8a",
+		"66e9ca05-7027-45f5-a953-d9fa1ff7f1a0": "generated-edge-simstep-a17d799e-12b0-470a-8e98-5ec9ed6bd1b3-66e9ca05-7027-45f5-a953-d9fa1ff7f1a0",
+		"3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a": "generated-edge-simstep-73c3f672-dfe3-460c-905d-c6bd9eddbd55-3bbf1b29-a5a6-4c17-bbe5-9ec562708b8a",
+		"262b607f-db42-4642-91b9-abd5a1108374": "generated-edge-simstep-35e70e93-56f9-4ae9-a4e0-d4eb08246f4b-262b607f-db42-4642-91b9-abd5a1108374",
+		"81663818-d2d6-4cfe-8a71-7b37237f7f95": "generated-edge-simstep-15986b7a-0256-4f61-97b4-61e8c654b7e4-81663818-d2d6-4cfe-8a71-7b37237f7f95",
+		"b054dd02-8e6a-4e42-be4a-7e082e6187d9": "generated-edge-simstep-60bc2812-8cec-4cf7-888d-7566c874c9dd-b054dd02-8e6a-4e42-be4a-7e082e6187d9",
+		"6bb72882-9525-4207-88b9-9573f7a6b654": "generated-edge-simstep-a46b12aa-0542-4121-b024-209610723a23-6bb72882-9525-4207-88b9-9573f7a6b654",
+		"605d4cc4-7749-425e-8ba5-e12c6b23d1a3": "generated-edge-simstep-eefd4073-c00d-49d2-96ce-793146d1a1ce-605d4cc4-7749-425e-8ba5-e12c6b23d1a3",
+		"6825dcae-96a0-412f-ab1b-8e65b339933d": "crates/core/flags/defs.rs-simstep-2d298238-6bc9-4690-a137-78749b0e824e",
+		"019eb844-4613-490c-9b1a-5743aa71aeb4": "crates/core/flags/hiargs.rs-simstep-74c81953-d698-4cf4-8ed6-8324c078e7ff",
+		"c2791749-9b9a-4275-990a-a2c2319735f9": "crates/core/flags/hiargs.rs-simstep-54b70a6d-b1ee-42e1-87f2-ac6a947ac7cc",
+		"1c3b00d3-1533-4f77-855a-0a5ae9d0abd1": "crates/core/search.rs-simstep-7151f213-e403-4b2d-ad9f-112e4d69af4e",
+		"030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d": "generated-edge-simstep-c48cab01-3dac-4912-ba64-6cc02c44dd4f-030d64e0-e03b-4fc1-85a4-e3cfd3b08f1d",
+		"85dfd805-df63-4482-a789-93fa055a046c": "generated-edge-simstep-9dd7d4c1-48f3-446f-bf14-16a43e174654-85dfd805-df63-4482-a789-93fa055a046c",
+		"94bf3581-9419-46ea-9a55-94598c438500": "generated-edge-simstep-06fef420-4852-48e4-bc61-08ec1c756d79-94bf3581-9419-46ea-9a55-94598c438500",
+		"5440e915-a99c-4d7c-a041-ed3214ef356e": "crates/core/flags/lowargs.rs",
+		"2e2dd6c4-6e83-424c-8da5-b8171ce5479f": "crates/cli/src/decompress.rs",
+		"b5bf4086-9be8-40aa-a51f-b67c6f172778": "crates/core/flags/defs.rs-simstep-028f086b-a018-4564-82a0-7069685c5fe6",
+		"3e247a17-fe8e-4353-bc30-5ea6711f2d85": "crates/core/flags/hiargs.rs-simstep-978bc900-d4de-4d46-a790-971e589fa824",
+		"cadc0775-86e8-4e88-bd26-61f174b086eb": "crates/core/search.rs-simstep-b53b5e9f-939c-4ee5-a88c-437397bbe57f",
+		"36ea22a2-80cb-4c97-b055-b14052750de7": "crates/core/search.rs-simstep-bbe67bc0-80ec-4573-af90-99a3044945be",
+		"626197b8-ae20-4c15-9110-5e97703d7612": "crates/cli/src/decompress.rs-simstep-8e6d5c6c-f294-4dae-901e-1f74837d5791",
+		"88dd5a3a-40c2-43e3-ac59-ec2e806c3825": "crates/cli/src/decompress.rs-simstep-d8c3b0bc-3ff0-4aee-bf11-5653be83ea9b",
+		"acb6f4f0-b4fe-475e-9f15-96bff8ad5f13": "generated-edge-simstep-6703644c-54a4-44ac-9a0f-9e491ae74fb8-acb6f4f0-b4fe-475e-9f15-96bff8ad5f13",
+		"57f135d9-c844-4467-9dce-d84057fd5869": "generated-edge-simstep-5dfb2af4-d179-418b-ba1a-b3b4057951a7-57f135d9-c844-4467-9dce-d84057fd5869",
+		"a5c04342-f30c-4b03-88ef-fd5d5cc6dec5": "generated-edge-simstep-cb703e0d-2a54-42ed-93b9-0648e42f39e2-a5c04342-f30c-4b03-88ef-fd5d5cc6dec5",
+		"a2c78834-0693-40f4-91ad-076a6600ec8e": "generated-edge-simstep-9d428183-5928-4541-bff7-2f3399eb9f9d-a2c78834-0693-40f4-91ad-076a6600ec8e",
+		"e5d149ac-77cd-44b7-adaf-e71df369fe88": "generated-edge-simstep-3c0c4cad-0e48-4247-be8a-6c45e41015bf-e5d149ac-77cd-44b7-adaf-e71df369fe88",
+		"ef09f321-34b3-4a42-869e-19002e3a4382": "crates/searcher/src/searcher/glue.rs",
+		"65e6f10c-354e-430e-8920-63ca301b13f6": "crates/core/flags/defs.rs-simstep-0548c99b-847a-422e-98ee-68d9d8e74274",
+		"a03b1238-c735-4679-a3e8-782afc9e93e0": "crates/core/flags/hiargs.rs-simstep-f93bf41d-9482-4e31-8513-5f150b8839e1",
+		"d77e8ea1-2850-488f-af80-6417c53c8099": "crates/searcher/src/searcher/mod.rs-simstep-cc78378e-da78-43a0-926d-0c40f5ca294d",
+		"b8833d1c-74e5-4db9-9775-056216d25c47": "crates/searcher/src/searcher/glue.rs-simstep-a0a4371e-e74e-4fa4-b643-6f351759a477",
+		"1f3ae57d-ae3d-4633-be82-877091353aa6": "crates/printer/src/standard.rs-simstep-30500bdd-89dc-4b27-917c-7c554ca5ec5a",
+		"bcc616ab-4fd0-4234-9d6c-9b29eda63456": "generated-edge-simstep-73978832-90e0-47df-9c70-60f5ecf6dbcb-bcc616ab-4fd0-4234-9d6c-9b29eda63456",
+		"8e2520f4-89df-4244-9f53-91795625ca10": "generated-edge-simstep-d0d166ef-3aad-4ea4-8186-939165e650d1-8e2520f4-89df-4244-9f53-91795625ca10",
+		"0a935202-428b-429e-a4c4-b1dd464e4bda": "generated-edge-simstep-351fecf5-1670-436c-abcc-5460f7ad0bbf-0a935202-428b-429e-a4c4-b1dd464e4bda",
+		"7f305131-1f1e-4245-8dd4-d27e022f994a": "generated-edge-simstep-00c8ea3d-7f7f-46d3-b700-5ee54ccb6c18-7f305131-1f1e-4245-8dd4-d27e022f994a",
+		"bc250234-cbc6-45a9-bb30-a680e8a25434": "crates/matcher",
+		"97c08d6d-4900-4c90-8c85-4ba11ef19a61": "crates/matcher/src",
+		"d77a4716-11cf-4b4f-8142-92ff0d375bf2": "crates/printer/src/util.rs",
+		"c50efe68-b749-49a4-a253-6c52052d4fe6": "crates/matcher/src/lib.rs",
+		"613effaa-920d-4cad-84b3-74ea88807b5c": "crates/matcher/src/interpolate.rs",
+		"4fd8d6c1-cc49-4bfe-a852-ab24cffcf443": "crates/core/flags/defs.rs-simstep-6c3035dc-c539-474d-9d08-380371747982",
+		"d10772ea-5a19-4c72-ad04-754a0208a213": "crates/core/flags/hiargs.rs-simstep-0d5fe06c-3899-4862-b2a7-dcbeb7d70e78",
+		"2897d065-bc9c-47a0-935d-58720d432394": "crates/printer/src/standard.rs-simstep-bfb926ff-af12-4d27-8b74-1b216918243c",
+		"6f4daaff-ddca-41f0-ad53-d48d290d885b": "crates/printer/src/util.rs-simstep-7e01b0f6-7c2f-4578-8bcd-e92dff0173d8",
+		"778e8bbe-678f-4a3c-8911-52fab94d475b": "crates/matcher/src/interpolate.rs-simstep-86be35a1-d0f0-424f-9f87-9f3e7e924ed7",
+		"7138d741-53de-48fc-a962-99b13e1d7706": "crates/printer/src/standard.rs-simstep-6506fc09-ffcb-4339-bd4a-e84253d0c1b6",
+		"ee822001-55cc-47c3-8efc-295818547c1a": "crates/printer/src/standard.rs-simstep-0c6dc36c-3ce4-40c7-9fe0-91ab470855a5",
+		"205c10d8-385d-45c1-9829-2e59c67b8005": "generated-edge-simstep-2d10ae06-aecd-4480-8826-c036f9a2f1c9-205c10d8-385d-45c1-9829-2e59c67b8005",
+		"ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02": "generated-edge-simstep-c2eae192-e8c3-413a-8c95-fda6e860e445-ef6ffd97-f1da-4e8d-a77b-bb9c1a651d02",
+		"da844bfb-d742-4ee0-af58-61cd861b9350": "generated-edge-simstep-50975416-4977-4580-a765-b51dfbe4b983-da844bfb-d742-4ee0-af58-61cd861b9350",
+		"5442b0ed-343b-41ed-b7fc-f5baf0e5991c": "generated-edge-simstep-ec97fde2-3851-40bf-be8a-598def3c9285-5442b0ed-343b-41ed-b7fc-f5baf0e5991c",
+		"50dbd73e-3872-4462-8540-93e549529ef2": "generated-edge-simstep-d4a50acf-c118-4c92-b8a8-e02e8b362453-50dbd73e-3872-4462-8540-93e549529ef2",
+		"349e4381-82c9-490b-bfdd-bdc9bb872c75": "generated-edge-simstep-0b9d9c56-54ba-4399-8a63-331359e80d04-349e4381-82c9-490b-bfdd-bdc9bb872c75",
+		"cd38b9ee-aec0-4a28-87fb-462f8ec364c2": "crates/cli/src/process.rs",
+		"371cba6e-4f3e-43f1-a988-edb4f54e2c44": "crates/core/flags/defs.rs-simstep-ac7d4e6d-0c1f-4f09-835e-15a57c688ef7",
+		"dad1acc0-24c5-45ef-8a24-7b84a04f3620": "crates/core/flags/hiargs.rs-simstep-358073c2-ed72-4198-91b7-b96779ef1070",
+		"41c68e49-b2b4-463f-b7e9-444a1f388ede": "crates/core/search.rs-simstep-b5e56eed-3eaf-41fc-8ace-df49b7975aa0",
+		"661242fb-a028-49ef-8a40-665bdc8f8b9a": "crates/core/search.rs-simstep-804852c5-f087-4553-a287-f0b4309ea273",
+		"84432abe-73a2-46dd-aa06-178ca2b62ff8": "crates/core/search.rs-simstep-d3f25c6a-769a-46e8-8b8d-bbdc9e2a2f86",
+		"fa7bdd21-d61e-497f-9427-eda4d39438cd": "crates/core/search.rs-simstep-26355175-5341-488d-a476-30e2f796176c",
+		"fd865b14-7ee5-4b22-afc0-f1642849edd8": "crates/printer/src/standard.rs-simstep-4ff85d42-34c0-41f3-a939-2eca1f58810d",
+		"e2b512be-0da5-4e08-a8f0-4d5271c56bec": "generated-edge-simstep-cb082c95-721e-4c17-be86-42145855c6d4-e2b512be-0da5-4e08-a8f0-4d5271c56bec",
+		"aacee49a-819e-4c4f-b165-f5c39c9c867f": "generated-edge-simstep-f0d155fc-0913-45bd-b53b-656dd6c98833-aacee49a-819e-4c4f-b165-f5c39c9c867f",
+		"10918ee4-422b-453e-bb5d-05d55fe40fd2": "generated-edge-simstep-e7df3fcb-604f-4fa7-afa6-385deec4fd46-10918ee4-422b-453e-bb5d-05d55fe40fd2",
+		"e6ad1c9e-fb02-48a3-91ce-1920e842ae43": "generated-edge-simstep-cbb156bb-8a73-4ff5-9275-3f2820b75bbc-e6ad1c9e-fb02-48a3-91ce-1920e842ae43",
+		"ed97f725-0d09-4009-8626-5bafe4b0f4bd": "generated-edge-simstep-318d899e-9197-4e1f-a2c6-301ac52bc43a-ed97f725-0d09-4009-8626-5bafe4b0f4bd",
+		"bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d": "generated-edge-simstep-00bfe31b-8a1e-445d-a4a8-f09f69bb4965-bc0fc965-c7a8-4cbd-ab83-8a7c7dc2a40d",
+		"23cc6e15-ec4f-467a-9e19-4cca7bad4056": "crates/core/flags/parse.rs",
+		"7715a01b-ffc3-4e46-8446-5f55b158012e": "crates/core/flags/config.rs",
+		"f762e7b2-4ed1-4ae0-8746-b958e16b2499": "crates/core/flags/parse.rs-simstep-480456a6-14e2-435f-a647-f548b7db9da2",
+		"dbfee10c-86e3-476f-86f0-7e2ca77cc529": "crates/core/flags/config.rs-simstep-feb6f7e3-8788-40e3-9408-fc32898d04e0",
+		"0ea2e988-76a8-4989-9841-0c4c130de7a9": "crates/core/flags/parse.rs-simstep-6f8fc4cd-ab98-4f17-8883-d5938b953bf4",
+		"0cfd7f6c-1a85-422b-9ea8-8c1dcf0467c1": "crates/core/flags/defs.rs-simstep-1e1e2b32-f650-47f5-b13d-e8b6a6f9c47e",
+		"02cc98f2-4801-485b-b0ee-9780bcee6344": "crates/core/flags/hiargs.rs-simstep-487a5b7a-65d2-4fdf-9a73-2911d82b7f61",
+		"f922a6d3-7cbf-48ac-b204-399522834fe1": "crates/core/search.rs-simstep-cd58a6a2-35b8-4bee-9a79-e6419ea3942d",
+		"fadf13c2-4eee-46a9-945d-a0a12855832b": "generated-edge-simstep-14c535f9-7ea4-4433-9c51-6ea91fec4304-fadf13c2-4eee-46a9-945d-a0a12855832b",
+		"fc568437-30b2-4ab2-a1f0-876eec72e1db": "generated-edge-simstep-3ebae179-adbb-4ac1-b010-1ce0e0476a58-fc568437-30b2-4ab2-a1f0-876eec72e1db",
+		"e7a3ab74-74b5-4476-9b14-836f04678cc7": "generated-edge-simstep-4f1ea281-b9b0-4651-9e19-3f834dd2c885-e7a3ab74-74b5-4476-9b14-836f04678cc7",
+		"d07f3a20-1f28-42d6-8f89-d63f5372b039": "generated-edge-simstep-86b94dae-4068-4544-8ed8-46daf73755e8-d07f3a20-1f28-42d6-8f89-d63f5372b039",
+		"b72ce07f-2387-40a1-90ba-4deafeeb4793": "generated-edge-simstep-bcf37e0f-c3e9-44fd-bb74-a4501dd7b5d2-b72ce07f-2387-40a1-90ba-4deafeeb4793"
+	}
+}


### PR DESCRIPTION

I was trying to understand how `ripgrep` works under the hood so I created a diagram for it using [code-canvas.com](http://code-canvas.com). I think it will be pretty helpful for contributors to quickly onboard to the inner-works of `ripgrep`.

Here is the generated diagram for `ripgrep` grouped by the application's use-cases and their runtime data flows: 
[Open ripgrep's interactive diagram](https://www.code-canvas.com/?session=unauthenticatedGithub&repo=ripgrep&owner=Abdulnaser97&branch=codecanvas-diagram-1759603911463&OnboardingTutorial=true)

<img width="1430" height="669" alt="image" src="https://github.com/user-attachments/assets/51bf9d96-43c6-45e0-9f4c-5f586d8e33cf" />

I built code canvas to simulate a senior engineer who have been working on `ripgrep`'s codebase for pretty long and can explain to you any functionality of the repository visually through diagrams.

Here is what users are saying about codecanvas

"I used to spend 4 hours asking GPT how a use case in a codebase works and I keep going back and forth until I am able to draw a diagram to summarize my understanding,
CodeCanvas gives me that diagram in 40 seconds"

-----

Some Notes:

- The diagram is already generated for `ripgrep`, completely free, no monthly subscription. Consider it as my contribution to help fellow contributors lower their context onboarding friction before they can start contributing.
- The diagram file is stored in the repository itself, so the readme link will only work after merging. Until then, you can view the diagram from the link I shared above.
- Read the [1 pager guide](https://docs.code-canvas.com/updating-diagram) to learn how to refine simulations to capture specific codebase logics you might want to cover.
- You can reach me out anytime on discord [discord.gg/t3ezMyMPqr](https://discord.gg/t3ezMyMPqr)


