### PR TITLE
ignore: fix problem with searching whitelisted hidden files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Bug fixes:
   Ensure hyphens in flag names are escaped in the roff text for the man page.
 * [BUG #3155](https://github.com/BurntSushi/ripgrep/issues/3155):
   Statically compile PCRE2 into macOS release artifacts on `aarch64`.
+* [BUG #3173](https://github.com/BurntSushi/ripgrep/issues/3173):
+  Fix ancestor ignore filter bug when searching whitelisted hidden files.
 
 Feature enhancements:
 


### PR DESCRIPTION
... specifically, when the whitelist comes from a _parent_ gitignore
file.

Our handling of parent gitignores is pretty ham-fisted and has been a
source of some unfortunate bugs. The problem is that we need to strip
the parent path from the path we're searching in order to correctly
apply the globs. But getting this stripping correct seems to be a subtle
affair.

Fixes #3173
