### PR TITLE
ignore: add lowercase r r_extensions

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -219,7 +219,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["qml"], &["*.qml"]),
     (&["qrc"], &["*.qrc"]),
     (&["qui"], &["*.ui"]),
-    (&["r"], &["*.R", "*.r", "*.Rmd", "*.Rnw"]),
+    (&["r"], &["*.R", "*.r", "*.Rmd", "*.rmd", "*.Rnw", "*.rnw"]),
     (&["racket"], &["*.rkt"]),
     (&["raku"], &[
         "*.raku", "*.rakumod", "*.rakudoc", "*.rakutest",


### PR DESCRIPTION
Add lowercase versions of *.Rmd and *.Rnw to the R type. 

These extensions are less common, but useful given that the *.r extension is also added as the R type.

Thanks for all the work you do on rg, if this isn't wanted I'm happy to keep using my custom r type.