### PR TITLE
printer: fix `--stats` for `--json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Bug fixes:
   Statically compile PCRE2 into macOS release artifacts on `aarch64`.
 * [BUG #3173](https://github.com/BurntSushi/ripgrep/issues/3173):
   Fix ancestor ignore filter bug when searching whitelisted hidden files.
+* [BUG #3178](https://github.com/BurntSushi/ripgrep/discussions/3178):
+  Fix bug causing incorrect summary statistics with `--json` flag.
 * [BUG #3179](https://github.com/BurntSushi/ripgrep/issues/3179):
   Fix gitignore bug when searching absolute paths with global gitignores.
 * [BUG #3180](https://github.com/BurntSushi/ripgrep/issues/3180):

--- a/crates/printer/src/json.rs
+++ b/crates/printer/src/json.rs
@@ -817,10 +817,6 @@ impl<'p, 's, M: Matcher, W: io::Write> Sink for JSONSink<'p, 's, M, W> {
         _searcher: &Searcher,
         finish: &SinkFinish,
     ) -> Result<(), io::Error> {
-        if !self.begin_printed {
-            return Ok(());
-        }
-
         self.binary_byte_offset = finish.binary_byte_offset();
         self.stats.add_elapsed(self.start_time.elapsed());
         self.stats.add_searches(1);
@@ -830,6 +826,9 @@ impl<'p, 's, M: Matcher, W: io::Write> Sink for JSONSink<'p, 's, M, W> {
         self.stats.add_bytes_searched(finish.byte_count());
         self.stats.add_bytes_printed(self.json.wtr.count());
 
+        if !self.begin_printed {
+            return Ok(());
+        }
         let msg = jsont::Message::End(jsont::End {
             path: self.path,
             binary_offset: finish.binary_byte_offset(),


### PR DESCRIPTION
Somehow, the JSON printer seems to have never emitted correct summary
statistics. And I believe #3178 is the first time anyone has ever
reported it. I believe this bug has persisted for years. That's
surprising.

Anyway, the problem here was that we were bailing out of `finish()` on
the sink if we weren't supposed to print anything. But we bailed out
before we tallied our summary statistics. Obviously we shouldn't do
that.

Fixes #3178
