### PR TITLE
add Cursor hyperlink alias

### DIFF
--- a/crates/printer/src/hyperlink/aliases.rs
+++ b/crates/printer/src/hyperlink/aliases.rs
@@ -4,6 +4,11 @@ use crate::hyperlink::HyperlinkAlias;
 ///
 /// These need to be sorted by name.
 pub(super) const HYPERLINK_PATTERN_ALIASES: &[HyperlinkAlias] = &[
+    alias(
+        "cursor",
+        "Cursor scheme (cursor://)",
+        "cursor://file{path}:{line}:{column}",
+    ),
     prioritized_alias(
         0,
         "default",
@@ -18,11 +23,6 @@ pub(super) const HYPERLINK_PATTERN_ALIASES: &[HyperlinkAlias] = &[
                 "file://{path}"
             }
         },
-    ),
-    alias(
-        "cursor",
-        "Cursor scheme (cursor://)",
-        "cursor://file{path}:{line}:{column}",
     ),
     alias(
         "file",


### PR DESCRIPTION
Add hyperlink alias for Cursor. It works the same way as the other VSCode forks.
I have the following code in my zshrc but I would like to add the alias officially.
```sh
if [[ "$TERM_PROGRAM" == 'vscode' ]]; then
  alias rg='rg --hyperlink-format="cursor://file{path}:{line}:{column}"'
fi
```