### PR TITLE
ignore/types: add ssa

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -274,6 +274,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["spark"], &["*.spark"]),
     (&["spec"], &["*.spec"]),
     (&["sql"], &["*.sql", "*.psql"]),
+    (&["ssa"], &["*.ssa"]),
     (&["stylus"], &["*.styl"]),
     (&["sv"], &["*.v", "*.vg", "*.sv", "*.svh", "*.h"]),
     (&["svelte"], &["*.svelte", "*.svelte.ts"]),


### PR DESCRIPTION
This PR adds support for [.ssa](https://en.wikipedia.org/wiki/Static_single-assignment_form) files as read by [qbe](https://c9x.me/compile/):

See: https://c9x.me/compile/doc/il.html#Input-Files