### PR TITLE
Fix mistake in man page for -w/--word-regexp

### DIFF
--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -7536,7 +7536,7 @@ impl Flag for WordRegexp {
         r"
 When enabled, ripgrep will only show matches surrounded by word boundaries.
 This is equivalent to surrounding every pattern with \fB\\b{start-half}\fP
-and \fB\\b{end-half}\fP.
+and \fB\{end-half}\b\fP.
 .sp
 This overrides the \flag{line-regexp} flag.
 "


### PR DESCRIPTION
This is a fix for the documentation for the `-w` flag. The feature itself works as intended.

The output of `man rg | grep -B 3 end-half` states that:

       -w, --word-regexp
           When  enabled,  ripgrep will only show matches surrounded by word boundaries.  This is equiva‐
           lent to surrounding every pattern with \b{start-half} and \b{end-half}.

in which the last bit seems incorrect -- `\b{end-half}` should be `{end-half}\b` meaning the END of the pattern match aligns with a word boundary. This seems like a typo or simple mistake.