### PR TITLE
ignore: only stat .jj if we actually care

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ TBD
 ===
 Unreleased changes. Release notes have not yet been written.
 
+Bug fixes:
+
+* [BUG #3212](https://github.com/BurntSushi/ripgrep/pull/3212):
+  Don't check for the existence of `.jj` when `--no-ignore` is used.
+
 
 15.1.0
 ======

--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -256,14 +256,15 @@ impl Ignore {
 
     /// Like add_child, but takes a full path and returns an IgnoreInner.
     fn add_child_path(&self, dir: &Path) -> (IgnoreInner, Option<Error>) {
-        let git_type = if self.0.opts.require_git
-            && (self.0.opts.git_ignore || self.0.opts.git_exclude)
-        {
+        let check_vcs_dir = self.0.opts.require_git
+            && (self.0.opts.git_ignore || self.0.opts.git_exclude);
+        let git_type = if check_vcs_dir {
             dir.join(".git").metadata().ok().map(|md| md.file_type())
         } else {
             None
         };
-        let has_git = git_type.is_some() || dir.join(".jj").exists();
+        let has_git =
+            check_vcs_dir && (git_type.is_some() || dir.join(".jj").exists());
 
         let mut errs = PartialErrorBuilder::default();
         let custom_ig_matcher = if self.0.custom_ignore_filenames.is_empty() {


### PR DESCRIPTION
I was comparing the work being done by fd and find and noticed (with strace -f -c -S calls) that fd was doing a ton of failed statx calls. Upon closer inspection it was stating .jj even though I was passing --no-ignore. Eventually I turned up this check in Ignore::add_child_path that was doing stat on .jj regardless of whether the options request it.

With this patch it'll only stat .jj if that's relevant to the query.