### PR TITLE
Separate flags from paths in decompression tool invocations

### DIFF
--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -488,14 +488,14 @@ fn try_resolve_binary<P: AsRef<Path>>(
 }
 
 fn default_decompression_commands() -> Vec<DecompressionCommand> {
-    const ARGS_GZIP: &[&str] = &["gzip", "-d", "-c"];
-    const ARGS_BZIP: &[&str] = &["bzip2", "-d", "-c"];
-    const ARGS_XZ: &[&str] = &["xz", "-d", "-c"];
-    const ARGS_LZ4: &[&str] = &["lz4", "-d", "-c"];
-    const ARGS_LZMA: &[&str] = &["xz", "--format=lzma", "-d", "-c"];
-    const ARGS_BROTLI: &[&str] = &["brotli", "-d", "-c"];
-    const ARGS_ZSTD: &[&str] = &["zstd", "-q", "-d", "-c"];
-    const ARGS_UNCOMPRESS: &[&str] = &["uncompress", "-c"];
+    const ARGS_GZIP: &[&str] = &["gzip", "-d", "-c", "--"];
+    const ARGS_BZIP: &[&str] = &["bzip2", "-d", "-c", "--"];
+    const ARGS_XZ: &[&str] = &["xz", "-d", "-c", "--"];
+    const ARGS_LZ4: &[&str] = &["lz4", "-d", "-c", "--"];
+    const ARGS_LZMA: &[&str] = &["xz", "--format=lzma", "-d", "-c", "--"];
+    const ARGS_BROTLI: &[&str] = &["brotli", "-d", "-c", "--"];
+    const ARGS_ZSTD: &[&str] = &["zstd", "-q", "-d", "-c", "--"];
+    const ARGS_UNCOMPRESS: &[&str] = &["uncompress", "-c", "--"];
 
     fn add(glob: &str, args: &[&str], cmds: &mut Vec<DecompressionCommand>) {
         let bin = match resolve_binary(Path::new(args[0])) {


### PR DESCRIPTION
This fixes the bug when the filename of a compressed file starts with the `-` character and it gets passed to the decompression tool, but gets treated as an option instead of file.

In the best case, the option would be invalid and the decompression tool would finish with an error. In the worst case, the filename that looks like a valid option could potentially overwrite or remove data as a side effect.

All decompression tools in use here follow the convention that everything after `--` is treated as a filename.