### PR TITLE
clippy: fix `map_clone` lint

### DIFF
--- a/crates/core/search.rs
+++ b/crates/core/search.rs
@@ -389,7 +389,7 @@ fn search_path<M: Matcher, W: WriteColor>(
             searcher.search_path(&matcher, path, &mut sink)?;
             Ok(SearchResult {
                 has_match: sink.has_match(),
-                stats: sink.stats().map(|s| s.clone()),
+                stats: sink.stats().cloned(),
             })
         }
         Printer::Summary(ref mut p) => {
@@ -397,7 +397,7 @@ fn search_path<M: Matcher, W: WriteColor>(
             searcher.search_path(&matcher, path, &mut sink)?;
             Ok(SearchResult {
                 has_match: sink.has_match(),
-                stats: sink.stats().map(|s| s.clone()),
+                stats: sink.stats().cloned(),
             })
         }
         Printer::JSON(ref mut p) => {
@@ -426,7 +426,7 @@ fn search_reader<M: Matcher, R: io::Read, W: WriteColor>(
             searcher.search_reader(&matcher, &mut rdr, &mut sink)?;
             Ok(SearchResult {
                 has_match: sink.has_match(),
-                stats: sink.stats().map(|s| s.clone()),
+                stats: sink.stats().cloned(),
             })
         }
         Printer::Summary(ref mut p) => {
@@ -434,7 +434,7 @@ fn search_reader<M: Matcher, R: io::Read, W: WriteColor>(
             searcher.search_reader(&matcher, &mut rdr, &mut sink)?;
             Ok(SearchResult {
                 has_match: sink.has_match(),
-                stats: sink.stats().map(|s| s.clone()),
+                stats: sink.stats().cloned(),
             })
         }
         Printer::JSON(ref mut p) => {

--- a/crates/globset/src/glob.rs
+++ b/crates/globset/src/glob.rs
@@ -1058,7 +1058,7 @@ impl<'a> Parser<'a> {
     }
 
     fn peek(&mut self) -> Option<char> {
-        self.chars.peek().map(|&ch| ch)
+        self.chars.peek().copied()
     }
 }
 

--- a/crates/matcher/tests/util.rs
+++ b/crates/matcher/tests/util.rs
@@ -54,7 +54,7 @@ impl Matcher for RegexMatcher {
     }
 
     fn capture_index(&self, name: &str) -> Option<usize> {
-        self.names.get(name).map(|i| *i)
+        self.names.get(name).copied()
     }
 
     // We purposely don't implement any other methods, so that we test the

--- a/crates/pcre2/src/matcher.rs
+++ b/crates/pcre2/src/matcher.rs
@@ -337,7 +337,7 @@ impl Matcher for RegexMatcher {
     }
 
     fn capture_index(&self, name: &str) -> Option<usize> {
-        self.names.get(name).map(|i| *i)
+        self.names.get(name).copied()
     }
 
     fn try_find_iter<F, E>(


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#map_clone