### PR TITLE
fix: address clippy::clone_on_copy and clippy::search_is_some lints

### DIFF
--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -549,7 +549,7 @@ impl HiArgs {
         builder
             .color_specs(self.colors.clone())
             .hyperlink(self.hyperlink_config.clone())
-            .separator(self.path_separator.clone())
+            .separator(self.path_separator)
             .terminator(self.path_terminator.unwrap_or(b'\n'));
         builder
     }
@@ -620,7 +620,7 @@ impl HiArgs {
             .max_columns(self.max_columns)
             .only_matching(self.only_matching)
             .path(self.with_filename)
-            .path_terminator(self.path_terminator.clone())
+            .path_terminator(self.path_terminator)
             .per_match_one_line(true)
             .per_match(self.vimgrep)
             .replacement(self.replace.clone().map(|r| r.into()))
@@ -631,7 +631,7 @@ impl HiArgs {
             .separator_field_match(
                 self.field_match_separator.clone().into_bytes(),
             )
-            .separator_path(self.path_separator.clone())
+            .separator_path(self.path_separator)
             .stats(self.stats.is_some())
             .trim_ascii(self.trim);
         // When doing multi-threaded searching, the buffer writer is
@@ -658,9 +658,9 @@ impl HiArgs {
             .hyperlink(self.hyperlink_config.clone())
             .kind(kind)
             .path(self.with_filename)
-            .path_terminator(self.path_terminator.clone())
+            .path_terminator(self.path_terminator)
             .separator_field(b":".to_vec())
-            .separator_path(self.path_separator.clone())
+            .separator_path(self.path_separator)
             .stats(self.stats.is_some())
             .build(wtr)
     }

--- a/crates/printer/src/color.rs
+++ b/crates/printer/src/color.rs
@@ -273,10 +273,10 @@ impl SpecValue {
         match *self {
             SpecValue::None => cspec.clear(),
             SpecValue::Fg(ref color) => {
-                cspec.set_fg(Some(color.clone()));
+                cspec.set_fg(Some(*color));
             }
             SpecValue::Bg(ref color) => {
-                cspec.set_bg(Some(color.clone()));
+                cspec.set_bg(Some(*color));
             }
             SpecValue::Style(ref style) => match *style {
                 Style::Bold => {

--- a/crates/regex/src/ban.rs
+++ b/crates/regex/src/ban.rs
@@ -12,7 +12,7 @@ pub(crate) fn check(expr: &Hir, byte: u8) -> Result<(), Error> {
     match *expr.kind() {
         HirKind::Empty => {}
         HirKind::Literal(hir::Literal(ref lit)) => {
-            if lit.iter().find(|&&b| b == byte).is_some() {
+            if lit.iter().any(|&b| b == byte) {
                 return invalid();
             }
         }
@@ -20,7 +20,7 @@ pub(crate) fn check(expr: &Hir, byte: u8) -> Result<(), Error> {
             if cls.ranges().iter().map(|r| r.len()).sum::<usize>() == 1 {
                 let contains =
                     |r: &&ClassUnicodeRange| r.start() <= ch && ch <= r.end();
-                if cls.ranges().iter().find(contains).is_some() {
+                if cls.ranges().iter().any(|r| contains(&r)) {
                     return invalid();
                 }
             }
@@ -30,7 +30,7 @@ pub(crate) fn check(expr: &Hir, byte: u8) -> Result<(), Error> {
                 let contains = |r: &&ClassBytesRange| {
                     r.start() <= byte && byte <= r.end()
                 };
-                if cls.ranges().iter().find(contains).is_some() {
+                if cls.ranges().iter().any(|r| contains(&r)) {
                     return invalid();
                 }
             }

--- a/crates/regex/src/strip.rs
+++ b/crates/regex/src/strip.rs
@@ -61,7 +61,7 @@ fn strip_from_match_ascii(expr: Hir, byte: u8) -> Result<Hir, Error> {
     Ok(match expr.into_kind() {
         HirKind::Empty => Hir::empty(),
         HirKind::Literal(hir::Literal(lit)) => {
-            if lit.iter().find(|&&b| b == byte).is_some() {
+            if lit.iter().any(|&b| b == byte) {
                 return invalid();
             }
             Hir::literal(lit)


### PR DESCRIPTION
## Summary
This PR addresses two Clippy lints to improve code clarity:

- **`clippy::clone_on_copy`**: Use direct copy (`*color`) instead of `.clone()` for `Copy` types
- **`clippy::search_is_some`**: Use `.any()` instead of `.find().is_some()` for iterator searches

## Changes

- `crates/printer/src/color.rs`: Replace `color.clone()` with `*color`
- `crates/core/flags/hiargs.rs`: Remove `.clone()` on `Option<u8>` fields
- `crates/regex/src/ban.rs`: Replace `.find().is_some()` with `.any()`
- `crates/regex/src/strip.rs`: Replace `.find().is_some()` with `.any()`

## References

- [clippy::clone_on_copy](https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy)
- [clippy::search_is_some](https://rust-lang.github.io/rust-clippy/master/index.html#search_is_some)
