### PR TITLE
Fix compression tests in QEMU cross-compilation environments

### DIFF
--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -922,8 +922,6 @@ be, to a very large extent, the result of luck. Sherlock Holmes
     eqnice!(expected, cmd.stdout());
 });
 
-// lz4 decompression tool doesn't work under RISC-V QEMU emulation in CI
-#[cfg(not(target_arch = "riscv64"))]
 rgtest!(compressed_lz4, |dir: Dir, mut cmd: TestCommand| {
     if !cmd_exists("lz4") {
         return;
@@ -954,8 +952,6 @@ be, to a very large extent, the result of luck. Sherlock Holmes
     eqnice!(expected, cmd.stdout());
 });
 
-// brotli decompression tool doesn't work under RISC-V QEMU emulation in CI
-#[cfg(not(target_arch = "riscv64"))]
 rgtest!(compressed_brotli, |dir: Dir, mut cmd: TestCommand| {
     if !cmd_exists("brotli") {
         return;
@@ -971,8 +967,6 @@ be, to a very large extent, the result of luck. Sherlock Holmes
     eqnice!(expected, cmd.stdout());
 });
 
-// zstd decompression tool doesn't work under RISC-V QEMU emulation in CI
-#[cfg(not(target_arch = "riscv64"))]
 rgtest!(compressed_zstd, |dir: Dir, mut cmd: TestCommand| {
     if !cmd_exists("zstd") {
         return;

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -45,7 +45,10 @@ pub fn sort_lines(lines: &str) -> String {
 /// Returns true if and only if the given program can be successfully executed
 /// with a `--help` flag.
 pub fn cmd_exists(program: &str) -> bool {
-    Command::new(program).arg("--help").output().is_ok()
+    match Command::new(program).arg("--help").output() {
+        Ok(output) => output.status.success(),
+        Err(_) => false,
+    }
 }
 
 /// Dir represents a directory in which tests should be run.


### PR DESCRIPTION
## Problem
Compression tests (lz4, brotli, zstd) fail on `riscv64` when running under QEMU user-mode emulation. The tests attempt to execute compression commands even when the required tools are missing, instead of skipping as expected.

## Root Cause
This is caused by a known limitation in QEMU user-mode's `posix_spawn` implementation. When spawning a non-existent command:
- **Expected:** `posix_spawn` returns `ENOENT` (Error).
- **QEMU:** `posix_spawn` returns `0` (Success), but the child process silently fails with exit code `127`.

**Technical Details:**
1. glibc 2.34+ attempts `clone3()`, which QEMU rejects with `ENOSYS`.
2. It falls back to `clone(CLONE_VM | CLONE_VFORK | ...)`.
3. QEMU silently strips `CLONE_VM` because it cannot share address spaces in process-based emulation ([syscall.c:6729-6731](https://gitlab.com/qemu-project/qemu/-/blob/0db2de22fcbf90adafab9d9dd1fc8203c66bfa75/linux-user/syscall.c#L6729-6731)).
4. Consequently, `fork()` is used (Copy-on-Write).
5. When the child writes the error code (`errno`) to the memory, it writes to its *own* copy. The parent reads the original memory (where error is 0) and assumes success.

This issue specifically affects newer environments (glibc 2.34+, e.g., Ubuntu 22.04+). Older environments like Ubuntu 20.04 (glibc 2.31) are unaffected because they handle `vfork` fallbacks differently, masking the QEMU bug.

## Why this fix is needed
Currently, `aarch64` tests pass only because the CI uses Ubuntu 20.04 (glibc 2.31). Once `cross-rs` or CI images update to Ubuntu 22.04+ (glibc 2.35+), `aarch64` and other architectures will start failing too. This PR prevents future breakages across all architectures.

## The Fix
Updated `cmd_exists()` to verify that the command **executed successfully** (exit code 0), rather than just checking if the spawn call itself returned `Ok`.

* **Native / Normal:** Returns `Err(NotFound)` -> function returns `false`.
* **QEMU (Bugged):** Returns `Ok(ExitStatus(127))` -> `status.success()` is `false` -> function returns `false`.

I also removed the `#[cfg(not(target_arch = "riscv64"))]` guards from the compression tests as they are no longer needed.

## Verification

Verified on an x86_64 host cross-compiling to `riscv64` and `aarch64` (via QEMU user-mode). Tests now correctly skip when compression tools are missing, and pass when they are present.

## Reference

* Related Rust issue: https://github.com/rust-lang/rust/issues/90825

> Edit
Change QEMU gitlab link to specific commit link.