### PR TITLE
doc: add linkable headings for options

### DIFF
--- a/crates/core/flags/doc/man.rs
+++ b/crates/core/flags/doc/man.rs
@@ -45,19 +45,34 @@ pub(crate) fn generate() -> String {
 /// Writes `roff` formatted documentation for `flag` to `out`.
 fn generate_flag(flag: &'static dyn Flag, out: &mut String) {
     writeln!(out, ".TP 12");
-    if let Some(byte) = flag.name_short() {
-        let name = char::from(byte);
-        write!(out, r"\fB\-{name}\fP");
+    let short = flag.name_short().map(char::from);
+    let name = flag.name_long().replace("-", r"\-");
+
+    if short.map(|c| c.is_ascii_alphanumeric()).unwrap_or(false) {
+        let short = short.unwrap();
+        write!(out, r"\fB\-{short}\fP");
         if let Some(var) = flag.doc_variable() {
             write!(out, r" \fI{var}\fP");
         }
         write!(out, r", ");
-    }
 
-    let name = flag.name_long().replace("-", r"\-");
-    write!(out, r"\fB\-\-{name}\fP");
-    if let Some(var) = flag.doc_variable() {
-        write!(out, r"=\fI{var}\fP");
+        write!(out, r"\fB\-\-{name}\fP");
+        if let Some(var) = flag.doc_variable() {
+            write!(out, r"=\fI{var}\fP");
+        }
+    } else {
+        write!(out, r"\fB\-\-{name}\fP");
+        if let Some(var) = flag.doc_variable() {
+            write!(out, r"=\fI{var}\fP");
+        }
+
+        if let Some(short) = short {
+            write!(out, r", ");
+            write!(out, r"\fB\-{short}\fP");
+            if let Some(var) = flag.doc_variable() {
+                write!(out, r" \fI{var}\fP");
+            }
+        }
     }
     write!(out, "\n");
 

--- a/crates/core/flags/doc/man.rs
+++ b/crates/core/flags/doc/man.rs
@@ -44,6 +44,7 @@ pub(crate) fn generate() -> String {
 
 /// Writes `roff` formatted documentation for `flag` to `out`.
 fn generate_flag(flag: &'static dyn Flag, out: &mut String) {
+    writeln!(out, ".TP 12");
     if let Some(byte) = flag.name_short() {
         let name = char::from(byte);
         write!(out, r"\fB\-{name}\fP");


### PR DESCRIPTION
This adds linkable headings for the option list in the generated man page.
Most options already work, but `--hidden` uses `.` as its short form (`-.`),
which prevents some man-to-HTML renderers from generating a stable anchor.
This change prefers the long option as the tag when the short option is not
ASCII alphanumeric, while preserving the usual short/long ordering for normal flags.

This addresses the request in #3243 to make option headings linkable.
