### PR TITLE
ignore/types: refactor lisp into scheme and lisp types

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -153,7 +153,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         "OFL-*[0-9]*",
     ]),
     (&["lilypond"], &["*.ly", "*.ily"]),
-    (&["lisp"], &["*.el", "*.jl", "*.lisp", "*.lsp", "*.sc", "*.scm"]),
+    (&["lisp"], &["*.asd", "*.lisp", "*.lsp"]),
     (&["llvm"], &["*.ll"]),
     (&["lock"], &["*.lock", "package-lock.json"]),
     (&["log"], &["*.log"]),
@@ -242,6 +242,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["sass"], &["*.sass", "*.scss"]),
     (&["scala"], &["*.scala", "*.sbt"]),
     (&["scdoc"], &["*.scd", "*.scdoc"]),
+    (&["scheme"], &["*.sc", "*.sch", "*.sld", "*.sls", "*.sps", "*.scm"]),
     (&["seed7"], &["*.sd7", "*.s7i"]),
     (&["sh"], &[
         // Portable/misc. init files


### PR DESCRIPTION
This PR refactors and cleans up the `lisp` type and adds a new `scheme` type.

Scheme and Lisp (Common Lisp) should be kept separate conceptually as they are different languages. Additionally, Julia code should not show up when searching for Lisp code. We already have an `elisp` type, so people searching for Emacs Lisp code should use that type for clarity and intent.

Lisp type changes:
- Added *.asd (ASDF system definition files - the standard build system for Common Lisp)
- Removed *.el (use `elisp` type instead)
- Removed *.jl (Julia, not a Lisp in the strict sense and we already have a `julia` type)
- Removed *.sc and *.scm (moved to new `scheme` type)

New Scheme type added:
- *.scm - Standard Scheme source code
- *.sc - Scheme source (alternate, rare)
- *.sch - Scheme source (alternate, rare)
- *.sld - R7RS library definition files
- *.sls - R6RS library source files
- *.sps - R6RS program source files

References:
- ASDF: https://asdf.common-lisp.dev/
- Scheme file extensions registry: https://registry.scheme.org/ (See the __Filename extensions__ section)
- R6RS specification: https://r6rs.org/
- R7RS specification: https://small.r7rs.org/