### PR TITLE
printer: add Zed hyperlink alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Bug fixes:
 * [BUG #3212](https://github.com/BurntSushi/ripgrep/pull/3212):
   Don't check for the existence of `.jj` when `--no-ignore` is used.
 
+Feature enhancements:
+
+* [FEATURE #3255](https://github.com/BurntSushi/ripgrep/pull/3255):
+  Add hyperlink alias for Zed.
+
 
 15.1.0
 ======

--- a/crates/printer/src/hyperlink/aliases.rs
+++ b/crates/printer/src/hyperlink/aliases.rs
@@ -65,6 +65,8 @@ pub(super) const HYPERLINK_PATTERN_ALIASES: &[HyperlinkAlias] = &[
         "VSCodium scheme (vscodium://)",
         "vscodium://file{path}:{line}:{column}",
     ),
+    // https://zed.dev/
+    alias("zed", "Zed scheme (zed://)", "zed://file{path}:{line}:{column}"),
 ];
 
 /// Creates a [`HyperlinkAlias`].


### PR DESCRIPTION
Similar to other editor aliases, main change is that this uses the `zed://` scheme

## Test plan
This results in line numbers and column numbers being emitted as expected
```sh
cargo run -- --hyperlink-format=zed "main"
```

