### PR TITLE
Add support for Toit language in default types.

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -296,6 +296,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         "*.terraformrc", "terraform.rc", "*.tfrc", "*.terraform.lock.hcl",
     ]),
     (&["thrift"], &["*.thrift"]),
+    (&["toit"], &["*.toit"]),
     (&["toml"], &["*.toml", "Cargo.lock"]),
     (&["ts", "typescript"], &["*.ts", "*.tsx", "*.cts", "*.mts"]),
     (&["twig"], &["*.twig"]),


### PR DESCRIPTION
A minor change but incredibly useful for me.  Toit was a commercial project, but open sourced a few years ago.  Its a language and a framework/container runtime for embedded platforms like ESP32.  I can't speak to how popular it is, although I don't know that there are other platforms doing what these guys do - if you dive into the people behind it and their genius, my guess is that its only a matter of time before it gets more noticed and takes off a bit.

After seeing PR #3253, here are some links to save you the time:
- More from [https://toitlang.org/](https://toitlang.org/), with [docs](https://docs.toit.io/) and [package repo](https://pkg.toit.io/).
- It's got [VSCode](https://marketplace.visualstudio.com/items?itemName=toit.toit) support and published with MS to get using [winget](https://github.com/microsoft/winget-pkgs/tree/2ffd111109010e867223eb73b5e31dcd59d5ad43/manifests/t/Toit), similar on the respective tools for Linux etc.
- I know its in some commercial products, see [https://toit.io/](https://toit.io/).

Disclosure: I'm not a maintainer/owner or anything, but since its made my life so much better, its my go to.  (I may also have become a fanboi!).  I contribute PR's if there's anything noteworthy, and publish my own Toit material for others. 

Thanks for your consideration!