### PR TITLE
ci: replace cargo install with install-action for cargo-fuzz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,9 +255,10 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install Fuzzer
-        run: cargo install cargo-fuzz
-        working-directory: fuzz
+      - name: Install cargo-fuzz
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
 
       - name: Verify fuzz targets build
         run: cargo check


### PR DESCRIPTION
Use [`taiki-e/install-action`](https://github.com/taiki-e/install-action) to install from a binary (from GitHub Releases) instead of compiling from source.