### PR TITLE
ignore/types: add Containerfile

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -47,6 +47,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["cml"], &["*.cml"]),
     (&["coffeescript"], &["*.coffee"]),
     (&["config"], &["*.cfg", "*.conf", "*.config", "*.ini"]),
+    (&["container"], &["*Containerfile*", "*Dockerfile*"]),
     (&["coq"], &["*.v"]),
     (&["cpp"], &[
         "*.[ChH]", "*.cc", "*.[ch]pp", "*.[ch]xx", "*.hh",  "*.inl",


### PR DESCRIPTION
This PR adds `Containerfile` as a synonym to `Dockerfile`.

`Containerfile` is the preferred file name in [Podman](https://docs.podman.io/en/latest/markdown/podman-build.1.html#file-f-containerfile) and [Buildah](https://github.com/containers/buildah/blob/main/docs/buildah-build.1.md).

In hindsight, `docker` could be not the best name for the file type, but my thinking is that it's best to leave it as it is than to add a new type, let alone rename it. Also, `container` would have been too generalized, and `containerfile` would have been too long to type.