### PR TITLE
core: bleat a DEBUG message when RIPGREP_CONFIG_PATH is not set

### DIFF
--- a/crates/core/flags/config.rs
+++ b/crates/core/flags/config.rs
@@ -15,7 +15,13 @@ use bstr::{ByteSlice, io::BufReadExt};
 /// Return a sequence of arguments derived from ripgrep rc configuration files.
 pub fn args() -> Vec<OsString> {
     let config_path = match std::env::var_os("RIPGREP_CONFIG_PATH") {
-        None => return vec![],
+        None => {
+            log::debug!(
+                "RIPGREP_CONFIG_PATH environment variable is not set, \
+                 therefore not reading any config file"
+            );
+            return vec![];
+        }
         Some(config_path) => {
             if config_path.is_empty() {
                 return vec![];


### PR DESCRIPTION
It seems to be common that folks either don't understand how to set
environment variables in a way that propagates to subprocesses, or just
forget to include `export` and think ripgrep is somehow broken.

While `RIPGREP_CONFIG_PATH` not being set is not an error, it still
seems useful to log a debug message when it isn't. This should hopefully
provide a clue that, no, ripgrep isn't broken. It just doesn't see the
environment variable.

Ref #3277
