### PR TITLE
docs: clarify half-boundary syntax for the -w/--word-regexp flag

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1004,7 +1004,11 @@ used options that will likely impact how you use ripgrep on a regular basis.
    as a literal string.
 * `-w/--word-regexp`: Require that all matches of the pattern be surrounded
   by word boundaries. That is, given `pattern`, the `--word-regexp` flag will
-  cause ripgrep to behave as if `pattern` were actually `\b(?:pattern)\b`.
+  cause ripgrep to behave as if `pattern` were actually
+  `\b{start-half}(?:pattern)\b{end-half}`.
+  (Unlike `\b`, these half-boundaries don't require a word character on one
+  side. For example, `rg -w -e -2` will match `-2` in `(-2)` but `rg '\b-2\b'`
+  will not.)
 * `-c/--count`: Report a count of total matched lines.
 * `--files`: Print the files that ripgrep *would* search, but don't actually
   search them.

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -7535,8 +7535,12 @@ impl Flag for WordRegexp {
     fn doc_long(&self) -> &'static str {
         r"
 When enabled, ripgrep will only show matches surrounded by word boundaries.
-This is equivalent to surrounding every pattern with \fB\\b{start-half}\fP
-and \fB\\b{end-half}\fP.
+This is equivalent to surrounding every pattern with \fB\\b{start-half}\fP and
+\fB\\b{end-half}\fP. These are a custom syntax from ripgrep's default regex
+engine that, unlike \fB\\b\fP, doesn't require matching a word character on one
+side. That is, \fB\\b{start-half}\fP corresponds to matching \fB\\W|\\A\fP on
+the left and \fB\\b{end-half}\fP corresponds to matching \fB\\W|\\z\fP on the
+right.
 .sp
 This overrides the \flag{line-regexp} flag.
 "


### PR DESCRIPTION
In [regex 1.10.0](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#1100-2023-10-09), the `\b{start-half}` and `\b{end-half}` assertions were introduced to improve how the `-w`/`--word-regexp` flag handles patterns containing non-word characters. While ripgrep's CLI help text was updated to mention this syntax during the lexopt transition (082245d), it omitted the rationale, potentially leaving users puzzled by this casual mention of a highly specific, non-standard regex feature.

Furthermore, `GUIDE.md` was still outdated, incorrectly claiming that `-w` wraps patterns in standard `\b` boundaries, further compounding the inconsistency and potential for confusion.

This patch updates `GUIDE.md` to reflect the actual underlying regex employed by ripgrep when the `-w`/`--word-regexp` flag is used.
It also adds a brief explanation to both the guide and the manpage acknowledging the non-standard nature of these half-boundary markers, and explaining what they're meant for.
