### PR TITLE
fix: use -- separator when passing file paths to decompression tools

### DIFF
--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -226,7 +226,7 @@ impl DecompressionReaderBuilder {
         let Some(mut cmd) = self.matcher.command(path) else {
             return DecompressionReader::new_passthru(path);
         };
-        cmd.arg(path);
+        cmd.arg("--").arg(path);
 
         match self.command_builder.build(&mut cmd) {
             Ok(cmd_reader) => Ok(DecompressionReader { rdr: Ok(cmd_reader) }),


### PR DESCRIPTION
## Summary

Fixes #3222 - Files with dash-prefixed names (e.g., `-10.txt.gz`) were causing decompression tools to fail with errors like `gzip: invalid option -- '0'` when using the `-z` flag.

## The Problem

When searching compressed files with `-z`, ripgrep spawns external decompression tools (gzip, bzip2, xz, etc.) and passes the file path as an argument:

```
gzip -d -c ./-10.txt.gz
```

This fails because gzip interprets `-10.txt.gz` as options, not a filename.

## The Fix

Added `--` separator before the file path to signal end of options:

```
gzip -d -c -- ./-10.txt.gz
```

## Testing

Verified locally:
```bash
$ echo "test content" > ./-10.txt
$ gzip ./-10.txt
$ rg -z test .
./-10.txt.gz:test content
```

## Changes

- `crates/cli/src/decompress.rs`: Single line change to add `--` separator

This is a minimal, safe fix that follows standard POSIX conventions for handling dash-prefixed filenames.