### PR TITLE
Add PKGBUILD type

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -207,6 +207,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         "*.php", "*.php3", "*.php4", "*.php5", "*.php7", "*.php8",
         "*.pht", "*.phtml"
     ]),
+    (&["pkgbuild"], &["PKGBUILD"]),
     (&["po"], &["*.po"]),
     (&["pod"], &["*.pod"]),
     (&["postscript"], &["*.eps", "*.ps"]),


### PR DESCRIPTION
I keep running into:
```
% rg something -t PKGBUILD
rg: unrecognized file type: PKGBUILD
```
And decided I should probably submit a patch for this. It seems convention is the type needs to be all lowercase, if allowed I would also add the uppercase variant as an alias (otherwise just keep as-is).

Thanks!