### PR TITLE
docs: fix typo in stats comment

### DIFF
--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -427,7 +427,7 @@ fn eprint_nothing_searched() {
 /// The `started` time should be the time at which ripgrep started working.
 ///
 /// If an error occurs while writing, then writing stops and the error is
-/// returned. Note that callers should probably ignore this errror, since
+/// returned. Note that callers should probably ignore this error, since
 /// whether stats fail to print or not generally shouldn't cause ripgrep to
 /// enter into an "error" state. And usually the only way for this to fail is
 /// if writing to stdout itself fails.


### PR DESCRIPTION
Summary\n- Fix a spelling mistake in a documentation comment.\n\nRelated issue\n- N/A\n\nGuideline alignment\n- https://github.com/BurntSushi/ripgrep (no CONTRIBUTING.md or PR template found)\n\nValidation\n- Not run (comment-only change).