### PR TITLE
upgrade the lower bound for termcolor from 1.1.0 to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ ignore = { version = "0.4.24", path = "crates/ignore" }
 lexopt = "0.3.0"
 log = "0.4.5"
 serde_json = "1.0.23"
-termcolor = "1.1.0"
+termcolor = "1.4.0"
 textwrap = { version = "0.16.0", default-features = false }
 
 [target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.tikv-jemallocator]


### PR DESCRIPTION
If you try to build it with a lower version, it fails, for example like this with 1.3.0:

```
error[E0599]: the method `clone` exists for struct `SearchWorker<Buffer>`, but its trait bounds were not satisfied
    --> crates/core/main.rs:181:37
     |
 181 |         let mut searcher = searcher.clone();
     |                                     ^^^^^ method cannot be called on `SearchWorker<Buffer>` due to unsatisfied trait bounds
     |
    ::: crates/core/search.rs:230:1
     |
 230 | pub(crate) struct SearchWorker<W> {
     | --------------------------------- method `clone` not found for this struct because it doesn't satisfy `SearchWorker<Buffer>: Clone`
     |
    ::: /home/capitol/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/termcolor-1.3.0/src/lib.rs:1183:1
     |
1183 | pub struct Buffer(BufferInner);
     | ----------------- doesn't satisfy `Buffer: Clone`
     |
note: trait bound `Buffer: Clone` was not satisfied
    --> crates/core/search.rs:229:10
     |
 229 | #[derive(Clone, Debug)]
     |          ^^^^^ unsatisfied trait bound introduced in this `derive` macro
     = help: items from traits can only be used if the trait is implemented and in scope
     = note: the following trait defines an item `clone`, perhaps you need to implement it:
             candidate #1: `Clone`

error[E0282]: type annotations needed
   --> crates/core/main.rs:190:17
    |
190 |             let search_result = match searcher.search(&haystack) {
    |                 ^^^^^^^^^^^^^
...
197 |             if search_result.has_match() {
    |                ------------- type must be known at this point
    |
help: consider giving `search_result` an explicit type
    |
190 |             let search_result: /* Type */ = match searcher.search(&haystack) {
    |                              ++++++++++++
```

from: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/ripgrep/debian/patches/bump-termcolor.diff?ref_type=heads