### PR TITLE
ci: add riscv64 to release build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,10 @@ jobs:
           target: s390x-unknown-linux-gnu
           strip: s390x-linux-gnu-strip
           qemu: qemu-s390x
+        - build: stable-riscv64
+          os: ubuntu-24.04-riscv
+          rust: stable
+          target: riscv64gc-unknown-linux-gnu
         - build: macos
           os: macos-latest
           rust: nightly
@@ -134,7 +138,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install packages (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu')
       shell: bash
       run: |
         ci/ubuntu-install-packages
@@ -198,6 +202,11 @@ jobs:
           "ghcr.io/cross-rs/${{ matrix.target }}:main" \
           "${{ matrix.strip }}" \
           "/$BIN"
+
+    - name: Strip release binary (native riscv64)
+      if: matrix.build == 'stable-riscv64'
+      shell: bash
+      run: strip "$BIN"
 
     - name: Determine archive name
       shell: bash


### PR DESCRIPTION
Adds `riscv64gc-unknown-linux-gnu` to the release build matrix, so future ripgrep releases include a native riscv64 binary.

Uses the RISE Project's native riscv64 GitHub Actions runners (`ubuntu-24.04-riscv`) instead of cross-compilation, following the same pattern as the `windows-11-arm` native builds. This avoids cross-rs riscv64 issues entirely.

Changes:
1. New matrix entry `stable-riscv64` with `os: ubuntu-24.04-riscv`
2. Widened "Install packages" condition to `startsWith(matrix.os, 'ubuntu')` so RISE runners also get build deps
3. Added native strip step for riscv64 (like the macOS native strip)

**RISE runners**: `ubuntu-24.04-riscv` is a native riscv64 runner provided by the [RISE Project](https://riseproject.dev/), free for open source. To enable: install the [RISE runners GitHub App](https://github.com/apps/rise-risc-v-runners). Already used by llama.cpp, and others. Without the app installed, the job stays queued with no available runner.

Build validated on native riscv64 hardware (BananaPi F3, SpacemiT K1, rv64gc) and on RISE runner: https://github.com/gounthar/ripgrep/actions/runs/23355353337

Closes #3310