### PR TITLE
fix: add -- separator before filename in compression tools

### DIFF
--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -226,7 +226,7 @@ impl DecompressionReaderBuilder {
         let Some(mut cmd) = self.matcher.command(path) else {
             return DecompressionReader::new_passthru(path);
         };
-        cmd.arg(path);
+        cmd.arg("--").arg(path);
 
         match self.command_builder.build(&mut cmd) {
             Ok(cmd_reader) => Ok(DecompressionReader { rdr: Ok(cmd_reader) }),


### PR DESCRIPTION
When searching compressed files with names that start with a dash (e.g., `-10.txt.gz`), ripgrep fails because the compression tool interprets the filename as command options.

Here's the issue that this PR addresses:
```
$ echo "hello" > ./-10.txt
$ gzip ./-10.txt
$ rg -z .
gzip: invalid option -- '0'
Try `gzip --help' for more information.
```

This happens because ripgrep calls compression tools like `gzip -d -c -10.txt.gz`, where `-10.txt.gz` gets parsed as invalid options.

The fix is simple: add `--` before the filename argument. This is the standard POSIX "end of options" marker that tells the tool everything following it should be treated as positional arguments, not options.

After this fix:
```
$ echo "hello" > ./-10.txt
$ gzip ./-10.txt
$ rg -z hello
-10.txt.gz:1:hello
```

This aligns with how most shell commands handle filenames that might be confused with options.

Fixes #3222