### PR TITLE
deps: update for direct-minimal-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,29 @@ jobs:
       shell: bash
       run: ${{ env.CARGO }} test --bin rg ${{ env.TARGET_FLAGS }} flags::defs::tests::available_shorts -- --nocapture
 
-     # Setup and compile on the wasm32-wasip1 target
+  direct-minimal-versions:
+    name: Verify minimal versions of direct dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+
+      - name: Update lockfile with minimal versions
+        run: cargo update -Z direct-minimal-versions
+
+      - name: Build ripgrep and all crates
+        run: cargo build --verbose --workspace
+
+      - name: Build ripgrep with PCRE2
+        run: cargo build --verbose --workspace --features pcre2
+
+  # Setup and compile on the wasm32-wasip1 target
   wasm:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,18 +55,18 @@ bstr = "1.7.0"
 grep = { version = "0.4.1", path = "crates/grep" }
 ignore = { version = "0.4.24", path = "crates/ignore" }
 lexopt = "0.3.0"
-log = "0.4.5"
-serde_json = "1.0.23"
-termcolor = "1.1.0"
+log = "0.4.20"
+serde_json = "1.0.107"
+termcolor = "1.4.0"
 textwrap = { version = "0.16.0", default-features = false }
 
 [target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.tikv-jemallocator]
 version = "0.6.0"
 
 [dev-dependencies]
-serde = "1.0.77"
-serde_derive = "1.0.77"
-walkdir = "2"
+serde = "1.0.193"
+serde_derive = "1.0.193"
+walkdir = "2.4.0"
 
 [features]
 pcre2 = ["grep/pcre2"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,10 +14,10 @@ license = "Unlicense OR MIT"
 edition = "2024"
 
 [dependencies]
-bstr = { version = "1.6.2", features = ["std"] }
+bstr = { version = "1.7.0", features = ["std"] }
 globset = { version = "0.4.18", path = "../globset" }
 log = "0.4.20"
-termcolor = "1.3.0"
+termcolor = "1.4.0"
 
 [target.'cfg(windows)'.dependencies.winapi-util]
 version = "0.1.6"

--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -21,10 +21,10 @@ bench = false
 
 [dependencies]
 aho-corasick = "1.1.1"
-arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
-bstr = { version = "1.6.2", default-features = false, features = ["std"] }
+arbitrary = { version = "1.4.2", optional = true, features = ["derive"] }
+bstr = { version = "1.7.0", default-features = false, features = ["std"] }
 log = { version = "0.4.20", optional = true }
-serde = { version = "1.0.188", optional = true }
+serde = { version = "1.0.193", optional = true }
 
 [dependencies.regex-syntax]
 version = "0.8.0"
@@ -32,7 +32,7 @@ default-features = false
 features = ["std"]
 
 [dependencies.regex-automata]
-version = "0.4.0"
+version = "0.4.1"
 default-features = false
 features = ["std", "perf", "syntax", "meta", "nfa", "hybrid"]
 

--- a/crates/grep/Cargo.toml
+++ b/crates/grep/Cargo.toml
@@ -22,8 +22,8 @@ grep-regex = { version = "0.1.14", path = "../regex" }
 grep-searcher = { version = "0.1.16", path = "../searcher" }
 
 [dev-dependencies]
-termcolor = "1.0.4"
-walkdir = "2.2.7"
+termcolor = "1.4.0"
+walkdir = "2.4.0"
 
 [features]
 pcre2 = ["grep-pcre2"]

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -27,15 +27,15 @@ same-file = "1.0.6"
 walkdir = "2.4.0"
 
 [dependencies.regex-automata]
-version = "0.4.0"
+version = "0.4.1"
 default-features = false
 features = ["std", "perf", "syntax", "meta", "nfa", "hybrid", "dfa-onepass"]
 
 [target.'cfg(windows)'.dependencies.winapi-util]
-version = "0.1.2"
+version = "0.1.6"
 
 [dev-dependencies]
-bstr = { version = "1.6.2", default-features = false, features = ["std"] }
+bstr = { version = "1.7.0", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.15"
 
 [features]

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -19,11 +19,11 @@ default = ["serde"]
 serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
-bstr = "1.6.2"
+bstr = "1.7.0"
 grep-matcher = { version = "0.1.8", path = "../matcher" }
 grep-searcher = { version = "0.1.16", path = "../searcher" }
-log = "0.4.5"
-termcolor = "1.3.0"
+log = "0.4.20"
+termcolor = "1.4.0"
 serde = { version = "1.0.193", optional = true }
 serde_json = { version = "1.0.107", optional = true }
 

--- a/crates/regex/Cargo.toml
+++ b/crates/regex/Cargo.toml
@@ -14,8 +14,8 @@ license = "Unlicense OR MIT"
 edition = "2024"
 
 [dependencies]
-bstr = "1.6.2"
+bstr = "1.7.0"
 grep-matcher = { version = "0.1.8", path = "../matcher" }
 log = "0.4.20"
-regex-automata = { version = "0.4.0" }
+regex-automata = { version = "0.4.1" }
 regex-syntax = "0.8.0"

--- a/crates/searcher/Cargo.toml
+++ b/crates/searcher/Cargo.toml
@@ -14,7 +14,7 @@ license = "Unlicense OR MIT"
 edition = "2024"
 
 [dependencies]
-bstr = { version = "1.6.2", default-features = false, features = ["std"] }
+bstr = { version = "1.7.0", default-features = false, features = ["std"] }
 encoding_rs = "0.8.33"
 encoding_rs_io = "0.1.7"
 grep-matcher = { version = "0.1.8", path = "../matcher" }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.16"
+version = "0.4.18"
 dependencies = [
  "aho-corasick",
  "arbitrary",


### PR DESCRIPTION
Fix the build when using minimum dependencies specified in `Cargo.toml` ([-Z direct-minimal-versions](https://doc.rust-lang.org/cargo/reference/unstable.html#direct-minimal-versions))

Closes https://github.com/BurntSushi/ripgrep/pull/3308