### PR TITLE
Add support for custom separator in globset

### DIFF
--- a/crates/globset/examples/custom_separator.rs
+++ b/crates/globset/examples/custom_separator.rs
@@ -1,0 +1,47 @@
+use globset::GlobBuilder;
+
+fn main() {
+    let patterns = vec!["hello.*.rld", "hello.*.*.rld", "hello.**.rld"];
+    let targets = vec!["hello.b.rld", "hello.w..rld"];
+
+    println!("--- Testing Custom Separator ('.') ---\n");
+
+    for pattern in patterns {
+        println!("Pattern: \"{}\"", pattern);
+
+        let glob = GlobBuilder::new(pattern)
+            .separator('.')
+            .literal_separator(true)
+            .build()
+            .unwrap()
+            .compile_matcher();
+
+        for target in &targets {
+            let matches = glob.is_match(target);
+            let status = if matches { "MATCH" } else { "FAIL " };
+            println!("  [{}] Target: \"{}\"", status, target);
+        }
+        println!();
+    }
+
+    println!("--- Testing Default Behavior (Standard Paths) ---\n");
+    let default_glob = GlobBuilder::new("src/*.rs")
+        .literal_separator(true)
+        .build()
+        .unwrap()
+        .compile_matcher();
+
+    println!("Pattern: \"src/*.rs\" (Default separator '/')");
+    println!(
+        "  [{}] Target: \"src/lib.rs\"",
+        if default_glob.is_match("src/lib.rs") { "MATCH" } else { "FAIL " }
+    );
+    println!(
+        "  [{}] Target: \"src/path/to.rs\"",
+        if default_glob.is_match("src/path/to.rs") {
+            "MATCH"
+        } else {
+            "FAIL "
+        }
+    );
+}

--- a/crates/globset/src/glob.rs
+++ b/crates/globset/src/glob.rs
@@ -233,7 +233,11 @@ struct GlobOptions {
     /// character class is found, the opening `[` is treated as a literal `[`.
     /// When this isn't enabled, an opening `[` without a corresponding `]` is
     /// treated as an error.
+    /// By default, this is false.
     allow_unclosed_class: bool,
+    /// The separator character to use for path matching.
+    /// By default, this is `/`.
+    separator: char,
 }
 
 impl GlobOptions {
@@ -244,6 +248,7 @@ impl GlobOptions {
             backslash_escape: !is_separator('\\'),
             empty_alternates: false,
             allow_unclosed_class: false,
+            separator: '/',
         }
     }
 }
@@ -442,7 +447,7 @@ impl Glob {
             lit.push(c);
         }
         if need_sep {
-            lit.push('/');
+            lit.push(self.opts.separator);
         }
         if lit.is_empty() { None } else { Some(lit) }
     }
@@ -469,7 +474,7 @@ impl Glob {
                 // We only care if this follows a path component if the next
                 // token is a literal.
                 if let Some(&Token::Literal(_)) = self.tokens.get(1) {
-                    lit.push('/');
+                    lit.push(self.opts.separator);
                     (1, true)
                 } else {
                     (1, false)
@@ -493,7 +498,11 @@ impl Glob {
             let Token::Literal(c) = *t else { return None };
             lit.push(c);
         }
-        if lit.is_empty() || lit == "/" { None } else { Some((lit, entire)) }
+        if lit.is_empty() || lit == self.opts.separator.to_string() {
+            None
+        } else {
+            Some((lit, entire))
+        }
     }
 
     /// If this pattern only needs to inspect the basename of a file path,
@@ -525,7 +534,7 @@ impl Glob {
         }
         for t in self.tokens[start..].iter() {
             match *t {
-                Token::Literal('/') => return None,
+                Token::Literal(c) if c == self.opts.separator => return None,
                 Token::Literal(_) => {} // OK
                 Token::Any | Token::ZeroOrMore => {
                     if !self.opts.literal_separator {
@@ -664,6 +673,19 @@ impl<'a> GlobBuilder<'a> {
         self.opts.allow_unclosed_class = yes;
         self
     }
+
+    /// Set the separator character to use for this pattern.
+    ///
+    /// By default, the separator character is `/`.
+    ///
+    /// Note that when a separator is set, it is used instead of the platform's
+    /// default path separator(s). For example, if you set the separator to
+    /// `.`, then `*` will not match `.` if `literal_separator` is enabled,
+    /// but it *will* match `/`.
+    pub fn separator(&mut self, c: char) -> &mut GlobBuilder<'a> {
+        self.opts.separator = c;
+        self
+    }
 }
 
 impl Tokens {
@@ -695,6 +717,7 @@ impl Tokens {
         tokens: &[Token],
         re: &mut String,
     ) {
+        let sep = char_to_escaped_literal(options.separator);
         for tok in tokens.iter() {
             match *tok {
                 Token::Literal(c) => {
@@ -702,26 +725,41 @@ impl Tokens {
                 }
                 Token::Any => {
                     if options.literal_separator {
-                        re.push_str("[^/]");
+                        re.push_str("[^");
+                        re.push_str(&sep);
+                        re.push(']');
                     } else {
                         re.push_str(".");
                     }
                 }
                 Token::ZeroOrMore => {
                     if options.literal_separator {
-                        re.push_str("[^/]*");
+                        re.push_str("[^");
+                        re.push_str(&sep);
+                        re.push_str("]*");
                     } else {
                         re.push_str(".*");
                     }
                 }
                 Token::RecursivePrefix => {
-                    re.push_str("(?:/?|.*/)");
+                    re.push_str("(?:");
+                    re.push_str(&sep);
+                    re.push_str("?|.*");
+                    re.push_str(&sep);
+                    re.push(')');
                 }
                 Token::RecursiveSuffix => {
-                    re.push_str("/.*");
+                    re.push_str(&sep);
+                    re.push_str(".*");
                 }
                 Token::RecursiveZeroOrMore => {
-                    re.push_str("(?:/|/.*/)");
+                    re.push_str("(?:");
+                    re.push_str(&sep);
+                    re.push_str("|");
+                    re.push_str(&sep);
+                    re.push_str(".*");
+                    re.push_str(&sep);
+                    re.push(')');
                 }
                 Token::Class { negated, ref ranges } => {
                     re.push('[');
@@ -906,17 +944,17 @@ impl<'a> Parser<'a> {
         }
         assert!(self.bump() == Some('*'));
         if !self.have_tokens()? {
-            if !self.peek().map_or(true, is_separator) {
+            if !self.peek().map_or(true, |c| self.is_sep(c)) {
                 self.push_token(Token::ZeroOrMore)?;
                 self.push_token(Token::ZeroOrMore)?;
             } else {
                 self.push_token(Token::RecursivePrefix)?;
-                assert!(self.bump().map_or(true, is_separator));
+                assert!(self.bump().map_or(true, |c| self.is_sep(c)));
             }
             return Ok(());
         }
 
-        if !prev.map(is_separator).unwrap_or(false) {
+        if !prev.map(|c| self.is_sep(c)).unwrap_or(false) {
             if self.branches.len() <= 1
                 || (prev != Some(',') && prev != Some('{'))
             {
@@ -931,8 +969,8 @@ impl<'a> Parser<'a> {
                 true
             }
             Some(',') | Some('}') if self.branches.len() >= 2 => true,
-            Some(c) if is_separator(c) => {
-                assert!(self.bump().map(is_separator).unwrap_or(false));
+            Some(c) if self.is_sep(c) => {
+                assert!(self.bump().map(|c| self.is_sep(c)).unwrap_or(false));
                 false
             }
             _ => {
@@ -1059,6 +1097,14 @@ impl<'a> Parser<'a> {
 
     fn peek(&mut self) -> Option<char> {
         self.chars.peek().map(|&ch| ch)
+    }
+
+    fn is_sep(&self, c: char) -> bool {
+        if self.opts.separator == '/' {
+            is_separator(c)
+        } else {
+            c == self.opts.separator
+        }
     }
 }
 

--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -1136,4 +1136,62 @@ mod tests {
             "GlobSetBuilder { pats: [Glob(\"*foo*\"), Glob(\"*bar*\"), Glob(\"*quux*\")] }",
         );
     }
+
+    #[test]
+    fn custom_separator_works() {
+        use crate::glob::GlobBuilder;
+
+        // Test with '.' as separator
+        let glob = GlobBuilder::new("foo.*.bar")
+            .separator('.')
+            .literal_separator(true)
+            .build()
+            .unwrap()
+            .compile_matcher();
+
+        assert!(glob.is_match("foo.a.bar"));
+        assert!(!glob.is_match("foo.a.b.bar")); // * should not match across '.'
+        assert!(glob.is_match("foo./.bar")); // * matches '/' because it's not the separator
+
+        // Test with '**' and '.' as separator
+        let glob = GlobBuilder::new("foo.**.bar")
+            .separator('.')
+            .build()
+            .unwrap()
+            .compile_matcher();
+
+        assert!(glob.is_match("foo.a.bar"));
+        assert!(glob.is_match("foo.a.b.bar"));
+        assert!(glob.is_match("foo.bar"));
+    }
+
+    #[test]
+    fn custom_separator_escaping_works() {
+        use crate::glob::GlobBuilder;
+
+        // Test with '|' as separator (ensure it's escaped in regex)
+        let glob = GlobBuilder::new("a|*|b")
+            .separator('|')
+            .literal_separator(true)
+            .build()
+            .unwrap()
+            .compile_matcher();
+
+        assert!(glob.is_match("a|x|b"));
+        assert!(!glob.is_match("a|x|y|b"));
+    }
+
+    #[test]
+    fn default_separator_behavior_unchanged() {
+        use crate::glob::GlobBuilder;
+
+        let glob = GlobBuilder::new("foo/*/bar")
+            .literal_separator(true)
+            .build()
+            .unwrap()
+            .compile_matcher();
+
+        assert!(glob.is_match("foo/a/bar"));
+        assert!(!glob.is_match("foo/a/b/bar"));
+    }
 }


### PR DESCRIPTION
**Summary**

This PR adds support for custom component separators to the globset crate, resolving #2703.
While globset is primarily used for file paths (using / or \), this change allows it to be used for any hierarchical string format (e.g., matching Python module names like pkg.module.*).

**Changes**

- Added a new public method GlobBuilder::separator(char) to configure the boundary character for a pattern.
- Updated the regex generation logic to use the custom separator (with automatic escaping for meta-characters like . or |).
- Updated the glob parser to correctly identify recursive wildcards (**) based on the custom separator.
- Ensured all existing matching optimizations (prefix, suffix, basename) respect the new configuration.

**Verification**

- New Tests : Added unit tests in crates/globset/src/lib.rs for basic and recursive matching with custom separators (. and |).
- Regressions: Confirmed that all existing globset tests pass, ensuring no breaking changes for standard file-path matching.
- Example: Added crates/globset/examples/custom_separator.rs for demonstration.

 
Fixes #2703