### PR TITLE
fix: suppress reset escape sequences when color style is none

### DIFF
--- a/crates/printer/src/path.rs
+++ b/crates/printer/src/path.rs
@@ -154,9 +154,14 @@ impl<W: WriteColor> PathPrinter<W> {
             self.wtr.write_all(ppath.as_bytes())?;
         } else {
             let status = self.start_hyperlink(&ppath)?;
-            self.wtr.set_color(self.config.colors.path())?;
-            self.wtr.write_all(ppath.as_bytes())?;
-            self.wtr.reset()?;
+            let spec = self.config.colors.path();
+            if spec.is_none() {
+                self.wtr.write_all(ppath.as_bytes())?;
+            } else {
+                self.wtr.set_color(spec)?;
+                self.wtr.write_all(ppath.as_bytes())?;
+                self.wtr.reset()?;
+            }
             self.interpolator.finish(status, &mut self.wtr)?;
         }
         self.wtr.write_all(&[self.config.terminator])

--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -1432,6 +1432,10 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
 
     fn write_spec(&self, spec: &ColorSpec, buf: &[u8]) -> io::Result<()> {
         let mut wtr = self.wtr().borrow_mut();
+        if spec.is_none() {
+            wtr.write_all(buf)?;
+            return Ok(());
+        }
         wtr.set_color(spec)?;
         wtr.write_all(buf)?;
         wtr.reset()?;
@@ -1440,7 +1444,12 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
 
     fn write_path(&self, path: &PrinterPath) -> io::Result<()> {
         let mut wtr = self.wtr().borrow_mut();
-        wtr.set_color(self.config().colors.path())?;
+        let spec = self.config().colors.path();
+        if spec.is_none() {
+            wtr.write_all(path.as_bytes())?;
+            return Ok(());
+        }
+        wtr.set_color(spec)?;
         wtr.write_all(path.as_bytes())?;
         wtr.reset()
     }

--- a/crates/printer/src/summary.rs
+++ b/crates/printer/src/summary.rs
@@ -615,6 +615,10 @@ impl<'p, 's, M: Matcher, W: WriteColor> SummarySink<'p, 's, M, W> {
 
     /// Write the given bytes using the give style.
     fn write_spec(&self, spec: &ColorSpec, buf: &[u8]) -> io::Result<()> {
+        if spec.is_none() {
+            self.write(buf)?;
+            return Ok(());
+        }
         self.summary.wtr.borrow_mut().set_color(spec)?;
         self.write(buf)?;
         self.summary.wtr.borrow_mut().reset()?;

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -518,11 +518,13 @@ rgtest!(r568_leading_hyphen_option_args, |dir: Dir, mut cmd: TestCommand| {
 });
 
 // See: https://github.com/BurntSushi/ripgrep/issues/599
+// See: https://github.com/BurntSushi/ripgrep/issues/3289
 //
 // This test used to check that we emitted color escape sequences even for
 // empty matches, but with the addition of the JSON output format, clients no
 // longer need to rely on escape sequences to parse matches. Therefore, we no
-// longer emit useless escape sequences.
+// longer emit useless escape sequences. In particular, when colors are set to
+// 'none', we suppress reset sequences entirely.
 rgtest!(r599, |dir: Dir, mut cmd: TestCommand| {
     dir.create("input.txt", "\n\ntest\n");
     cmd.args(&[
@@ -542,8 +544,8 @@ rgtest!(r599, |dir: Dir, mut cmd: TestCommand| {
     ]);
 
     let expected = "\
-[0m1[0m:
-[0m2[0m:
+1:
+2:
 ";
     eqnice_repr!(expected, cmd.stdout());
 });


### PR DESCRIPTION
## Summary

- Skip `set_color()`/`reset()` calls when the `ColorSpec` is `is_none()`, preventing unnecessary `\e[0m` reset sequences in output when `--colors=path:none` or `--colors=line:none` are set
- Applied consistently across all 4 code paths: `standard.rs::write_spec`, `standard.rs::write_path`, `summary.rs::write_spec`, and `path.rs::write`
- Follows the existing pattern already used for match colors at `standard.rs:1226`

## Test plan

- [x] Updated existing `r599` regression test to expect no reset sequences when colors are `none`
- [x] All 320 integration tests pass
- [x] Full workspace test suite passes (`cargo test --workspace --features pcre2`)
- [x] `cargo fmt --all --check` clean
- [x] `cargo doc --no-deps --document-private-items --workspace` clean

Closes #3289