### PR TITLE
ignore: fix panic in walk iterator when min_depth skips root

### DIFF
--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -1126,7 +1126,9 @@ impl Iterator for Walk {
                     return Some(Err(Error::from_walkdir(err)));
                 }
                 Ok(WalkEvent::Exit) => {
-                    self.ig = self.ig.parent().unwrap();
+                    if let Some(parent) = self.ig.parent() {
+                        self.ig = parent;
+                    }
                 }
                 Ok(WalkEvent::Dir(ent)) => {
                     let mut ent = DirEntry::new_walkdir(ent, None);
@@ -2330,6 +2332,20 @@ mod tests {
             td.path(),
             builder.min_depth(Some(2)).max_depth(Some(1)),
             &["a/b", "a/foo"],
+        );
+    }
+
+    // Regression test for: https://github.com/BurntSushi/ripgrep/issues/3286
+    #[test]
+    fn min_depth_max_depth_no_panic() {
+        let td = tmpdir();
+        mkdirp(td.path().join("a"));
+        wfile(td.path().join("foo"), "");
+
+        assert_paths(
+            td.path(),
+            WalkBuilder::new(td.path()).min_depth(Some(1)).max_depth(Some(1)),
+            &["a", "foo"],
         );
     }
 


### PR DESCRIPTION
## Summary

- Fix panic at `self.ig.parent().unwrap()` when `min_depth > 0` causes the root entry to be skipped
- When `min_depth > 0`, `WalkDir` never yields the root at depth 0, so `add_child()` is never called for it. But `WalkEventIter` still emits an `Exit` event, and `parent()` returns `None` since `self.ig` is already at the root level
- Replace `unwrap()` with `if let Some(parent)` guard to skip the pop when there is no parent

## Test plan

- [x] Added `min_depth_max_depth_no_panic` regression test covering both single-threaded and parallel walks
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo fmt --all --check` — clean
- [x] `cargo build --workspace` — clean

Closes #3286