### PR TITLE
fix(ignore): avoid nanosleep busy loop in worker fallback (#2761)

### DIFF
--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -1842,11 +1842,10 @@ impl<'s> Worker<'s> {
                             break;
                         }
                         // Our stack isn't blocking. Instead of burning the
-                        // CPU waiting, we let the thread sleep for a bit. In
-                        // general, this tends to only occur once the search is
-                        // approaching termination.
-                        let dur = std::time::Duration::from_millis(1);
-                        std::thread::sleep(dur);
+                        // CPU waiting, yield the scheduler so that blocked
+                        // workers can make progress without spinning in a
+                        // nanosleep loop.
+                        std::thread::yield_now();
                     }
                 }
             }


### PR DESCRIPTION
Fixes #2761

## Summary

Fixes a busy-loop fallback in ignore walker worker scheduling that could spin in nanosleep while another worker is blocked on a FIFO.

## Problem

When one worker blocks on a FIFO, other workers can enter a repeated nanosleep cycle in Worker::get_work instead of yielding cleanly.

## What changed

- Replace millisecond sleep fallback in Worker::get_work with scheduler yield (yield_now).

## Solution

Use std::thread::yield_now() in the non-blocking stack fallback path so workers stop burning CPU while waiting for progress.

## Why

This preserves behavior while reducing unnecessary syscall/CPU churn in stalled traversal scenarios.

## Tests

- `cargo test -p ignore walk -- --nocapture`
- `cargo test -p ripgrep --tests`
