### PR TITLE
fix: ignore: parallel walker occasionally hangs if visitor panics (#3009)

### DIFF
--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -1629,9 +1629,10 @@ impl<'s> Worker<'s> {
     /// skipped by the ignore matcher.
     fn run(mut self) {
         while let Some(work) = self.get_work() {
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                self.run_one(work)
-            }));
+            let result =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    self.run_one(work)
+                }));
             match result {
                 Ok(WalkState::Continue) => {}
                 Ok(WalkState::Quit) => self.quit_now(),

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -1629,8 +1629,17 @@ impl<'s> Worker<'s> {
     /// skipped by the ignore matcher.
     fn run(mut self) {
         while let Some(work) = self.get_work() {
-            if let WalkState::Quit = self.run_one(work) {
-                self.quit_now();
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                self.run_one(work)
+            }));
+            match result {
+                Ok(WalkState::Continue) => {}
+                Ok(WalkState::Quit) => self.quit_now(),
+                Ok(WalkState::Skip) => {}
+                Err(payload) => {
+                    self.quit_now();
+                    std::panic::resume_unwind(payload);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #3009

## Summary

Fixes a nondeterministic hang in `ignore` parallel walk when visitor code panics.

## Problem

`WalkParallel::visit()` / `WalkParallel::run()` could hang after a panic in visitor logic. The panic did not always terminate worker progression cleanly, leaving threads stuck in work retrieval loops.

## Reproduction

From `crates/ignore`, run parallel tests repeatedly (as described in #3009) until a panic path is hit; on affected code this can hang.

## What changed

- `crates/ignore/src/walk.rs`
- In `Worker::run`, wrap `run_one(work)` with `std::panic::catch_unwind`.
- On panic, call `quit_now()` before `resume_unwind(payload)` so all workers observe quit state and stop.

## Why this works

The change preserves panic propagation while ensuring global worker shutdown is signaled on panic, preventing the hang/livelock behavior.

## Validation

- `cargo check --workspace`
- `cargo test -p ignore --lib -- --nocapture`

## Scope

Single-file, targeted fix in `ignore` worker loop.