### PR TITLE
feat: Improve group capture highlight support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ Bug fixes:
 * [BUG #3212](https://github.com/BurntSushi/ripgrep/pull/3212):
   Don't check for the existence of `.jj` when `--no-ignore` is used.
 
+Feature enhancements:
+
+* Add `--capture-highlight` to color explicit capture groups within standard
+  output, `--capture-list` to print one record per explicit capture group and
+  `--json-captures` for structured capture-aware JSON output.
+* Add `--json-captures-lines=never|always`. The default is `never`, which keeps
+  capture-aware JSON compact by omitting the parent `lines` payload unless it
+  is explicitly requested.
+
+Feature enhancements:
+
+* Add `--capture-highlight` for coloring explicit capture groups inside
+  standard output.
+* Add `--capture-list` for emitting one record per explicit capture group with
+  offsets.
+* Add `--json-captures` for occurrence- and capture-aware JSON output.
+* Add `--json-captures-lines=never|always`, with `never` as the default, so
+  capture-aware JSON can stay compact unless the parent `lines` payload is
+  explicitly requested.
+
 
 15.1.0
 ======

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -523,6 +523,49 @@ at index 0, but the `0`th capturing group always corresponds to the entire
 match. The capturing group at index `1` always corresponds to the first
 explicit capturing group found in the regex pattern.)
 
+### Capture-aware output
+
+ripgrep can also surface capture groups directly in its output instead of
+treating the whole regex match as one undifferentiated span.
+
+If you want to keep the usual grep-like output shape, but visually distinguish
+capture groups inside a larger match, use `--capture-highlight`. This is most
+useful with `--only-matching`:
+
+```bash
+$ rg '.{0,20}(fast).{0,20}' -o --capture-highlight README.md
+```
+
+That prints the full outer match, but colors the explicit capture groups
+separately from the surrounding bytes.
+
+If you want one record per explicit capture group, use `--capture-list`:
+
+```bash
+$ rg '(fast)\\s+(\\w+)' --capture-list README.md
+```
+
+Each record includes the capture start location, absolute byte offset and the
+capture bytes themselves.
+
+If you want machine-readable capture output, use `--json-captures`:
+
+```bash
+$ rg '(fast)\\s+(\\w+)' --json-captures README.md
+```
+
+By default, `--json-captures` omits the parent `lines` payload from `match`
+and `context` messages. This keeps the JSON smaller, especially when searching
+binary or otherwise large records. If you need the full parent record bytes,
+enable them explicitly:
+
+```bash
+$ rg '(fast)\\s+(\\w+)' --json-captures --json-captures-lines=always README.md
+```
+
+When `lines` is present, occurrence and capture offsets are still relative to
+that parent payload, just like the existing `--json` format.
+
 Capturing groups can also be named, which is sometimes more convenient than
 using the indices. For example, the following command is equivalent to the
 above command:

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ generally speaking):
   syntax is provided via the `--engine (default|pcre2|auto)` option.
 * ripgrep has [rudimentary support for replacements](GUIDE.md#replacements),
   which permit rewriting output based on what was matched.
+* ripgrep can report explicit regex capture groups in both human-readable and
+  machine-readable forms. Use `--capture-highlight` to color capture groups
+  inside standard output, `--capture-list` to print one record per capture with
+  offsets, and `--json-captures` for structured output keyed by occurrences and
+  groups.
 * ripgrep supports [searching files in text encodings](GUIDE.md#file-encoding)
   other than UTF-8, such as UTF-16, latin-1, GBK, EUC-JP, Shift_JIS and more.
   (Some support for automatically detecting UTF-16 is provided. Other text

--- a/crates/core/flags/complete/rg.zsh
+++ b/crates/core/flags/complete/rg.zsh
@@ -176,7 +176,10 @@ _rg() {
 
     + '(json)' # JSON options
     '--json[output results in JSON Lines format]'
+    '--json-captures[output matches and capture groups in JSON Lines format]'
+    '--json-captures-lines=[control whether lines are emitted in --json-captures]:when:(never always)'
     $no"--no-json[don't output results in JSON Lines format]"
+    $no"--no-json-captures[don't output matches and capture groups in JSON Lines format]"
 
     + '(line-number)' # Line-number options
     {-n,--line-number}'[show line numbers for matches]'
@@ -218,6 +221,8 @@ _rg() {
 
     + '(only)' # Only-match options
     {-o,--only-matching}'[show only matching part of each line]'
+    '--capture-highlight[highlight explicit capture groups in standard output]'
+    '--capture-list[show one record per explicit capture group]'
 
     + '(passthru)' # Pass-through options
     '(--vimgrep)--passthru[show both matching and non-matching lines]'

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -25,9 +25,10 @@ use crate::flags::{
     Category, Flag, FlagValue,
     lowargs::{
         BinaryMode, BoundaryMode, BufferMode, CaseMode, ColorChoice,
-        ContextMode, EncodingMode, EngineChoice, GenerateMode, LoggingMode,
-        LowArgs, MmapMode, Mode, PatternSource, SearchMode, SortMode,
-        SortModeKind, SpecialMode, TypeChange,
+        ContextMode, EncodingMode, EngineChoice, GenerateMode,
+        JSONCapturesLines as JSONCapturesLinesMode, LoggingMode, LowArgs,
+        MmapMode, Mode, PatternSource, SearchMode, SortMode, SortModeKind,
+        SpecialMode, TypeChange,
     },
 };
 
@@ -52,6 +53,8 @@ pub(super) const FLAGS: &[&dyn Flag] = &[
     &BlockBuffered,
     &ByteOffset,
     &CaseSensitive,
+    &CaptureHighlight,
+    &CaptureList,
     &Color,
     &Colors,
     &Column,
@@ -86,6 +89,8 @@ pub(super) const FLAGS: &[&dyn Flag] = &[
     &IncludeZero,
     &InvertMatch,
     &JSON,
+    &JSONCaptures,
+    &JSONCapturesLines,
     &LineBuffered,
     &LineNumber,
     &LineNumberNo,
@@ -684,6 +689,99 @@ fn test_case_sensitive() {
 
     let args = parse_low_raw(["-s"]).unwrap();
     assert_eq!(CaseMode::Sensitive, args.case);
+}
+
+/// --capture-highlight
+#[derive(Debug)]
+struct CaptureHighlight;
+
+impl Flag for CaptureHighlight {
+    fn is_switch(&self) -> bool {
+        true
+    }
+    fn name_long(&self) -> &'static str {
+        "capture-highlight"
+    }
+    fn doc_category(&self) -> Category {
+        Category::Output
+    }
+    fn doc_short(&self) -> &'static str {
+        r"Highlight explicit capture groups in standard output."
+    }
+    fn doc_long(&self) -> &'static str {
+        r"
+Highlight explicit capture groups in ripgrep's standard output.
+.sp
+This keeps ripgrep's existing text output shape, but colors explicit capture
+groups distinctly from the surrounding bytes of the overall match.
+.sp
+This flag requires at least one explicit capture group in the compiled regex.
+It is most useful with \flag{only-matching}, but also works with normal
+line-oriented output.
+"
+    }
+
+    fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
+        assert!(v.unwrap_switch(), "--capture-highlight has no negation");
+        args.capture_highlight = true;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_capture_highlight() {
+    let args = parse_low_raw(None::<&str>).unwrap();
+    assert_eq!(false, args.capture_highlight);
+
+    let args = parse_low_raw(["--capture-highlight"]).unwrap();
+    assert_eq!(true, args.capture_highlight);
+}
+
+/// --capture-list
+#[derive(Debug)]
+struct CaptureList;
+
+impl Flag for CaptureList {
+    fn is_switch(&self) -> bool {
+        true
+    }
+    fn name_long(&self) -> &'static str {
+        "capture-list"
+    }
+    fn doc_category(&self) -> Category {
+        Category::Output
+    }
+    fn doc_short(&self) -> &'static str {
+        r"Print one record for each explicit capture group."
+    }
+    fn doc_long(&self) -> &'static str {
+        r"
+Print one output record for each explicit capture group that participated in a
+match.
+.sp
+Each record includes the capture group's location information together with the
+capture bytes themselves.
+.sp
+This flag requires at least one explicit capture group in the compiled regex.
+"
+    }
+
+    fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
+        assert!(v.unwrap_switch(), "--capture-list has no negation");
+        args.capture_list = true;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_capture_list() {
+    let args = parse_low_raw(None::<&str>).unwrap();
+    assert_eq!(false, args.capture_list);
+
+    let args = parse_low_raw(["--capture-list"]).unwrap();
+    assert_eq!(true, args.capture_list);
 }
 
 /// --color
@@ -3530,6 +3628,125 @@ fn test_json() {
 
     let args = parse_low_raw(["--json", "-l", "--no-json"]).unwrap();
     assert_eq!(Mode::Search(SearchMode::FilesWithMatches), args.mode);
+}
+
+/// --json-captures
+#[derive(Debug)]
+struct JSONCaptures;
+
+impl Flag for JSONCaptures {
+    fn is_switch(&self) -> bool {
+        true
+    }
+    fn name_long(&self) -> &'static str {
+        "json-captures"
+    }
+    fn name_negated(&self) -> Option<&'static str> {
+        Some("no-json-captures")
+    }
+    fn doc_category(&self) -> Category {
+        Category::OutputModes
+    }
+    fn doc_short(&self) -> &'static str {
+        r"Show matches and capture groups in JSON Lines."
+    }
+    fn doc_long(&self) -> &'static str {
+        r"
+Enable printing results in a capture-aware JSON Lines format.
+.sp
+This mode emits the same lifecycle messages as \flag{json}, but each match
+message contains the overall regex occurrences together with all capture groups
+for each occurrence.
+.sp
+This flag requires at least one explicit capture group in the compiled regex.
+.sp
+By default, this mode omits the parent \fBlines\fP payload from match and
+context messages. Use \flag{json-captures-lines} with \fBalways\fP to include it.
+.sp
+Like \flag{json}, this output mode always implies \flag{stats}.
+"
+    }
+
+    fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
+        if v.unwrap_switch() {
+            args.mode.update(Mode::Search(SearchMode::JSONCaptures));
+        } else if matches!(args.mode, Mode::Search(SearchMode::JSONCaptures)) {
+            args.mode.update(Mode::Search(SearchMode::Standard));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_json_captures() {
+    let args = parse_low_raw(None::<&str>).unwrap();
+    assert_eq!(Mode::Search(SearchMode::Standard), args.mode);
+
+    let args = parse_low_raw(["--json-captures"]).unwrap();
+    assert_eq!(Mode::Search(SearchMode::JSONCaptures), args.mode);
+
+    let args =
+        parse_low_raw(["--json-captures", "--no-json-captures"]).unwrap();
+    assert_eq!(Mode::Search(SearchMode::Standard), args.mode);
+}
+
+/// --json-captures-lines
+#[derive(Debug)]
+struct JSONCapturesLines;
+
+impl Flag for JSONCapturesLines {
+    fn is_switch(&self) -> bool {
+        false
+    }
+    fn name_long(&self) -> &'static str {
+        "json-captures-lines"
+    }
+    fn doc_variable(&self) -> Option<&'static str> {
+        Some("WHEN")
+    }
+    fn doc_choices(&self) -> &'static [&'static str] {
+        &["never", "always"]
+    }
+    fn doc_category(&self) -> Category {
+        Category::OutputModes
+    }
+    fn doc_short(&self) -> &'static str {
+        r"Control whether `lines` is emitted in `--json-captures`."
+    }
+    fn doc_long(&self) -> &'static str {
+        r"
+Control whether \fBlines\fP is emitted in capture-aware JSON output.
+.sp
+The default is \fBnever\fP, which omits the parent record payload from each
+match and context message. Use \fBalways\fP to include the full parent record
+payload.
+"
+    }
+
+    fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
+        let value = v.unwrap_value();
+        let string = convert::str(&value)?;
+        args.json_captures_lines = match string {
+            "never" => JSONCapturesLinesMode::Never,
+            "always" => JSONCapturesLinesMode::Always,
+            unk => anyhow::bail!("choice '{unk}' is unrecognized"),
+        };
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_json_captures_lines() {
+    let args = parse_low_raw(None::<&str>).unwrap();
+    assert_eq!(JSONCapturesLinesMode::Never, args.json_captures_lines);
+
+    let args = parse_low_raw(["--json-captures-lines", "never"]).unwrap();
+    assert_eq!(JSONCapturesLinesMode::Never, args.json_captures_lines);
+
+    let args = parse_low_raw(["--json-captures-lines", "always"]).unwrap();
+    assert_eq!(JSONCapturesLinesMode::Always, args.json_captures_lines);
 }
 
 /// --line-buffered

--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -16,8 +16,9 @@ use crate::{
     flags::lowargs::{
         BinaryMode, BoundaryMode, BufferMode, CaseMode, ColorChoice,
         ContextMode, ContextSeparator, EncodingMode, EngineChoice,
-        FieldContextSeparator, FieldMatchSeparator, LowArgs, MmapMode, Mode,
-        PatternSource, SearchMode, SortMode, SortModeKind, TypeChange,
+        FieldContextSeparator, FieldMatchSeparator, JSONCapturesLines,
+        LowArgs, MmapMode, Mode, PatternSource, SearchMode, SortMode,
+        SortModeKind, TypeChange,
     },
     haystack::{Haystack, HaystackBuilder},
     search::{PatternMatcher, Printer, SearchWorker, SearchWorkerBuilder},
@@ -39,6 +40,8 @@ pub(crate) struct HiArgs {
     buffer: BufferMode,
     byte_offset: bool,
     case: CaseMode,
+    capture_highlight: bool,
+    capture_list: bool,
     color: ColorChoice,
     colors: grep::printer::ColorSpecs,
     column: bool,
@@ -62,6 +65,7 @@ pub(crate) struct HiArgs {
     ignore_file: Vec<PathBuf>,
     include_zero: bool,
     invert_match: bool,
+    json_captures_lines: JSONCapturesLines,
     is_terminal_stdout: bool,
     line_number: bool,
     max_columns: Option<u64>,
@@ -138,6 +142,37 @@ impl HiArgs {
             },
             _ => {}
         }
+        if low.capture_highlight && low.capture_list {
+            anyhow::bail!(
+                "--capture-highlight and --capture-list cannot be used together"
+            );
+        }
+        if (low.capture_highlight || low.capture_list)
+            && !matches!(low.mode, Mode::Search(SearchMode::Standard))
+        {
+            anyhow::bail!(
+                "capture-aware standard output requires ripgrep's standard search mode"
+            );
+        }
+        if (low.capture_highlight || low.capture_list) && low.vimgrep {
+            anyhow::bail!(
+                "capture-aware standard output cannot be used with --vimgrep"
+            );
+        }
+        if (low.capture_highlight
+            || low.capture_list
+            || matches!(low.mode, Mode::Search(SearchMode::JSONCaptures)))
+            && low.replace.is_some()
+        {
+            anyhow::bail!(
+                "capture-aware output cannot be used with --replace"
+            );
+        }
+        if !matches!(low.mode, Mode::Search(SearchMode::JSONCaptures))
+            && !matches!(low.json_captures_lines, JSONCapturesLines::Never)
+        {
+            anyhow::bail!("--json-captures-lines requires --json-captures");
+        }
 
         let mut state = State::new()?;
         let patterns = Patterns::from_low_args(&mut state, &mut low)?;
@@ -205,7 +240,7 @@ impl HiArgs {
                 | SearchMode::FilesWithoutMatch
                 | SearchMode::Count
                 | SearchMode::CountMatches => return false,
-                SearchMode::JSON => return true,
+                SearchMode::JSON | SearchMode::JSONCaptures => return true,
                 SearchMode::Standard => {
                     // A few things can imply counting line numbers. In
                     // particular, we generally want to show line numbers by
@@ -279,6 +314,7 @@ impl HiArgs {
             ignore_file_case_insensitive: low.ignore_file_case_insensitive,
             include_zero: low.include_zero,
             invert_match: low.invert_match,
+            json_captures_lines: low.json_captures_lines,
             is_terminal_stdout: state.is_terminal_stdout,
             line_number,
             max_columns: low.max_columns,
@@ -300,6 +336,8 @@ impl HiArgs {
             null_data: low.null_data,
             one_file_system: low.one_file_system,
             only_matching: low.only_matching,
+            capture_highlight: low.capture_highlight,
+            capture_list: low.capture_list,
             globs,
             path_separator: low.path_separator,
             path_terminator,
@@ -569,6 +607,7 @@ impl HiArgs {
                 | SearchMode::Count
                 | SearchMode::CountMatches
                 | SearchMode::JSON
+                | SearchMode::JSONCaptures
                 | SearchMode::Standard => SummaryKind::QuietWithMatch,
                 SearchMode::FilesWithoutMatch => {
                     SummaryKind::QuietWithoutMatch
@@ -582,6 +621,11 @@ impl HiArgs {
                 SearchMode::CountMatches => SummaryKind::CountMatches,
                 SearchMode::JSON => {
                     return Printer::JSON(self.printer_json(wtr));
+                }
+                SearchMode::JSONCaptures => {
+                    return Printer::JSONCaptures(
+                        self.printer_json_captures(wtr),
+                    );
                 }
                 SearchMode::Standard => {
                     return Printer::Standard(self.printer_standard(wtr));
@@ -603,6 +647,19 @@ impl HiArgs {
             .build(wtr)
     }
 
+    /// Builds a JSON capture printer.
+    fn printer_json_captures<W: std::io::Write>(
+        &self,
+        wtr: W,
+    ) -> grep::printer::JSONCaptures<W> {
+        grep::printer::JSONCapturesBuilder::new()
+            .lines(matches!(
+                self.json_captures_lines,
+                JSONCapturesLines::Always
+            ))
+            .build(wtr)
+    }
+
     /// Builds a "standard" grep printer where matches are printed as plain
     /// text lines.
     fn printer_standard<W: termcolor::WriteColor>(
@@ -614,6 +671,8 @@ impl HiArgs {
             .byte_offset(self.byte_offset)
             .color_specs(self.colors.clone())
             .column(self.column)
+            .capture_highlight(self.capture_highlight)
+            .capture_list(self.capture_list)
             .heading(self.heading)
             .hyperlink(self.hyperlink_config.clone())
             .max_columns_preview(self.max_columns_preview)
@@ -1251,7 +1310,12 @@ fn stats(low: &LowArgs) -> Option<grep::printer::Stats> {
     if !matches!(low.mode, Mode::Search(_)) {
         return None;
     }
-    if low.stats || matches!(low.mode, Mode::Search(SearchMode::JSON)) {
+    if low.stats
+        || matches!(
+            low.mode,
+            Mode::Search(SearchMode::JSON | SearchMode::JSONCaptures)
+        )
+    {
         return Some(grep::printer::Stats::new());
     }
     None

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -42,6 +42,8 @@ pub(crate) struct LowArgs {
     pub(crate) buffer: BufferMode,
     pub(crate) byte_offset: bool,
     pub(crate) case: CaseMode,
+    pub(crate) capture_highlight: bool,
+    pub(crate) capture_list: bool,
     pub(crate) color: ColorChoice,
     pub(crate) colors: Vec<UserColorSpec>,
     pub(crate) column: Option<bool>,
@@ -66,6 +68,7 @@ pub(crate) struct LowArgs {
     pub(crate) ignore_file_case_insensitive: bool,
     pub(crate) include_zero: bool,
     pub(crate) invert_match: bool,
+    pub(crate) json_captures_lines: JSONCapturesLines,
     pub(crate) line_number: Option<bool>,
     pub(crate) logging: Option<LoggingMode>,
     pub(crate) max_columns: Option<u64>,
@@ -211,6 +214,18 @@ pub(crate) enum SearchMode {
     CountMatches,
     /// Print matches in a JSON lines format.
     JSON,
+    /// Print matches and capture groups in a JSON lines format.
+    JSONCaptures,
+}
+
+/// Controls whether `--json-captures` includes the parent `lines` payload.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) enum JSONCapturesLines {
+    /// Omit `lines` from capture JSON output.
+    #[default]
+    Never,
+    /// Always include `lines` in capture JSON output.
+    Always,
 }
 
 /// The thing to generate via the --generate flag.

--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -438,7 +438,7 @@ fn print_stats<W: Write>(
     mut wtr: W,
 ) -> std::io::Result<()> {
     let elapsed = std::time::Instant::now().duration_since(started);
-    if matches!(mode, SearchMode::JSON) {
+    if matches!(mode, SearchMode::JSON | SearchMode::JSONCaptures) {
         // We specifically match the format laid out by the JSON printer in
         // the grep-printer crate. We simply "extend" it with the 'summary'
         // message type.

--- a/crates/core/search.rs
+++ b/crates/core/search.rs
@@ -208,6 +208,8 @@ pub(crate) enum Printer<W> {
     Summary(grep::printer::Summary<W>),
     /// A JSON printer, which emits results in the JSON Lines format.
     JSON(grep::printer::JSON<W>),
+    /// A JSON printer that emits occurrences and capture groups.
+    JSONCaptures(grep::printer::JSONCaptures<W>),
 }
 
 impl<W: WriteColor> Printer<W> {
@@ -217,6 +219,7 @@ impl<W: WriteColor> Printer<W> {
             Printer::Standard(ref mut p) => p.get_mut(),
             Printer::Summary(ref mut p) => p.get_mut(),
             Printer::JSON(ref mut p) => p.get_mut(),
+            Printer::JSONCaptures(ref mut p) => p.get_mut(),
         }
     }
 }
@@ -385,6 +388,12 @@ fn search_path<M: Matcher, W: WriteColor>(
 ) -> io::Result<SearchResult> {
     match *printer {
         Printer::Standard(ref mut p) => {
+            if p.requires_explicit_captures() && matcher.capture_count() <= 1 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "capture-aware output requires at least one explicit capture group",
+                ));
+            }
             let mut sink = p.sink_with_path(&matcher, path);
             searcher.search_path(&matcher, path, &mut sink)?;
             Ok(SearchResult {
@@ -408,6 +417,20 @@ fn search_path<M: Matcher, W: WriteColor>(
                 stats: Some(sink.stats().clone()),
             })
         }
+        Printer::JSONCaptures(ref mut p) => {
+            if p.requires_explicit_captures() && matcher.capture_count() <= 1 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "capture-aware output requires at least one explicit capture group",
+                ));
+            }
+            let mut sink = p.sink_with_path(&matcher, path);
+            searcher.search_path(&matcher, path, &mut sink)?;
+            Ok(SearchResult {
+                has_match: sink.has_match(),
+                stats: Some(sink.stats().clone()),
+            })
+        }
     }
 }
 
@@ -422,6 +445,12 @@ fn search_reader<M: Matcher, R: io::Read, W: WriteColor>(
 ) -> io::Result<SearchResult> {
     match *printer {
         Printer::Standard(ref mut p) => {
+            if p.requires_explicit_captures() && matcher.capture_count() <= 1 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "capture-aware output requires at least one explicit capture group",
+                ));
+            }
             let mut sink = p.sink_with_path(&matcher, path);
             searcher.search_reader(&matcher, &mut rdr, &mut sink)?;
             Ok(SearchResult {
@@ -438,6 +467,20 @@ fn search_reader<M: Matcher, R: io::Read, W: WriteColor>(
             })
         }
         Printer::JSON(ref mut p) => {
+            let mut sink = p.sink_with_path(&matcher, path);
+            searcher.search_reader(&matcher, &mut rdr, &mut sink)?;
+            Ok(SearchResult {
+                has_match: sink.has_match(),
+                stats: Some(sink.stats().clone()),
+            })
+        }
+        Printer::JSONCaptures(ref mut p) => {
+            if p.requires_explicit_captures() && matcher.capture_count() <= 1 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "capture-aware output requires at least one explicit capture group",
+                ));
+            }
             let mut sink = p.sink_with_path(&matcher, path);
             searcher.search_reader(&matcher, &mut rdr, &mut sink)?;
             Ok(SearchResult {

--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -612,6 +612,19 @@ pub trait Matcher {
         None
     }
 
+    /// Maps the given capture group index to its corresponding capture group
+    /// name, if one exists.
+    ///
+    /// Group names are not guaranteed to exist for every index. In
+    /// particular, group `0` is the overall match and is always unnamed.
+    ///
+    /// By default, capturing groups are not supported, so this always returns
+    /// `None`.
+    #[inline]
+    fn capture_name(&self, _index: usize) -> Option<&str> {
+        None
+    }
+
     /// Returns the start and end byte range of the first match in `haystack`.
     /// If no match exists, then `None` is returned.
     ///

--- a/crates/pcre2/src/matcher.rs
+++ b/crates/pcre2/src/matcher.rs
@@ -80,7 +80,9 @@ impl RegexMatcherBuilder {
                     names.insert(name.to_string(), i);
                 }
             }
-            RegexMatcher { regex, names }
+            let names_by_index =
+                regex.capture_names().iter().cloned().collect();
+            RegexMatcher { regex, names, names_by_index }
         })
     }
 
@@ -302,6 +304,7 @@ impl RegexMatcherBuilder {
 pub struct RegexMatcher {
     regex: Regex,
     names: HashMap<String, usize>,
+    names_by_index: Vec<Option<String>>,
 }
 
 impl RegexMatcher {
@@ -338,6 +341,10 @@ impl Matcher for RegexMatcher {
 
     fn capture_index(&self, name: &str) -> Option<usize> {
         self.names.get(name).map(|i| *i)
+    }
+
+    fn capture_name(&self, index: usize) -> Option<&str> {
+        self.names_by_index.get(index).and_then(|name| name.as_deref())
     }
 
     fn try_find_iter<F, E>(

--- a/crates/printer/src/json_captures.rs
+++ b/crates/printer/src/json_captures.rs
@@ -1,0 +1,372 @@
+use std::{io, io::Write, path::Path, time::Instant};
+
+use grep_matcher::Matcher;
+use grep_searcher::{Searcher, Sink, SinkContext, SinkFinish, SinkMatch};
+
+use crate::{
+    counter::CounterWriter,
+    jsont,
+    stats::Stats,
+    util::{
+        CaptureMatch as RecordedCaptureMatch, Replacer,
+        capture_matches_in_context,
+    },
+};
+
+#[derive(Clone, Debug, Default)]
+struct Config {
+    pretty: bool,
+    always_begin_end: bool,
+    lines: bool,
+}
+
+/// A builder for configuring JSON capture output.
+#[derive(Clone, Debug)]
+pub struct JSONCapturesBuilder {
+    config: Config,
+}
+
+impl JSONCapturesBuilder {
+    /// Return a new builder with the default JSON capture configuration.
+    pub fn new() -> JSONCapturesBuilder {
+        JSONCapturesBuilder { config: Config::default() }
+    }
+
+    /// Pretty-print JSON output.
+    pub fn pretty(&mut self, yes: bool) -> &mut JSONCapturesBuilder {
+        self.config.pretty = yes;
+        self
+    }
+
+    /// Emit `begin` and `end` messages even when a search has no matches.
+    pub fn always_begin_end(&mut self, yes: bool) -> &mut JSONCapturesBuilder {
+        self.config.always_begin_end = yes;
+        self
+    }
+
+    /// Include the parent `lines` payload in each match or context message.
+    pub fn lines(&mut self, yes: bool) -> &mut JSONCapturesBuilder {
+        self.config.lines = yes;
+        self
+    }
+
+    /// Build a JSON capture printer from the current configuration.
+    pub fn build<W: io::Write>(&self, wtr: W) -> JSONCaptures<W> {
+        JSONCaptures {
+            config: self.config.clone(),
+            wtr: CounterWriter::new(wtr),
+            occurrences: vec![],
+        }
+    }
+}
+
+/// A JSON Lines printer that emits full regex occurrences and capture groups.
+#[derive(Clone, Debug)]
+pub struct JSONCaptures<W> {
+    config: Config,
+    wtr: CounterWriter<W>,
+    occurrences: Vec<RecordedCaptureMatch>,
+}
+
+impl<W: io::Write> JSONCaptures<W> {
+    /// Return a JSON capture printer with the default configuration.
+    pub fn new(wtr: W) -> JSONCaptures<W> {
+        JSONCapturesBuilder::new().build(wtr)
+    }
+
+    /// Return an implementation of `Sink` for this printer.
+    pub fn sink<'s, M: Matcher>(
+        &'s mut self,
+        matcher: M,
+    ) -> JSONCapturesSink<'static, 's, M, W> {
+        JSONCapturesSink {
+            matcher,
+            scratch: Replacer::new(),
+            json: self,
+            path: None,
+            start_time: Instant::now(),
+            match_count: 0,
+            binary_byte_offset: None,
+            begin_printed: false,
+            stats: Stats::new(),
+        }
+    }
+
+    /// Return an implementation of `Sink` associated with a file path.
+    pub fn sink_with_path<'p, 's, M, P>(
+        &'s mut self,
+        matcher: M,
+        path: &'p P,
+    ) -> JSONCapturesSink<'p, 's, M, W>
+    where
+        M: Matcher,
+        P: ?Sized + AsRef<Path>,
+    {
+        JSONCapturesSink {
+            matcher,
+            scratch: Replacer::new(),
+            json: self,
+            path: Some(path.as_ref()),
+            start_time: Instant::now(),
+            match_count: 0,
+            binary_byte_offset: None,
+            begin_printed: false,
+            stats: Stats::new(),
+        }
+    }
+
+    /// Return whether this printer requires explicit capture groups.
+    /// Returns true if and only if this printer requires explicit capture
+    /// groups.
+    pub fn requires_explicit_captures(&self) -> bool {
+        true
+    }
+
+    /// Return a mutable reference to the underlying writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        self.wtr.get_mut()
+    }
+
+    fn write_message(
+        &mut self,
+        message: &jsont::CaptureMessage<'_>,
+    ) -> io::Result<()> {
+        if self.config.pretty {
+            serde_json::to_writer_pretty(&mut self.wtr, message)?;
+        } else {
+            serde_json::to_writer(&mut self.wtr, message)?;
+        }
+        self.wtr.write_all(b"\n")?;
+        Ok(())
+    }
+}
+
+/// A sink for the JSON capture printer.
+#[derive(Debug)]
+pub struct JSONCapturesSink<'p, 's, M: Matcher, W> {
+    matcher: M,
+    scratch: Replacer<M>,
+    json: &'s mut JSONCaptures<W>,
+    path: Option<&'p Path>,
+    start_time: Instant,
+    match_count: u64,
+    binary_byte_offset: Option<u64>,
+    begin_printed: bool,
+    stats: Stats,
+}
+
+impl<'p, 's, M: Matcher, W: io::Write> JSONCapturesSink<'p, 's, M, W> {
+    /// Returns true if and only if this sink saw a match in the previous
+    /// search.
+    pub fn has_match(&self) -> bool {
+        self.match_count > 0
+    }
+
+    /// Return the statistics gathered for this sink.
+    pub fn stats(&self) -> &Stats {
+        &self.stats
+    }
+
+    fn record_occurrences(
+        &mut self,
+        searcher: &Searcher,
+        bytes: &[u8],
+        range: std::ops::Range<usize>,
+    ) -> io::Result<()> {
+        self.json.occurrences.clear();
+        let caps = self.scratch.captures(&self.matcher)?;
+        capture_matches_in_context(
+            searcher,
+            &self.matcher,
+            bytes,
+            range.clone(),
+            caps,
+            &mut self.json.occurrences,
+        )?;
+        if !self.json.occurrences.is_empty()
+            && self.json.occurrences.last().unwrap().overall().is_empty()
+            && self.json.occurrences.last().unwrap().overall().start()
+                >= range.end
+        {
+            self.json.occurrences.pop().unwrap();
+        }
+        Ok(())
+    }
+
+    fn write_begin_message(&mut self) -> io::Result<()> {
+        if self.begin_printed {
+            return Ok(());
+        }
+        let msg =
+            jsont::CaptureMessage::Begin(jsont::Begin { path: self.path });
+        self.json.write_message(&msg)?;
+        self.begin_printed = true;
+        Ok(())
+    }
+
+    fn occurrences<'a>(
+        &self,
+        bytes: &'a [u8],
+        absolute_offset: u64,
+    ) -> Vec<jsont::CaptureOccurrence<'a>> {
+        self.json
+            .occurrences
+            .iter()
+            .map(|occurrence| {
+                let captures = occurrence
+                    .captures()
+                    .iter()
+                    .enumerate()
+                    .map(|(index, capture)| match *capture {
+                        Some(span) => jsont::CaptureGroup {
+                            index,
+                            name: self
+                                .matcher
+                                .capture_name(index)
+                                .map(str::to_string),
+                            m: Some(&bytes[span]),
+                            start: Some(span.start()),
+                            end: Some(span.end()),
+                            absolute_start: Some(
+                                absolute_offset + span.start() as u64,
+                            ),
+                            absolute_end: Some(
+                                absolute_offset + span.end() as u64,
+                            ),
+                        },
+                        None => jsont::CaptureGroup {
+                            index,
+                            name: self
+                                .matcher
+                                .capture_name(index)
+                                .map(str::to_string),
+                            m: None,
+                            start: None,
+                            end: None,
+                            absolute_start: None,
+                            absolute_end: None,
+                        },
+                    })
+                    .collect::<Vec<_>>();
+                let overall = occurrence.overall();
+                jsont::CaptureOccurrence {
+                    m: &bytes[overall],
+                    start: overall.start(),
+                    end: overall.end(),
+                    absolute_start: absolute_offset + overall.start() as u64,
+                    absolute_end: absolute_offset + overall.end() as u64,
+                    captures,
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+impl<'p, 's, M: Matcher, W: io::Write> Sink
+    for JSONCapturesSink<'p, 's, M, W>
+{
+    type Error = io::Error;
+
+    fn matched(
+        &mut self,
+        searcher: &Searcher,
+        mat: &SinkMatch<'_>,
+    ) -> Result<bool, io::Error> {
+        self.match_count += 1;
+        self.write_begin_message()?;
+        self.record_occurrences(
+            searcher,
+            mat.buffer(),
+            mat.bytes_range_in_buffer(),
+        )?;
+        self.stats.add_matches(self.json.occurrences.len() as u64);
+        self.stats.add_matched_lines(mat.lines().count() as u64);
+
+        let occurrences =
+            self.occurrences(mat.bytes(), mat.absolute_byte_offset());
+        let msg = jsont::CaptureMessage::Match(jsont::CaptureMatch {
+            path: self.path,
+            lines: self.json.config.lines.then_some(mat.bytes()),
+            line_number: mat.line_number(),
+            absolute_offset: mat.absolute_byte_offset(),
+            occurrences,
+        });
+        self.json.write_message(&msg)?;
+        Ok(true)
+    }
+
+    fn context(
+        &mut self,
+        searcher: &Searcher,
+        ctx: &SinkContext<'_>,
+    ) -> Result<bool, io::Error> {
+        self.write_begin_message()?;
+        self.json.occurrences.clear();
+
+        if searcher.invert_match() {
+            self.record_occurrences(
+                searcher,
+                ctx.bytes(),
+                0..ctx.bytes().len(),
+            )?;
+        }
+        let occurrences =
+            self.occurrences(ctx.bytes(), ctx.absolute_byte_offset());
+        let msg = jsont::CaptureMessage::Context(jsont::CaptureContext {
+            path: self.path,
+            lines: self.json.config.lines.then_some(ctx.bytes()),
+            line_number: ctx.line_number(),
+            absolute_offset: ctx.absolute_byte_offset(),
+            occurrences,
+        });
+        self.json.write_message(&msg)?;
+        Ok(true)
+    }
+
+    fn binary_data(
+        &mut self,
+        _searcher: &Searcher,
+        _binary_byte_offset: u64,
+    ) -> Result<bool, io::Error> {
+        Ok(true)
+    }
+
+    fn begin(&mut self, _searcher: &Searcher) -> Result<bool, io::Error> {
+        self.json.wtr.reset_count();
+        self.start_time = Instant::now();
+        self.match_count = 0;
+        self.binary_byte_offset = None;
+
+        if !self.json.config.always_begin_end {
+            return Ok(true);
+        }
+        self.write_begin_message()?;
+        Ok(true)
+    }
+
+    fn finish(
+        &mut self,
+        _searcher: &Searcher,
+        finish: &SinkFinish,
+    ) -> Result<(), io::Error> {
+        self.binary_byte_offset = finish.binary_byte_offset();
+        self.stats.add_elapsed(self.start_time.elapsed());
+        self.stats.add_searches(1);
+        if self.match_count > 0 {
+            self.stats.add_searches_with_match(1);
+        }
+        self.stats.add_bytes_searched(finish.byte_count());
+        self.stats.add_bytes_printed(self.json.wtr.count());
+
+        if !self.begin_printed {
+            return Ok(());
+        }
+        let msg = jsont::CaptureMessage::End(jsont::End {
+            path: self.path,
+            binary_offset: finish.binary_byte_offset(),
+            stats: self.stats.clone(),
+        });
+        self.json.write_message(&msg)?;
+        Ok(())
+    }
+}

--- a/crates/printer/src/jsont.rs
+++ b/crates/printer/src/jsont.rs
@@ -133,6 +133,159 @@ impl<'a> serde::Serialize for Context<'a> {
     }
 }
 
+pub(crate) enum CaptureMessage<'a> {
+    Begin(Begin<'a>),
+    End(End<'a>),
+    Match(CaptureMatch<'a>),
+    Context(CaptureContext<'a>),
+}
+
+impl<'a> serde::Serialize for CaptureMessage<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct("CaptureMessage", 2)?;
+        match *self {
+            CaptureMessage::Begin(ref msg) => {
+                state.serialize_field("type", &"begin")?;
+                state.serialize_field("data", msg)?;
+            }
+            CaptureMessage::End(ref msg) => {
+                state.serialize_field("type", &"end")?;
+                state.serialize_field("data", msg)?;
+            }
+            CaptureMessage::Match(ref msg) => {
+                state.serialize_field("type", &"match")?;
+                state.serialize_field("data", msg)?;
+            }
+            CaptureMessage::Context(ref msg) => {
+                state.serialize_field("type", &"context")?;
+                state.serialize_field("data", msg)?;
+            }
+        }
+        state.end()
+    }
+}
+
+pub(crate) struct CaptureMatch<'a> {
+    pub(crate) path: Option<&'a Path>,
+    pub(crate) lines: Option<&'a [u8]>,
+    pub(crate) line_number: Option<u64>,
+    pub(crate) absolute_offset: u64,
+    pub(crate) occurrences: Vec<CaptureOccurrence<'a>>,
+}
+
+impl<'a> serde::Serialize for CaptureMatch<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct(
+            "CaptureMatch",
+            4 + usize::from(self.lines.is_some()),
+        )?;
+        state.serialize_field("path", &self.path.map(Data::from_path))?;
+        if let Some(lines) = self.lines {
+            state.serialize_field("lines", &Data::from_bytes(lines))?;
+        }
+        state.serialize_field("line_number", &self.line_number)?;
+        state.serialize_field("absolute_offset", &self.absolute_offset)?;
+        state.serialize_field("occurrences", &self.occurrences)?;
+        state.end()
+    }
+}
+
+pub(crate) struct CaptureContext<'a> {
+    pub(crate) path: Option<&'a Path>,
+    pub(crate) lines: Option<&'a [u8]>,
+    pub(crate) line_number: Option<u64>,
+    pub(crate) absolute_offset: u64,
+    pub(crate) occurrences: Vec<CaptureOccurrence<'a>>,
+}
+
+impl<'a> serde::Serialize for CaptureContext<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct(
+            "CaptureContext",
+            4 + usize::from(self.lines.is_some()),
+        )?;
+        state.serialize_field("path", &self.path.map(Data::from_path))?;
+        if let Some(lines) = self.lines {
+            state.serialize_field("lines", &Data::from_bytes(lines))?;
+        }
+        state.serialize_field("line_number", &self.line_number)?;
+        state.serialize_field("absolute_offset", &self.absolute_offset)?;
+        state.serialize_field("occurrences", &self.occurrences)?;
+        state.end()
+    }
+}
+
+pub(crate) struct CaptureOccurrence<'a> {
+    pub(crate) m: &'a [u8],
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+    pub(crate) absolute_start: u64,
+    pub(crate) absolute_end: u64,
+    pub(crate) captures: Vec<CaptureGroup<'a>>,
+}
+
+impl<'a> serde::Serialize for CaptureOccurrence<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct("CaptureOccurrence", 6)?;
+        state.serialize_field("match", &Data::from_bytes(self.m))?;
+        state.serialize_field("start", &self.start)?;
+        state.serialize_field("end", &self.end)?;
+        state.serialize_field("absolute_start", &self.absolute_start)?;
+        state.serialize_field("absolute_end", &self.absolute_end)?;
+        state.serialize_field("captures", &self.captures)?;
+        state.end()
+    }
+}
+
+pub(crate) struct CaptureGroup<'a> {
+    pub(crate) index: usize,
+    pub(crate) name: Option<String>,
+    pub(crate) m: Option<&'a [u8]>,
+    pub(crate) start: Option<usize>,
+    pub(crate) end: Option<usize>,
+    pub(crate) absolute_start: Option<u64>,
+    pub(crate) absolute_end: Option<u64>,
+}
+
+impl<'a> serde::Serialize for CaptureGroup<'a> {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = s.serialize_struct("CaptureGroup", 7)?;
+        state.serialize_field("index", &self.index)?;
+        state.serialize_field("name", &self.name)?;
+        state.serialize_field("match", &self.m.map(Data::from_bytes))?;
+        state.serialize_field("start", &self.start)?;
+        state.serialize_field("end", &self.end)?;
+        state.serialize_field("absolute_start", &self.absolute_start)?;
+        state.serialize_field("absolute_end", &self.absolute_end)?;
+        state.end()
+    }
+}
+
 pub(crate) struct SubMatch<'a> {
     pub(crate) m: &'a [u8],
     pub(crate) replacement: Option<&'a [u8]>,
@@ -166,7 +319,7 @@ impl<'a> serde::Serialize for SubMatch<'a> {
 /// it is natively supported by JSON. When invalid UTF-8 is found, then it is
 /// represented as arbitrary bytes and base64 encoded.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-enum Data<'a> {
+pub(crate) enum Data<'a> {
     Text { text: Cow<'a, str> },
     Bytes { bytes: &'a [u8] },
 }

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -74,6 +74,10 @@ pub use crate::{
 
 #[cfg(feature = "serde")]
 pub use crate::json::{JSON, JSONBuilder, JSONSink};
+#[cfg(feature = "serde")]
+pub use crate::json_captures::{
+    JSONCaptures, JSONCapturesBuilder, JSONCapturesSink,
+};
 
 // The maximum number of bytes to execute a search to account for look-ahead.
 //
@@ -94,6 +98,8 @@ mod counter;
 mod hyperlink;
 #[cfg(feature = "serde")]
 mod json;
+#[cfg(feature = "serde")]
+mod json_captures;
 #[cfg(feature = "serde")]
 mod jsont;
 mod path;

--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -13,7 +13,7 @@ use {
     grep_searcher::{
         LineStep, Searcher, Sink, SinkContext, SinkFinish, SinkMatch,
     },
-    termcolor::{ColorSpec, NoColor, WriteColor},
+    termcolor::{Color, ColorSpec, NoColor, WriteColor},
 };
 
 use crate::{
@@ -22,8 +22,9 @@ use crate::{
     hyperlink::{self, HyperlinkConfig},
     stats::Stats,
     util::{
-        DecimalFormatter, PrinterPath, Replacer, Sunk,
-        find_iter_at_in_context, trim_ascii_prefix, trim_line_terminator,
+        CaptureMatch, DecimalFormatter, PrinterPath, Replacer, Sunk,
+        capture_matches_in_context, find_iter_at_in_context,
+        trim_ascii_prefix, trim_line_terminator,
     },
 };
 
@@ -39,6 +40,8 @@ struct Config {
     stats: bool,
     heading: bool,
     path: bool,
+    capture_highlight: bool,
+    capture_list: bool,
     only_matching: bool,
     per_match: bool,
     per_match_one_line: bool,
@@ -64,6 +67,8 @@ impl Default for Config {
             stats: false,
             heading: false,
             path: true,
+            capture_highlight: false,
+            capture_list: false,
             only_matching: false,
             per_match: false,
             per_match_one_line: false,
@@ -129,6 +134,7 @@ impl StandardBuilder {
             config: self.config.clone(),
             wtr: RefCell::new(CounterWriter::new(wtr)),
             matches: vec![],
+            occurrences: vec![],
         }
     }
 
@@ -228,6 +234,30 @@ impl StandardBuilder {
     /// This is enabled by default.
     pub fn path(&mut self, yes: bool) -> &mut StandardBuilder {
         self.config.path = yes;
+        self
+    }
+
+    /// Highlight explicit capture groups within each reported match.
+    ///
+    /// This keeps the standard printer's existing line-oriented layout, but
+    /// colors explicit capture groups distinctly from the surrounding bytes of
+    /// the overall match.
+    ///
+    /// This is disabled by default.
+    pub fn capture_highlight(&mut self, yes: bool) -> &mut StandardBuilder {
+        self.config.capture_highlight = yes;
+        self
+    }
+
+    /// Print one record for each explicit capture group that participated in
+    /// a match.
+    ///
+    /// Each record includes the capture group's start location, absolute byte
+    /// offset and group metadata before printing the capture bytes.
+    ///
+    /// This is disabled by default.
+    pub fn capture_list(&mut self, yes: bool) -> &mut StandardBuilder {
+        self.config.capture_list = yes;
         self
     }
 
@@ -481,6 +511,7 @@ pub struct Standard<W> {
     config: Config,
     wtr: RefCell<CounterWriter<W>>,
     matches: Vec<Match>,
+    occurrences: Vec<CaptureMatch>,
 }
 
 impl<W: WriteColor> Standard<W> {
@@ -578,9 +609,13 @@ impl<W: WriteColor> Standard<W> {
     fn needs_match_granularity(&self) -> bool {
         let supports_color = self.wtr.borrow().supports_color();
         let match_colored = !self.config.colors.matched().is_none();
+        let capture_highlight =
+            self.config.capture_highlight && supports_color;
 
         // Coloring requires identifying each individual match.
         (supports_color && match_colored)
+        // Capture highlighting requires finding each explicit capture group.
+        || capture_highlight
         // The column feature requires finding the position of the first match.
         || self.config.column
         // Requires finding each match for performing replacement.
@@ -589,8 +624,20 @@ impl<W: WriteColor> Standard<W> {
         || self.config.per_match
         // Emitting only the match requires finding each match.
         || self.config.only_matching
+        // Emitting one row per capture requires capture-aware matching.
+        || self.config.capture_list
         // Computing certain statistics requires finding each match.
         || self.config.stats
+    }
+
+    fn needs_capture_granularity(&self) -> bool {
+        self.config.capture_highlight || self.config.capture_list
+    }
+
+    /// Returns true if and only if this printer is configured to require
+    /// explicit capture groups.
+    pub fn requires_explicit_captures(&self) -> bool {
+        self.config.capture_highlight || self.config.capture_list
     }
 }
 
@@ -702,7 +749,30 @@ impl<'p, 's, M: Matcher, W: WriteColor> StandardSink<'p, 's, M, W> {
         range: std::ops::Range<usize>,
     ) -> io::Result<()> {
         self.standard.matches.clear();
+        self.standard.occurrences.clear();
         if !self.needs_match_granularity {
+            return Ok(());
+        }
+        if self.standard.needs_capture_granularity() {
+            let caps = self.replacer.captures(&self.matcher)?;
+            capture_matches_in_context(
+                searcher,
+                &self.matcher,
+                bytes,
+                range.clone(),
+                caps,
+                &mut self.standard.occurrences,
+            )?;
+            for occurrence in self.standard.occurrences.iter() {
+                self.standard.matches.push(occurrence.overall());
+            }
+            if !self.standard.matches.is_empty()
+                && self.standard.matches.last().unwrap().is_empty()
+                && self.standard.matches.last().unwrap().start() >= range.end
+            {
+                self.standard.matches.pop().unwrap();
+                self.standard.occurrences.pop().unwrap();
+            }
             return Ok(());
         }
         // If printing requires knowing the location of each individual match,
@@ -927,6 +997,9 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
 
     fn sink(&self) -> io::Result<()> {
         self.write_search_prelude()?;
+        if self.config().capture_list && !self.is_context() {
+            return self.sink_capture_list();
+        }
         if self.sunk.matches().is_empty() {
             if self.multi_line() && !self.is_context() {
                 self.sink_fast_multi_line()
@@ -940,6 +1013,223 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
                 self.sink_slow()
             }
         }
+    }
+
+    fn occurrences(&self) -> &'a [CaptureMatch] {
+        &self.sink.standard.occurrences
+    }
+
+    fn capture_highlight_on(&self) -> bool {
+        self.config().capture_highlight && self.wtr().borrow().supports_color()
+    }
+
+    fn capture_color_spec(&self, group_index: usize) -> ColorSpec {
+        const PALETTE: [Color; 6] = [
+            Color::Red,
+            Color::Cyan,
+            Color::Green,
+            Color::Magenta,
+            Color::Yellow,
+            Color::Blue,
+        ];
+
+        let mut spec = self.config().colors.matched().clone();
+        let color = PALETTE[(group_index.saturating_sub(1)) % PALETTE.len()];
+        spec.set_fg(Some(color));
+        spec
+    }
+
+    fn write_capture_spec(
+        &self,
+        group_index: usize,
+        buf: &[u8],
+    ) -> io::Result<()> {
+        let spec = self.capture_color_spec(group_index);
+        let mut wtr = self.wtr().borrow_mut();
+        wtr.set_color(&spec)?;
+        wtr.write_all(buf)?;
+        if self.highlight_on() {
+            wtr.set_color(self.config().colors.highlight())?;
+        } else {
+            wtr.reset()?;
+        }
+        Ok(())
+    }
+
+    fn capture_spans_for_range(
+        &self,
+        output_range: Match,
+        rebase_start: usize,
+    ) -> Vec<(Match, usize)> {
+        let mut spans = vec![];
+        for occurrence in self.occurrences() {
+            for (group_index, capture) in
+                occurrence.captures().iter().enumerate().skip(1)
+            {
+                let Some(capture) = *capture else { continue };
+                let start = cmp::max(capture.start(), output_range.start());
+                let end = cmp::min(capture.end(), output_range.end());
+                if start >= end {
+                    continue;
+                }
+                spans.push((
+                    Match::new(start - rebase_start, end - rebase_start),
+                    group_index,
+                ));
+            }
+        }
+        spans.sort_by_key(|(span, group_index)| {
+            (span.start(), span.end() - span.start(), *group_index)
+        });
+        spans
+    }
+
+    fn capture_owner(
+        &self,
+        spans: &[(Match, usize)],
+        offset: usize,
+    ) -> Option<usize> {
+        spans.iter().fold(None, |best, (span, group_index)| {
+            if span.start() <= offset && offset < span.end() {
+                match best {
+                    None => Some(*group_index),
+                    Some(prev_group) => {
+                        let prev = spans
+                            .iter()
+                            .find(|(candidate, idx)| {
+                                *idx == prev_group
+                                    && candidate.start() <= offset
+                                    && offset < candidate.end()
+                            })
+                            .map(|(candidate, _)| *candidate)
+                            .unwrap();
+                        let prev_len = prev.end() - prev.start();
+                        let next_len = span.end() - span.start();
+                        if next_len < prev_len
+                            || (next_len == prev_len
+                                && *group_index < prev_group)
+                        {
+                            Some(*group_index)
+                        } else {
+                            Some(prev_group)
+                        }
+                    }
+                }
+            } else {
+                best
+            }
+        })
+    }
+
+    fn write_capture_highlighted_line(
+        &self,
+        bytes: &[u8],
+        mut range: Match,
+        rebase_start: usize,
+    ) -> io::Result<()> {
+        self.trim_line_terminator(bytes, &mut range);
+        self.trim_ascii_prefix(bytes, &mut range);
+        let slice = &bytes[range];
+        if slice.is_empty() {
+            self.write_line_term()?;
+            return Ok(());
+        }
+        if !self.capture_highlight_on() {
+            self.write_line(slice)?;
+            return Ok(());
+        }
+        let spans = self.capture_spans_for_range(range, rebase_start);
+        if spans.is_empty() {
+            self.write_line(slice)?;
+            return Ok(());
+        }
+        let mut boundaries = vec![0, slice.len()];
+        for (span, _) in spans.iter() {
+            boundaries.push(span.start());
+            boundaries.push(span.end());
+        }
+        boundaries.sort_unstable();
+        boundaries.dedup();
+
+        self.start_line_highlight()?;
+        for window in boundaries.windows(2) {
+            let start = window[0];
+            let end = window[1];
+            if start == end {
+                continue;
+            }
+            let segment = &slice[start..end];
+            if let Some(group_index) = self.capture_owner(&spans, start) {
+                self.write_capture_spec(group_index, segment)?;
+            } else {
+                self.write(segment)?;
+            }
+        }
+        self.end_line_highlight()?;
+        self.write_line_term()
+    }
+
+    fn capture_location(&self, span: Match) -> (Option<u64>, u64) {
+        let mut count = 0u64;
+        let mut line_start = 0usize;
+        let line_term = self.searcher.line_terminator().as_byte();
+        let mut stepper = LineStep::new(line_term, 0, self.sunk.bytes().len());
+        while let Some((start, end)) = stepper.next(self.sunk.bytes()) {
+            if span.start() < end {
+                line_start = start;
+                break;
+            }
+            count += 1;
+        }
+        (
+            self.sunk.line_number().map(|line| line + count),
+            (span.start() - line_start) as u64 + 1,
+        )
+    }
+
+    fn write_capture_record(
+        &self,
+        group_index: usize,
+        span: Match,
+    ) -> io::Result<()> {
+        let (line_number, column) = self.capture_location(span);
+        let absolute_offset =
+            self.sunk.absolute_byte_offset() + span.start() as u64;
+
+        let mut prelude = PreludeWriter::new(self);
+        prelude.start(line_number, Some(column))?;
+        prelude.write_path_force()?;
+        prelude.write_line_number(line_number)?;
+        prelude.write_column_number_force(column)?;
+        prelude.write_byte_offset_force(absolute_offset)?;
+        prelude.end()?;
+
+        self.write(b"group=")?;
+        let group = DecimalFormatter::new(group_index as u64);
+        self.write(group.as_bytes())?;
+        self.write(self.separator_field())?;
+        if let Some(name) = self.sink.matcher.capture_name(group_index) {
+            self.write(b"name=")?;
+            self.write(name.as_bytes())?;
+            self.write(self.separator_field())?;
+        }
+        self.write(&self.sunk.bytes()[span])?;
+        if !self.has_line_terminator(&self.sunk.bytes()[span]) {
+            self.write_line_term()?;
+        }
+        Ok(())
+    }
+
+    fn sink_capture_list(&self) -> io::Result<()> {
+        for occurrence in self.occurrences() {
+            for (group_index, capture) in
+                occurrence.captures().iter().enumerate().skip(1)
+            {
+                let Some(span) = *capture else { continue };
+                self.write_capture_record(group_index, span)?;
+            }
+        }
+        Ok(())
     }
 
     /// Print matches (limited to one line) quickly by avoiding the detection
@@ -996,15 +1286,23 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
         debug_assert!(!self.multi_line() || self.is_context());
 
         if self.config().only_matching {
-            for &m in self.sunk.matches() {
+            let occurrences = self.occurrences();
+            for (i, &m) in self.sunk.matches().iter().enumerate() {
                 self.write_prelude(
                     self.sunk.absolute_byte_offset() + m.start() as u64,
                     self.sunk.line_number(),
                     Some(m.start() as u64 + 1),
                 )?;
-
-                let buf = &self.sunk.bytes()[m];
-                self.write_colored_line(&[Match::new(0, buf.len())], buf)?;
+                if self.capture_highlight_on() && i < occurrences.len() {
+                    self.write_capture_highlighted_line(
+                        self.sunk.bytes(),
+                        m,
+                        m.start(),
+                    )?;
+                } else {
+                    let buf = &self.sunk.bytes()[m];
+                    self.write_colored_line(&[Match::new(0, buf.len())], buf)?;
+                }
             }
         } else if self.config().per_match {
             for &m in self.sunk.matches() {
@@ -1013,7 +1311,15 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
                     self.sunk.line_number(),
                     Some(m.start() as u64 + 1),
                 )?;
-                self.write_colored_line(&[m], self.sunk.bytes())?;
+                if self.capture_highlight_on() {
+                    self.write_capture_highlighted_line(
+                        self.sunk.bytes(),
+                        m,
+                        0,
+                    )?;
+                } else {
+                    self.write_colored_line(&[m], self.sunk.bytes())?;
+                }
             }
         } else {
             self.write_prelude(
@@ -1021,7 +1327,18 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
                 self.sunk.line_number(),
                 Some(self.sunk.matches()[0].start() as u64 + 1),
             )?;
-            self.write_colored_line(self.sunk.matches(), self.sunk.bytes())?;
+            if self.capture_highlight_on() {
+                self.write_capture_highlighted_line(
+                    self.sunk.bytes(),
+                    Match::new(0, self.sunk.bytes().len()),
+                    0,
+                )?;
+            } else {
+                self.write_colored_line(
+                    self.sunk.matches(),
+                    self.sunk.bytes(),
+                )?;
+            }
         }
         Ok(())
     }
@@ -1053,6 +1370,8 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
             self.trim_ascii_prefix(bytes, &mut line);
             if self.exceeds_max_columns(&bytes[line]) {
                 self.write_exceeded_line(bytes, line, matches, &mut midx)?;
+            } else if self.capture_highlight_on() {
+                self.write_capture_highlighted_line(bytes, line, 0)?;
             } else {
                 self.write_colored_matches(bytes, line, matches, &mut midx)?;
                 self.write_line_term()?;
@@ -1062,6 +1381,54 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
     }
 
     fn sink_slow_multi_line_only_matching(&self) -> io::Result<()> {
+        if self.capture_highlight_on() {
+            let line_term = self.searcher.line_terminator().as_byte();
+            let bytes = self.sunk.bytes();
+            for occurrence in self.occurrences() {
+                let m = occurrence.overall();
+                let mut count = 0;
+                let mut stepper = LineStep::new(line_term, 0, bytes.len());
+                while let Some((start, end)) = stepper.next(bytes) {
+                    let line = Match::new(start, end);
+                    if line.start() >= m.end() {
+                        break;
+                    } else if line.end() <= m.start() {
+                        count += 1;
+                        continue;
+                    }
+                    let this_line = Match::new(
+                        cmp::max(line.start(), m.start()),
+                        cmp::min(line.end(), m.end()),
+                    );
+                    self.write_prelude(
+                        self.sunk.absolute_byte_offset()
+                            + this_line.start() as u64,
+                        self.sunk.line_number().map(|n| n + count),
+                        Some(
+                            this_line.start().saturating_sub(line.start())
+                                as u64
+                                + 1,
+                        ),
+                    )?;
+                    if self.exceeds_max_columns(&bytes[this_line]) {
+                        self.write_exceeded_line(
+                            bytes,
+                            this_line,
+                            &[m],
+                            &mut 0,
+                        )?;
+                    } else {
+                        self.write_capture_highlighted_line(
+                            bytes,
+                            this_line,
+                            this_line.start(),
+                        )?;
+                    }
+                    count += 1;
+                }
+            }
+            return Ok(());
+        }
         let line_term = self.searcher.line_terminator().as_byte();
         let spec = self.config().colors.matched();
         let bytes = self.sunk.bytes();
@@ -1113,6 +1480,41 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
     }
 
     fn sink_slow_multi_per_match(&self) -> io::Result<()> {
+        if self.capture_highlight_on() {
+            let line_term = self.searcher.line_terminator().as_byte();
+            let bytes = self.sunk.bytes();
+            for occurrence in self.occurrences() {
+                let m = occurrence.overall();
+                let mut count = 0;
+                let mut stepper = LineStep::new(line_term, 0, bytes.len());
+                while let Some((start, end)) = stepper.next(bytes) {
+                    let line = Match::new(start, end);
+                    if line.start() >= m.end() {
+                        break;
+                    } else if line.end() <= m.start() {
+                        count += 1;
+                        continue;
+                    }
+                    self.write_prelude(
+                        self.sunk.absolute_byte_offset() + line.start() as u64,
+                        self.sunk.line_number().map(|n| n + count),
+                        Some(
+                            m.start().saturating_sub(line.start()) as u64 + 1,
+                        ),
+                    )?;
+                    count += 1;
+                    if self.exceeds_max_columns(&bytes[line]) {
+                        self.write_exceeded_line(bytes, line, &[m], &mut 0)?;
+                    } else {
+                        self.write_capture_highlighted_line(bytes, line, 0)?;
+                    }
+                    if self.config().per_match_one_line {
+                        break;
+                    }
+                }
+            }
+            return Ok(());
+        }
         let line_term = self.searcher.line_terminator().as_byte();
         let spec = self.config().colors.matched();
         let bytes = self.sunk.bytes();
@@ -1676,6 +2078,20 @@ impl<'a, M: Matcher, W: WriteColor> PreludeWriter<'a, M, W> {
         Ok(())
     }
 
+    #[inline(always)]
+    fn write_path_force(&mut self) -> io::Result<()> {
+        let Some(path) = self.std.path() else { return Ok(()) };
+        self.write_separator()?;
+        self.std.write_path(path)?;
+
+        self.next_separator = if self.config().path_terminator.is_some() {
+            PreludeSeparator::PathTerminator
+        } else {
+            PreludeSeparator::FieldSeparator
+        };
+        Ok(())
+    }
+
     /// Writes the line number field if present.
     #[inline(always)]
     fn write_line_number(&mut self, line: Option<u64>) -> io::Result<()> {
@@ -1701,12 +2117,30 @@ impl<'a, M: Matcher, W: WriteColor> PreludeWriter<'a, M, W> {
         Ok(())
     }
 
+    #[inline(always)]
+    fn write_column_number_force(&mut self, column: u64) -> io::Result<()> {
+        self.write_separator()?;
+        let n = DecimalFormatter::new(column);
+        self.std.write_spec(self.config().colors.column(), n.as_bytes())?;
+        self.next_separator = PreludeSeparator::FieldSeparator;
+        Ok(())
+    }
+
     /// Writes the byte offset field if configured to do so.
     #[inline(always)]
     fn write_byte_offset(&mut self, offset: u64) -> io::Result<()> {
         if !self.config().byte_offset {
             return Ok(());
         }
+        self.write_separator()?;
+        let n = DecimalFormatter::new(offset);
+        self.std.write_spec(self.config().colors.column(), n.as_bytes())?;
+        self.next_separator = PreludeSeparator::FieldSeparator;
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn write_byte_offset_force(&mut self, offset: u64) -> io::Result<()> {
         self.write_separator()?;
         let n = DecimalFormatter::new(offset);
         self.std.write_spec(self.config().colors.column(), n.as_bytes())?;
@@ -3077,6 +3511,48 @@ line 3 x
 2:16:Holmeses
 5:12:Watson has to have it taken out for him and dusted,
 6:12:and exhibited clearly
+";
+        assert_eq_printed!(expected, got);
+    }
+
+    #[test]
+    fn capture_highlight_only_matching_ansi() {
+        let matcher = RegexMatcher::new(r"(foo)(1)(bar)").unwrap();
+        let mut printer = StandardBuilder::new()
+            .capture_highlight(true)
+            .only_matching(true)
+            .build(Ansi::new(vec![]));
+        SearcherBuilder::new()
+            .build()
+            .search_reader(&matcher, b"x foo1bar y\n", printer.sink(&matcher))
+            .unwrap();
+
+        let got = printer_contents_ansi(&mut printer);
+        let expected = "\x1b[0m\x1b[1m\x1b[31mfoo\x1b[0m\x1b[0m\x1b[1m\x1b[36m1\x1b[0m\x1b[0m\x1b[1m\x1b[32mbar\x1b[0m\n";
+        assert_eq_printed!(expected, got);
+    }
+
+    #[test]
+    fn capture_list() {
+        let matcher = RegexMatcher::new(r"(aa )?(fairplay)( bb)?").unwrap();
+        let mut printer = StandardBuilder::new()
+            .capture_list(true)
+            .build(NoColor::new(vec![]));
+        SearcherBuilder::new()
+            .line_number(true)
+            .build()
+            .search_reader(
+                &matcher,
+                b"aa fairplay bb\n",
+                printer.sink(&matcher),
+            )
+            .unwrap();
+
+        let got = printer_contents(&mut printer);
+        let expected = "\
+1:1:0:group=1:aa 
+1:4:3:group=2:fairplay
+1:12:11:group=3: bb
 ";
         assert_eq_printed!(expected, got);
     }

--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -10,6 +10,34 @@ use {
 
 use crate::{MAX_LOOK_AHEAD, hyperlink::HyperlinkPath};
 
+/// A complete regex occurrence, including the overall match and every capture
+/// group span that participated in it.
+#[derive(Clone, Debug)]
+pub(crate) struct CaptureMatch {
+    overall: Match,
+    captures: Vec<Option<Match>>,
+}
+
+impl CaptureMatch {
+    #[inline]
+    pub(crate) fn new(
+        overall: Match,
+        captures: Vec<Option<Match>>,
+    ) -> CaptureMatch {
+        CaptureMatch { overall, captures }
+    }
+
+    #[inline]
+    pub(crate) fn overall(&self) -> Match {
+        self.overall
+    }
+
+    #[inline]
+    pub(crate) fn captures(&self) -> &[Option<Match>] {
+        &self.captures
+    }
+}
+
 /// A type for handling replacements while amortizing allocation.
 pub(crate) struct Replacer<M: Matcher> {
     space: Option<Space<M>>,
@@ -136,6 +164,15 @@ impl<M: Matcher> Replacer<M> {
             space.dst.clear();
             space.matches.clear();
         }
+    }
+
+    /// Return reusable space for extracting captures without performing a
+    /// replacement.
+    pub(crate) fn captures<'a>(
+        &'a mut self,
+        matcher: &M,
+    ) -> io::Result<&'a mut M::Captures> {
+        Ok(&mut self.allocate(matcher)?.caps)
     }
 
     /// Allocate space for replacements when used with the given matcher and
@@ -525,6 +562,57 @@ where
                 return false;
             }
             matched(m)
+        })
+        .map_err(io::Error::error_message)
+}
+
+/// Like `Matcher::captures_iter_at`, but accepts an end bound by discarding
+/// matches that start beyond the given range.
+pub(crate) fn capture_matches_in_context<M>(
+    searcher: &Searcher,
+    matcher: M,
+    mut bytes: &[u8],
+    range: std::ops::Range<usize>,
+    caps: &mut M::Captures,
+    matches: &mut Vec<CaptureMatch>,
+) -> io::Result<()>
+where
+    M: Matcher,
+{
+    let is_multi_line = searcher.multi_line_with_matcher(&matcher);
+    if is_multi_line {
+        if bytes[range.end..].len() >= MAX_LOOK_AHEAD {
+            bytes = &bytes[..range.end + MAX_LOOK_AHEAD];
+        }
+    } else {
+        let mut m = Match::new(0, range.end);
+        trim_line_terminator(searcher, bytes, &mut m);
+        bytes = &bytes[..m.end()];
+    }
+    matcher
+        .captures_iter_at(bytes, range.start, caps, |caps| {
+            let overall = caps.get(0).unwrap();
+            if overall.start() >= range.end {
+                return false;
+            }
+            let captures = (0..caps.len())
+                .map(|i| {
+                    caps.get(i).map(|m| {
+                        Match::new(
+                            m.start() - range.start,
+                            m.end() - range.start,
+                        )
+                    })
+                })
+                .collect();
+            matches.push(CaptureMatch::new(
+                Match::new(
+                    overall.start() - range.start,
+                    overall.end() - range.start,
+                ),
+                captures,
+            ));
+            true
         })
         .map_err(io::Error::error_message)
 }

--- a/crates/regex/src/matcher.rs
+++ b/crates/regex/src/matcher.rs
@@ -436,6 +436,11 @@ impl Matcher for RegexMatcher {
     }
 
     #[inline]
+    fn capture_name(&self, index: usize) -> Option<&str> {
+        self.regex.group_info().to_name(PatternID::ZERO, index)
+    }
+
+    #[inline]
     fn try_find_iter<F, E>(
         &self,
         haystack: &[u8],

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -1172,3 +1172,45 @@ rgtest!(stop_on_nonmatch, |dir: Dir, mut cmd: TestCommand| {
     cmd.args(&["--stop-on-nonmatch", "[235]"]);
     eqnice!("test:line2\ntest:line3\n", cmd.stdout());
 });
+
+rgtest!(capture_highlight_requires_group, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("test", "fairplay\n");
+    cmd.args(&["--capture-highlight", "fairplay", "test"]);
+    cmd.assert_err();
+});
+
+rgtest!(capture_list_requires_group, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("test", "fairplay\n");
+    cmd.args(&["--capture-list", "fairplay", "test"]);
+    cmd.assert_err();
+});
+
+rgtest!(json_captures_requires_group, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("test", "fairplay\n");
+    cmd.args(&["--json-captures", "fairplay", "test"]);
+    cmd.assert_err();
+});
+
+rgtest!(
+    json_captures_lines_requires_json_captures,
+    |dir: Dir, mut cmd: TestCommand| {
+        dir.create("test", "fairplay\n");
+        cmd.args(&["--json-captures-lines=always", "(fairplay)", "test"]);
+        cmd.assert_err();
+    }
+);
+
+rgtest!(
+    capture_highlight_conflicts_vimgrep,
+    |dir: Dir, mut cmd: TestCommand| {
+        dir.create("test", "fairplay\n");
+        cmd.args(&["--capture-highlight", "--vimgrep", "(fairplay)", "test"]);
+        cmd.assert_err();
+    }
+);
+
+rgtest!(capture_list_conflicts_replace, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("test", "fairplay\n");
+    cmd.args(&["--capture-list", "--replace", "x", "(fairplay)", "test"]);
+    cmd.assert_err();
+});

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -17,6 +17,17 @@ enum Message {
     Summary(Summary),
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "data")]
+#[serde(rename_all = "snake_case")]
+enum CaptureMessage {
+    Begin(Begin),
+    End(End),
+    Match(CaptureMatch),
+    Context(CaptureContext),
+    Summary(Summary),
+}
+
 impl Message {
     fn unwrap_begin(&self) -> Begin {
         match *self {
@@ -50,6 +61,15 @@ impl Message {
         match *self {
             Message::Summary(ref x) => x.clone(),
             ref x => panic!("expected Message::Summary but got {x:?}"),
+        }
+    }
+}
+
+impl CaptureMessage {
+    fn unwrap_match(&self) -> CaptureMatch {
+        match *self {
+            CaptureMessage::Match(ref x) => x.clone(),
+            ref x => panic!("expected CaptureMessage::Match but got {x:?}"),
         }
     }
 }
@@ -106,6 +126,51 @@ struct SubMatch {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct CaptureMatch {
+    path: Option<Data>,
+    lines: Option<Data>,
+    line_number: Option<u64>,
+    absolute_offset: u64,
+    occurrences: Vec<CaptureOccurrence>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct CaptureContext {
+    path: Option<Data>,
+    lines: Option<Data>,
+    line_number: Option<u64>,
+    absolute_offset: u64,
+    occurrences: Vec<CaptureOccurrence>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct CaptureOccurrence {
+    #[serde(rename = "match")]
+    m: Data,
+    start: usize,
+    end: usize,
+    absolute_start: u64,
+    absolute_end: u64,
+    captures: Vec<CaptureGroup>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct CaptureGroup {
+    index: usize,
+    name: Option<String>,
+    #[serde(rename = "match")]
+    m: Option<Data>,
+    start: Option<usize>,
+    end: Option<usize>,
+    absolute_start: Option<u64>,
+    absolute_end: Option<u64>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 enum Data {
     Text { text: String },
@@ -149,6 +214,13 @@ fn json_decode(jsonlines: &str) -> Vec<Message> {
     json::Deserializer::from_str(jsonlines)
         .into_iter()
         .collect::<Result<Vec<Message>, _>>()
+        .unwrap()
+}
+
+fn json_captures_decode(jsonlines: &str) -> Vec<CaptureMessage> {
+    json::Deserializer::from_str(jsonlines)
+        .into_iter()
+        .collect::<Result<Vec<CaptureMessage>, _>>()
         .unwrap()
 }
 
@@ -438,4 +510,62 @@ rgtest!(r1412_look_behind_match_missing, |dir: Dir, mut cmd: TestCommand| {
     let m = msgs[1].unwrap_match();
     assert_eq!(m.lines, Data::text("bar\n"));
     assert_eq!(m.submatches.len(), 1);
+});
+
+rgtest!(json_captures_basic, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("test", "aa fairplay bb\n");
+    cmd.arg("--json-captures").arg(r"(aa )?(fairplay)( bb)?").arg("test");
+
+    let msgs = json_captures_decode(&cmd.stdout());
+    assert_eq!(msgs.len(), 4);
+
+    let m = msgs[1].unwrap_match();
+    assert_eq!(m.lines, None);
+    assert_eq!(m.occurrences.len(), 1);
+    assert_eq!(m.occurrences[0].m, Data::text("aa fairplay bb"));
+    assert_eq!(m.occurrences[0].captures.len(), 4);
+    assert_eq!(
+        m.occurrences[0].captures[0].m,
+        Some(Data::text("aa fairplay bb"))
+    );
+    assert_eq!(m.occurrences[0].captures[1].m, Some(Data::text("aa ")));
+    assert_eq!(m.occurrences[0].captures[2].m, Some(Data::text("fairplay")));
+    assert_eq!(m.occurrences[0].captures[3].m, Some(Data::text(" bb")));
+});
+
+rgtest!(
+    json_captures_missing_optional_group,
+    |dir: Dir, mut cmd: TestCommand| {
+        dir.create("test", "fairplay\n");
+        cmd.arg("--json-captures").arg(r"(fairplay)( foo)?").arg("test");
+
+        let msgs = json_captures_decode(&cmd.stdout());
+        assert_eq!(msgs.len(), 4);
+
+        let m = msgs[1].unwrap_match();
+        assert_eq!(m.occurrences.len(), 1);
+        assert_eq!(m.occurrences[0].captures.len(), 3);
+        assert_eq!(
+            m.occurrences[0].captures[1].m,
+            Some(Data::text("fairplay"))
+        );
+        assert_eq!(m.occurrences[0].captures[2].m, None);
+        assert_eq!(m.occurrences[0].captures[2].start, None);
+        assert_eq!(m.occurrences[0].captures[2].absolute_start, None);
+    }
+);
+
+rgtest!(json_captures_lines_always, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("test", "aa fairplay bb\n");
+    cmd.arg("--json-captures")
+        .arg("--json-captures-lines=always")
+        .arg(r"(aa )?(fairplay)( bb)?")
+        .arg("test");
+
+    let msgs = json_captures_decode(&cmd.stdout());
+    assert_eq!(msgs.len(), 4);
+
+    let m = msgs[1].unwrap_match();
+    assert_eq!(m.lines, Some(Data::text("aa fairplay bb\n")));
+    assert_eq!(m.occurrences.len(), 1);
 });


### PR DESCRIPTION
> [!CAUTION]
> Vibe-coded for personal use

Improves **group captures** by adding group color highlighting in output, json captures or list.

<img width="751" height="376" alt="image" src="https://github.com/user-attachments/assets/dff548b1-57c4-4789-9967-fe1067ac5e23" />

Feature enhancements:

* Add `--capture-highlight` to color explicit capture groups within standard output, `--capture-list` to print one record per explicit capture group and `--json-captures` for structured capture-aware JSON output.
* Add `--json-captures-lines=never|always`. The default is `never`, which keeps capture-aware JSON compact by omitting the parent `lines` payload unless it is explicitly requested.

Feature enhancements:

* Add `--capture-highlight` for coloring explicit capture groups inside standard output.
* Add `--capture-list` for emitting one record per explicit capture group with offsets.
* Add `--json-captures` for occurrence- and capture-aware JSON output.
* Add `--json-captures-lines=never|always`, with `never` as the default, so capture-aware JSON can stay compact unless the parent `lines` payload is explicitly requested.

Usage examples:

```shell
# highlight
$ rg -i ".{0,50}.(foo|bar).{0,50}" \
      --only-matching \
      --capture-highlight

# json capture
$ rg -i ".{0,50}.(foo|bar).{0,50}" \
      --json-captures-lines=[none]|always \
      --json-captures 
      
# list 
$ rg -i ".{0,50}.(foo|bar).{0,50}" \
      --only-matching \
      --capture-list
```

<img width="886" height="449" alt="image" src="https://github.com/user-attachments/assets/9393137b-96a6-4e9a-b654-1c72d0410af0" />

<img width="750" height="464" alt="image" src="https://github.com/user-attachments/assets/d4839f23-7173-40da-bd75-b75a034d1c3a" />
