### PR TITLE
feat(globset): expose MatchStrategy API

### DIFF
--- a/crates/globset/src/glob.rs
+++ b/crates/globset/src/glob.rs
@@ -13,7 +13,7 @@ use crate::{Candidate, Error, ErrorKind, new_regex};
 /// possible to test whether any of those patterns matches by looking up a
 /// file path's extension in a hash table.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum MatchStrategy {
+pub enum MatchStrategy {
     /// A pattern matches if and only if the entire file path matches this
     /// literal string.
     Literal(String),
@@ -48,7 +48,7 @@ pub(crate) enum MatchStrategy {
 
 impl MatchStrategy {
     /// Returns a matching strategy for the given pattern.
-    pub(crate) fn new(pat: &Glob) -> MatchStrategy {
+    pub fn new(pat: &Glob) -> MatchStrategy {
         if let Some(lit) = pat.basename_literal() {
             MatchStrategy::BasenameLiteral(lit)
         } else if let Some(lit) = pat.literal() {

--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -129,11 +129,10 @@ use {
 };
 
 use crate::{
-    glob::MatchStrategy,
     pathutil::{file_name, file_name_ext, normalize_path},
 };
 
-pub use crate::glob::{Glob, GlobBuilder, GlobMatcher};
+pub use crate::glob::{Glob, GlobBuilder, GlobMatcher, MatchStrategy};
 
 mod fnv;
 mod glob;


### PR DESCRIPTION
This PR exposes the MatchStrategy API in globset, allowing users to customize matching strategies.\n\n## Changes\n- Exposed MatchStrategy API for public use\n\nRelated to #2780