### PR TITLE
feat(globset): expose MatchStrategy in public API

### DIFF
--- a/crates/globset/src/glob.rs
+++ b/crates/globset/src/glob.rs
@@ -12,8 +12,12 @@ use crate::{Candidate, Error, ErrorKind, new_regex};
 /// patterns. For example, if many patterns are of the form `*.ext`, then it's
 /// possible to test whether any of those patterns matches by looking up a
 /// file path's extension in a hash table.
+///
+/// This is useful for users who want to inspect or categorize patterns
+/// based on their matching strategy, or for building custom optimizations
+/// based on the detected strategy.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum MatchStrategy {
+pub enum MatchStrategy {
     /// A pattern matches if and only if the entire file path matches this
     /// literal string.
     Literal(String),
@@ -48,7 +52,16 @@ pub(crate) enum MatchStrategy {
 
 impl MatchStrategy {
     /// Returns a matching strategy for the given pattern.
-    pub(crate) fn new(pat: &Glob) -> MatchStrategy {
+    ///
+    /// This analyzes the glob pattern and determines the optimal matching
+    /// strategy that can be used. For example, a pattern like `*.rs` will
+    /// return `MatchStrategy::Extension(".rs")`, while a pattern like
+    /// `foo/bar` will return `MatchStrategy::Literal("foo/bar")`.
+    ///
+    /// Note that case-insensitive patterns will generally result in a
+    /// `MatchStrategy::Regex` strategy, since literal optimizations are
+    /// only possible when case sensitivity is enabled.
+    pub fn new(pat: &Glob) -> MatchStrategy {
         if let Some(lit) = pat.basename_literal() {
             MatchStrategy::BasenameLiteral(lit)
         } else if let Some(lit) = pat.literal() {

--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -129,7 +129,6 @@ use {
 };
 
 use crate::{
-    glob::MatchStrategy,
     pathutil::{file_name, file_name_ext, normalize_path},
 };
 

--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -133,7 +133,7 @@ use crate::{
     pathutil::{file_name, file_name_ext, normalize_path},
 };
 
-pub use crate::glob::{Glob, GlobBuilder, GlobMatcher};
+pub use crate::glob::{Glob, GlobBuilder, GlobMatcher, MatchStrategy};
 
 mod fnv;
 mod glob;


### PR DESCRIPTION
This change exposes the `MatchStrategy` enum and its `new()` method in the public API, allowing library users to:
- Detect the matching strategy for a given glob pattern
- Build custom optimizations based on the strategy type
- Categorize patterns by their matching behavior

The `MatchStrategy` enum variants are already well-documented, and the `new()` method now includes expanded documentation explaining the behavior and return values.

## Usage Example

```rust
use globset::{Glob, MatchStrategy};

let glob = Glob::new("*.rs")?;
let strategy = MatchStrategy::new(&glob);

match strategy {
    MatchStrategy::Extension(ext) => {
        println!("Extension-based match: {}", ext);
    }
    MatchStrategy::Literal(lit) => {
        println!("Literal match: {}", lit);
    }
    // ... other strategies
    MatchStrategy::Regex => {
        println!("Requires regex matching");
    }
}
```

Closes #2780