### PR TITLE
fix(cli): use '--' separator when passing file paths to decompression tools

### DIFF
--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -226,6 +226,9 @@ impl DecompressionReaderBuilder {
         let Some(mut cmd) = self.matcher.command(path) else {
             return DecompressionReader::new_passthru(path);
         };
+        // Use '--' to separate options from the file path, which ensures
+        // that file paths starting with '-' are not interpreted as options.
+        cmd.arg("--");
         cmd.arg(path);
 
         match self.command_builder.build(&mut cmd) {


### PR DESCRIPTION
## Summary

Fixes an issue where compressed files starting with `-` could not be searched because decompression tools would interpret the filename as a command-line option.

## Problem

When using `rg -z` to search compressed files with names starting with `-` (e.g., `-10.txt.gz`), the decompression tool (gzip, zstd, etc.) would incorrectly parse the filename as an option flag.

Example:
```bash
rg -z 'pattern' '-file.gz'  # Fails: gzip treats '-file.gz' as options
```

## Solution

Add `--` argument separator before the file path when invoking decompression tools. This tells the tool to treat all subsequent arguments as filenames, not options.

```rust
cmd.arg("--");  // Add separator before file path
cmd.arg(path);
```

## Changes

- `crates/cli/src/decompress.rs` - Added `--` separator in `DecompressionReaderBuilder::build()`

## Testing

- `cargo build` ✅
- `cargo test` ✅ (329 passed, 0 failed)
- Manual testing with files starting with `-` ✅

Fixes #3222