### PR TITLE
fix(ignore): treat braces literally in gitignore patterns (#1221)

### DIFF
--- a/crates/globset/src/glob.rs
+++ b/crates/globset/src/glob.rs
@@ -234,6 +234,9 @@ struct GlobOptions {
     /// When this isn't enabled, an opening `[` without a corresponding `]` is
     /// treated as an error.
     allow_unclosed_class: bool,
+    /// Whether or not braces are always treated literally and never as
+    /// alternation groups.
+    literal_braces: bool,
 }
 
 impl GlobOptions {
@@ -244,6 +247,7 @@ impl GlobOptions {
             backslash_escape: !is_separator('\\'),
             empty_alternates: false,
             allow_unclosed_class: false,
+            literal_braces: false,
         }
     }
 }
@@ -664,6 +668,16 @@ impl<'a> GlobBuilder<'a> {
         self.opts.allow_unclosed_class = yes;
         self
     }
+
+    /// Toggle whether braces (`{` and `}`) are always treated literally.
+    ///
+    /// When enabled, braces no longer start or end alternation groups.
+    ///
+    /// This is disabled by default.
+    pub fn literal_braces(&mut self, yes: bool) -> &mut GlobBuilder<'a> {
+        self.opts.literal_braces = yes;
+        self
+    }
 }
 
 impl Tokens {
@@ -826,8 +840,8 @@ impl<'a> Parser<'a> {
                 '?' => self.push_token(Token::Any)?,
                 '*' => self.parse_star()?,
                 '[' if !self.found_unclosed_class => self.parse_class()?,
-                '{' => self.push_alternate()?,
-                '}' => self.pop_alternate()?,
+                '{' if !self.opts.literal_braces => self.push_alternate()?,
+                '}' if !self.opts.literal_braces => self.pop_alternate()?,
                 ',' => self.parse_comma()?,
                 '\\' => self.parse_backslash()?,
                 c => self.push_token(Token::Literal(c))?,
@@ -1088,6 +1102,7 @@ mod tests {
         bsesc: Option<bool>,
         ealtre: Option<bool>,
         unccls: Option<bool>,
+        litbrace: Option<bool>,
     }
 
     macro_rules! syntax {
@@ -1133,6 +1148,9 @@ mod tests {
                 if let Some(unccls) = $options.unccls {
                     builder.allow_unclosed_class(unccls);
                 }
+                if let Some(litbrace) = $options.litbrace {
+                    builder.literal_braces(litbrace);
+                }
 
                 let pat = builder.build().unwrap();
                 assert_eq!(format!("(?-u){}", $re), pat.regex());
@@ -1159,6 +1177,9 @@ mod tests {
                 }
                 if let Some(ealtre) = $options.ealtre {
                     builder.empty_alternates(ealtre);
+                }
+                if let Some(litbrace) = $options.litbrace {
+                    builder.literal_braces(litbrace);
                 }
                 let pat = builder.build().unwrap();
                 let matcher = pat.compile_matcher();
@@ -1190,6 +1211,9 @@ mod tests {
                 }
                 if let Some(ealtre) = $options.ealtre {
                     builder.empty_alternates(ealtre);
+                }
+                if let Some(litbrace) = $options.litbrace {
+                    builder.literal_braces(litbrace);
                 }
                 let pat = builder.build().unwrap();
                 let matcher = pat.compile_matcher();
@@ -1285,6 +1309,7 @@ mod tests {
         bsesc: None,
         ealtre: None,
         unccls: None,
+        litbrace: None,
     };
     const SLASHLIT: Options = Options {
         casei: None,
@@ -1292,6 +1317,7 @@ mod tests {
         bsesc: None,
         ealtre: None,
         unccls: None,
+        litbrace: None,
     };
     const NOBSESC: Options = Options {
         casei: None,
@@ -1299,6 +1325,7 @@ mod tests {
         bsesc: Some(false),
         ealtre: None,
         unccls: None,
+        litbrace: None,
     };
     const BSESC: Options = Options {
         casei: None,
@@ -1306,6 +1333,7 @@ mod tests {
         bsesc: Some(true),
         ealtre: None,
         unccls: None,
+        litbrace: None,
     };
     const EALTRE: Options = Options {
         casei: None,
@@ -1313,6 +1341,7 @@ mod tests {
         bsesc: Some(true),
         ealtre: Some(true),
         unccls: None,
+        litbrace: None,
     };
     const UNCCLS: Options = Options {
         casei: None,
@@ -1320,6 +1349,15 @@ mod tests {
         bsesc: None,
         ealtre: None,
         unccls: Some(true),
+        litbrace: None,
+    };
+    const LITBRACE: Options = Options {
+        casei: None,
+        litsep: None,
+        bsesc: None,
+        ealtre: None,
+        unccls: None,
+        litbrace: Some(true),
     };
 
     toregex!(allow_unclosed_class_single, r"[", r"^\[$", &UNCCLS);
@@ -1365,6 +1403,8 @@ mod tests {
     toregex!(re9, "[+]", r"^[\+]$");
     toregex!(re10, "+", r"^\+$");
     toregex!(re11, "☃", r"^\xe2\x98\x83$");
+    toregex!(re11a, "{a,b}", r"^\{a,b\}$", &LITBRACE);
+    toregex!(re11b, "{{a}}", r"^\{\{a\}\}$", &LITBRACE);
     toregex!(re12, "**", r"^.*$");
     toregex!(re13, "**/", r"^.*$");
     toregex!(re14, "**/*", r"^(?:/?|.*/).*$");
@@ -1481,6 +1521,8 @@ mod tests {
     matches!(matchalt17, "{a,b{c,d}}", "bc");
     matches!(matchalt18, "{a,b{c,d}}", "bd");
     matches!(matchalt19, "{a,b{c,d}}", "a");
+    matches!(matchalt20, "{a,b}", "{a,b}", LITBRACE);
+    matches!(matchalt21, "{{a}}", "{{a}}", LITBRACE);
 
     matches!(matchslash1, "abc/def", "abc/def", SLASHLIT);
     #[cfg(unix)]
@@ -1513,6 +1555,7 @@ mod tests {
     nmatches!(matchnot6, "/**/test", "/one/notthis");
     nmatches!(matchnot7, "/**/test", "/notthis");
     nmatches!(matchnot8, "**/.*", "ab.c");
+    nmatches!(matchnot8a, "{{a}}", "a", LITBRACE);
     nmatches!(matchnot9, "**/.*", "abc/ab.c");
     nmatches!(matchnot10, ".*/**", "a.bc");
     nmatches!(matchnot11, ".*/**", "abc/a.bc");

--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -1146,7 +1146,7 @@ mod tests {
     #[test]
     fn errored() {
         let td = tmpdir();
-        wfile(td.path().join(".gitignore"), "{foo");
+        wfile(td.path().join(".gitignore"), "[z-a]");
 
         let (_, err) = IgnoreBuilder::new().build().add_child(td.path());
         assert!(err.is_some());
@@ -1155,8 +1155,8 @@ mod tests {
     #[test]
     fn errored_both() {
         let td = tmpdir();
-        wfile(td.path().join(".gitignore"), "{foo");
-        wfile(td.path().join(".ignore"), "{bar");
+        wfile(td.path().join(".gitignore"), "[z-a]");
+        wfile(td.path().join(".ignore"), "[z-a]");
 
         let (_, err) = IgnoreBuilder::new().build().add_child(td.path());
         assert_eq!(2, partial(err.expect("an error")).len());
@@ -1166,7 +1166,7 @@ mod tests {
     fn errored_partial() {
         let td = tmpdir();
         mkdirp(td.path().join(".git"));
-        wfile(td.path().join(".gitignore"), "{foo\nbar");
+        wfile(td.path().join(".gitignore"), "[z-a]\nbar");
 
         let (ig, err) = IgnoreBuilder::new().build().add_child(td.path());
         assert!(err.is_some());
@@ -1176,7 +1176,7 @@ mod tests {
     #[test]
     fn errored_partial_and_ignore() {
         let td = tmpdir();
-        wfile(td.path().join(".gitignore"), "{foo\nbar");
+        wfile(td.path().join(".gitignore"), "[z-a]\nbar");
         wfile(td.path().join(".ignore"), "!bar");
 
         let (ig, err) = IgnoreBuilder::new().build().add_child(td.path());

--- a/crates/ignore/src/gitignore.rs
+++ b/crates/ignore/src/gitignore.rs
@@ -517,6 +517,7 @@ impl GitignoreBuilder {
             .case_insensitive(self.case_insensitive)
             .backslash_escape(true)
             .allow_unclosed_class(self.allow_unclosed_class)
+            .literal_braces(true)
             .build()
             .map_err(|err| Error::Glob {
                 glob: Some(glob.original.clone()),
@@ -751,6 +752,8 @@ mod tests {
     ignored!(ig42, ROOT, "s*.rs", "sfoo.rs");
     ignored!(ig43, ROOT, "**", "foo.rs");
     ignored!(ig44, ROOT, "**/**/*", "a/foo.rs");
+    ignored!(ig45, ROOT, "*.txt{}", "foo.txt{}");
+    ignored!(ig46, ROOT, "{{a}}", "{{a}}");
 
     not_ignored!(ignot1, ROOT, "amonths", "months");
     not_ignored!(ignot2, ROOT, "monthsa", "months");
@@ -776,6 +779,8 @@ mod tests {
     not_ignored!(ignot17, ROOT, "src/*.rs", "src/grep/src/main.rs");
     not_ignored!(ignot18, ROOT, "path1/*", "path2/path1/foo");
     not_ignored!(ignot19, ROOT, "s*.rs", "src/foo.rs");
+    not_ignored!(ignot20, ROOT, "*.txt{}", "foo.txt");
+    not_ignored!(ignot21, ROOT, "{{a}}", "a");
 
     fn bytes(s: &str) -> Vec<u8> {
         s.to_string().into_bytes()


### PR DESCRIPTION
Fixes #1221

## Summary

Align gitignore parsing with Git semantics by treating braces as literal characters in ignore patterns while preserving existing globset alternation behavior for non-ignore callers.

## Problem

The issue reports that ripgrep/globset currently interprets braces in ignore patterns as alternation, but Git treats braces literally. This creates mismatches where ignore rules in .gitignore/.ignore behave differently from Git and can include/exclude files unexpectedly.

## What changed

- Added a literal-braces option to globset parsing and covered it with dedicated tests.
- Enabled literal-braces mode in ignore/gitignore builder so ignore files follow Git-compatible brace semantics.
- Updated ignore error-path tests and added regression cases for brace literals in ignore patterns.

## Solution

Enable literal brace parsing specifically in the ignore/gitignore path, keep default alternation behavior in globset for other callers, and add coverage in globset and ignore tests to verify both positive and negative brace cases.

## Why

This keeps the fix minimal and root-cause focused: we change semantics only where Git-compatibility is required, avoid broad parser behavior regressions, and back the change with targeted + broad Rust tests that passed in CI-like local validation.

## Tests

- `cargo test -p globset --lib`
- `cargo test -p ignore --lib`
- `cargo test --workspace --lib`
