### PR TITLE
ci: add loongarch64 to release build matrixLoongarch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,12 @@ jobs:
           os: ubuntu-latest
           rust: stable
           target: riscv64gc-unknown-linux-gnu
+        - build: stable-loongarch64
+          os: ubuntu-latest
+          rust: stable
+          target: loongarch64-unknown-linux-gnu
+          strip: loongarch64-linux-gnu-strip
+          qemu: qemu-loongarch64
         - build: macos
           os: macos-latest
           rust: nightly
@@ -131,12 +137,16 @@ jobs:
         # In the past, new releases of 'cross' have broken CI. So for now, we
         # pin it. We also use their pre-compiled binary releases because cross
         # has over 100 dependencies and takes a bit to compile.
-        dir="$RUNNER_TEMP/cross-download"
-        mkdir "$dir"
-        echo "$dir" >> $GITHUB_PATH
-        cd "$dir"
-        curl -LO "https://github.com/cross-rs/cross/releases/download/$CROSS_VERSION/cross-x86_64-unknown-linux-musl.tar.gz"
-        tar xf cross-x86_64-unknown-linux-musl.tar.gz
+        if [[ "${{ matrix.target }}" == loongarch64* ]]; then
+          cargo install --git https://github.com/cross-rs/cross --rev 4090beca3cfffa44371a5bba524de3a578aa46c3 cross
+        else
+          dir="$RUNNER_TEMP/cross-download"
+          mkdir "$dir"
+          echo "$dir" >> $GITHUB_PATH
+          cd "$dir"
+          curl -LO "https://github.com/cross-rs/cross/releases/download/$CROSS_VERSION/cross-x86_64-unknown-linux-musl.tar.gz"
+          tar xf cross-x86_64-unknown-linux-musl.tar.gz
+        fi
         echo "CARGO=cross" >> $GITHUB_ENV
         echo "TARGET_FLAGS=--target ${{ matrix.target }}" >> $GITHUB_ENV
         echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           os: ubuntu-latest
           rust: stable
           target: loongarch64-unknown-linux-gnu
-          strip: loongarch64-linux-gnu-strip
+          strip: loongarch64-unknown-linux-gnu-strip
           qemu: qemu-loongarch64
         - build: macos
           os: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           os: ubuntu-latest
           rust: stable
           target: loongarch64-unknown-linux-gnu
-          strip: loongarch64-linux-gnu-strip
+          strip: loongarch64-unknown-linux-gnu-strip
           qemu: qemu-loongarch64
         - build: macos
           os: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,12 @@ jobs:
           target: s390x-unknown-linux-gnu
           strip: s390x-linux-gnu-strip
           qemu: qemu-s390x
+        - build: stable-loongarch64
+          os: ubuntu-latest
+          rust: stable
+          target: loongarch64-unknown-linux-gnu
+          strip: loongarch64-linux-gnu-strip
+          qemu: qemu-loongarch64
         - build: macos
           os: macos-latest
           rust: nightly
@@ -152,12 +158,16 @@ jobs:
         # In the past, new releases of 'cross' have broken CI. So for now, we
         # pin it. We also use their pre-compiled binary releases because cross
         # has over 100 dependencies and takes a bit to compile.
-        dir="$RUNNER_TEMP/cross-download"
-        mkdir "$dir"
-        echo "$dir" >> $GITHUB_PATH
-        cd "$dir"
-        curl -LO "https://github.com/cross-rs/cross/releases/download/$CROSS_VERSION/cross-x86_64-unknown-linux-musl.tar.gz"
-        tar xf cross-x86_64-unknown-linux-musl.tar.gz
+        if [[ "${{ matrix.target }}" == loongarch64* ]]; then
+          cargo install --git https://github.com/cross-rs/cross --rev 4090beca3cfffa44371a5bba524de3a578aa46c3 cross
+        else
+          dir="$RUNNER_TEMP/cross-download"
+          mkdir "$dir"
+          echo "$dir" >> $GITHUB_PATH
+          cd "$dir"
+          curl -LO "https://github.com/cross-rs/cross/releases/download/$CROSS_VERSION/cross-x86_64-unknown-linux-musl.tar.gz"
+          tar xf cross-x86_64-unknown-linux-musl.tar.gz
+        fi
         echo "CARGO=cross" >> $GITHUB_ENV
 
     - name: Set target variables


### PR DESCRIPTION
Special case: LoongArch requires a newer version of cross than v0.2.5.
We install it from git for LoongArch targets.  Commit 4090beca3cfffa44371a5bba524de3a578aa46c3 is from November 2024, ~600 commits after v0.2.5, and includes LoongArch support.