### PR TITLE
fix(#2820): --files now correctly handles implicit pattern argument

### DIFF
--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -1077,6 +1077,25 @@ impl Paths {
         // patterns have already been read from LowArgs. This let's us safely
         // assume that all remaining positional arguments are intended to be
         // file paths.
+        //
+        // However, in non-search modes (like --files), when there are multiple
+        // positional arguments and no patterns were provided via -e/-f, the
+        // first positional would have been treated as a pattern in search mode.
+        // To maintain consistency with what files would actually be searched,
+        // we skip the first positional argument in this case. This ensures that
+        // --files lists the files that would actually be searched.
+        //
+        // We only apply this when there are multiple positionals because:
+        // - Single positional (like `--files .`) is likely an intentional path
+        // - Multiple positionals (like `--files . node_modules`) suggests pattern+path
+        //
+        // See: https://github.com/BurntSushi/ripgrep/issues/2820
+        if !matches!(low.mode, Mode::Search(_))
+            && low.patterns.is_empty()
+            && low.positional.len() >= 2
+        {
+            low.positional.remove(0);
+        }
 
         let mut paths = Vec::with_capacity(low.positional.len());
         for osarg in low.positional.drain(..) {


### PR DESCRIPTION
When using --files with positional arguments, the first positional was incorrectly treated as a path when it would have been a pattern in search mode. This caused --files to list files outside the intended search path.

The fix: When --files (or other non-search modes) has multiple positional arguments and no explicit patterns via -e/-f, skip the first positional as it would be the pattern in search mode.

Example:
```bash
rg "." node_modules --files
```

Before: Listed files from "." (current dir) and node_modules
After: Only lists files from node_modules (the intended search path)

This ensures --files lists files that would actually be searched.

Fixes #2820