### PR TITLE
Teach --search-zip to detect compressed files without extensions

### DIFF
--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -1,7 +1,7 @@
 use std::{
     ffi::{OsStr, OsString},
     fs::File,
-    io,
+    io::{self, Read},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -25,6 +25,9 @@ pub struct DecompressionMatcherBuilder {
 struct DecompressionCommand {
     /// The glob that matches this command.
     glob: String,
+    /// An optional magic header that can be used to detect compressed files
+    /// independent of their file path.
+    magic: Option<&'static [u8]>,
     /// The command or binary name.
     bin: PathBuf,
     /// The arguments to invoke with the command.
@@ -137,7 +140,12 @@ impl DecompressionMatcherBuilder {
         let bin = try_resolve_binary(Path::new(program.as_ref()))?;
         let args =
             args.into_iter().map(|a| a.as_ref().to_os_string()).collect();
-        self.commands.push(DecompressionCommand { glob, bin, args });
+        self.commands.push(DecompressionCommand {
+            glob,
+            magic: None,
+            bin,
+            args,
+        });
         Ok(self)
     }
 }
@@ -177,19 +185,36 @@ impl DecompressionMatcher {
     /// If there are multiple possible commands matching the given path, then
     /// the command added last takes precedence.
     pub fn command<P: AsRef<Path>>(&self, path: P) -> Option<Command> {
-        if let Some(i) = self.globs.matches(path).into_iter().next_back() {
-            let decomp_cmd = &self.commands[i];
-            let mut cmd = Command::new(&decomp_cmd.bin);
-            cmd.args(&decomp_cmd.args);
-            return Some(cmd);
-        }
-        None
+        let path = path.as_ref();
+        let i = self
+            .globs
+            .matches(path)
+            .into_iter()
+            .next_back()
+            .or_else(|| self.command_index_by_magic(path))?;
+        let decomp_cmd = &self.commands[i];
+        let mut cmd = Command::new(&decomp_cmd.bin);
+        cmd.args(&decomp_cmd.args);
+        Some(cmd)
     }
 
     /// Returns true if and only if the given file path has at least one
     /// matching command to perform decompression on.
     pub fn has_command<P: AsRef<Path>>(&self, path: P) -> bool {
-        self.globs.is_match(path)
+        let path = path.as_ref();
+        self.globs.is_match(path) || self.command_index_by_magic(path).is_some()
+    }
+
+    fn command_index_by_magic(&self, path: &Path) -> Option<usize> {
+        let mut file = File::open(path).ok()?;
+        let mut buf = [0; 16];
+        let len = file.read(&mut buf).ok()?;
+        self.commands.iter().enumerate().find_map(|(i, cmd)| {
+            let magic = cmd.magic?;
+            buf.get(..len)
+                .filter(|bytes| bytes.starts_with(magic))
+                .map(|_| i)
+        })
     }
 }
 
@@ -497,7 +522,12 @@ fn default_decompression_commands() -> Vec<DecompressionCommand> {
     const ARGS_ZSTD: &[&str] = &["zstd", "-q", "-d", "-c"];
     const ARGS_UNCOMPRESS: &[&str] = &["uncompress", "-c"];
 
-    fn add(glob: &str, args: &[&str], cmds: &mut Vec<DecompressionCommand>) {
+    fn add(
+        glob: &str,
+        magic: Option<&'static [u8]>,
+        args: &[&str],
+        cmds: &mut Vec<DecompressionCommand>,
+    ) {
         let bin = match resolve_binary(Path::new(args[0])) {
             Ok(bin) => bin,
             Err(err) => {
@@ -507,6 +537,7 @@ fn default_decompression_commands() -> Vec<DecompressionCommand> {
         };
         cmds.push(DecompressionCommand {
             glob: glob.to_string(),
+            magic,
             bin,
             args: args
                 .iter()
@@ -516,17 +547,17 @@ fn default_decompression_commands() -> Vec<DecompressionCommand> {
         });
     }
     let mut cmds = vec![];
-    add("*.gz", ARGS_GZIP, &mut cmds);
-    add("*.tgz", ARGS_GZIP, &mut cmds);
-    add("*.bz2", ARGS_BZIP, &mut cmds);
-    add("*.tbz2", ARGS_BZIP, &mut cmds);
-    add("*.xz", ARGS_XZ, &mut cmds);
-    add("*.txz", ARGS_XZ, &mut cmds);
-    add("*.lz4", ARGS_LZ4, &mut cmds);
-    add("*.lzma", ARGS_LZMA, &mut cmds);
-    add("*.br", ARGS_BROTLI, &mut cmds);
-    add("*.zst", ARGS_ZSTD, &mut cmds);
-    add("*.zstd", ARGS_ZSTD, &mut cmds);
-    add("*.Z", ARGS_UNCOMPRESS, &mut cmds);
+    add("*.gz", Some(b"\x1F\x8B"), ARGS_GZIP, &mut cmds);
+    add("*.tgz", Some(b"\x1F\x8B"), ARGS_GZIP, &mut cmds);
+    add("*.bz2", Some(b"BZh"), ARGS_BZIP, &mut cmds);
+    add("*.tbz2", Some(b"BZh"), ARGS_BZIP, &mut cmds);
+    add("*.xz", Some(b"\xFD7zXZ\x00"), ARGS_XZ, &mut cmds);
+    add("*.txz", Some(b"\xFD7zXZ\x00"), ARGS_XZ, &mut cmds);
+    add("*.lz4", Some(b"\x04\x22\x4D\x18"), ARGS_LZ4, &mut cmds);
+    add("*.lzma", None, ARGS_LZMA, &mut cmds);
+    add("*.br", None, ARGS_BROTLI, &mut cmds);
+    add("*.zst", Some(b"\x28\xB5\x2F\xFD"), ARGS_ZSTD, &mut cmds);
+    add("*.zstd", Some(b"\x28\xB5\x2F\xFD"), ARGS_ZSTD, &mut cmds);
+    add("*.Z", Some(b"\x1F\x9D"), ARGS_UNCOMPRESS, &mut cmds);
     cmds
 }

--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -202,7 +202,8 @@ impl DecompressionMatcher {
     /// matching command to perform decompression on.
     pub fn has_command<P: AsRef<Path>>(&self, path: P) -> bool {
         let path = path.as_ref();
-        self.globs.is_match(path) || self.command_index_by_magic(path).is_some()
+        self.globs.is_match(path)
+            || self.command_index_by_magic(path).is_some()
     }
 
     fn command_index_by_magic(&self, path: &Path) -> Option<usize> {
@@ -211,9 +212,7 @@ impl DecompressionMatcher {
         let len = file.read(&mut buf).ok()?;
         self.commands.iter().enumerate().find_map(|(i, cmd)| {
             let magic = cmd.magic?;
-            buf.get(..len)
-                .filter(|bytes| bytes.starts_with(magic))
-                .map(|_| i)
+            buf.get(..len).filter(|bytes| bytes.starts_with(magic)).map(|_| i)
         })
     }
 }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1008,6 +1008,21 @@ rgtest!(compressed_failing_gzip, |dir: Dir, mut cmd: TestCommand| {
     cmd.assert_non_empty_stderr();
 });
 
+rgtest!(compressed_gzip_without_extension, |dir: Dir, mut cmd: TestCommand| {
+    if !cmd_exists("gzip") {
+        return;
+    }
+
+    dir.create_bytes("sherlock", include_bytes!("./data/sherlock.gz"));
+    cmd.arg("-z").arg("Sherlock").arg("sherlock");
+
+    let expected = "\
+For the Doctor Watsons of this world, as opposed to the Sherlock
+be, to a very large extent, the result of luck. Sherlock Holmes
+";
+    eqnice!(expected, cmd.stdout());
+});
+
 rgtest!(binary_convert, |dir: Dir, mut cmd: TestCommand| {
     dir.create("file", "foo\x00bar\nfoo\x00baz\n");
     cmd.arg("--no-mmap").arg("foo").arg("file");

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1008,20 +1008,23 @@ rgtest!(compressed_failing_gzip, |dir: Dir, mut cmd: TestCommand| {
     cmd.assert_non_empty_stderr();
 });
 
-rgtest!(compressed_gzip_without_extension, |dir: Dir, mut cmd: TestCommand| {
-    if !cmd_exists("gzip") {
-        return;
-    }
+rgtest!(
+    compressed_gzip_without_extension,
+    |dir: Dir, mut cmd: TestCommand| {
+        if !cmd_exists("gzip") {
+            return;
+        }
 
-    dir.create_bytes("sherlock", include_bytes!("./data/sherlock.gz"));
-    cmd.arg("-z").arg("Sherlock").arg("sherlock");
+        dir.create_bytes("sherlock", include_bytes!("./data/sherlock.gz"));
+        cmd.arg("-z").arg("Sherlock").arg("sherlock");
 
-    let expected = "\
+        let expected = "\
 For the Doctor Watsons of this world, as opposed to the Sherlock
 be, to a very large extent, the result of luck. Sherlock Holmes
 ";
-    eqnice!(expected, cmd.stdout());
-});
+        eqnice!(expected, cmd.stdout());
+    }
+);
 
 rgtest!(binary_convert, |dir: Dir, mut cmd: TestCommand| {
     dir.create("file", "foo\x00bar\nfoo\x00baz\n");


### PR DESCRIPTION
Fixes #3342

## Summary

Teach `--search-zip` to detect compressed files by file magic when no extension match exists.

## Problem

`--search-zip` currently routes files to decompression commands based on extension globs like `*.gz` and `*.xz`. Compressed files without those extensions are skipped even when their contents clearly identify the format.

## What changed

- Extend the decompression matcher to carry optional magic headers for built-in compression formats.
- Fall back to magic-based detection when no extension glob matches the path.
- Add a regression test that verifies gzip content is searched correctly even without a `.gz` extension.

## Solution

Keep extension-based matching as the first path, but allow built-in decompression commands to recognize known formats from file headers. That preserves existing behavior for explicit associations while fixing extensionless compressed files.

## Why

This fixes the exact gap described in the issue without changing the command-selection surface for custom user associations. `--search-zip` now behaves according to the file contents instead of requiring a specific suffix.

## Tests

- `cargo test --test integration compressed_gzip -- --nocapture`
- `cargo check`
