### PR TITLE
fix: perf(ignore): don't search subdirs for git/ignore files if max depth is reached (#2565)

### DIFF
--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -1673,16 +1673,16 @@ impl<'s> Worker<'s> {
             true
         };
 
-        // Try to read the directory first before we transfer ownership
-        // to the provided closure. Do not unwrap it immediately, though,
-        // as we may receive an `Err` value e.g. in the case when we do not
-        // have sufficient read permissions to list the directory.
-        // In that case we still want to provide the closure with a valid
-        // entry before passing the error value.
-        let readdir = work.read_dir();
         let depth = work.dent.depth();
+        if self.max_depth.map_or(false, |max| depth >= max) {
+            return if should_visit {
+                self.visitor.visit(Ok(work.dent.clone()))
+            } else {
+                WalkState::Skip
+            };
+        }
         if should_visit {
-            let state = self.visitor.visit(Ok(work.dent));
+            let state = self.visitor.visit(Ok(work.dent.clone()));
             if !state.is_continue() {
                 return state;
             }
@@ -1691,6 +1691,14 @@ impl<'s> Worker<'s> {
             return WalkState::Skip;
         }
 
+        // Try to read the directory first before we transfer ownership
+        // to the provided closure. Do not unwrap it immediately, though,
+        // as we may receive an `Err` value e.g. in the case when we do not
+        // have sufficient read permissions to list the directory.
+        // In that case we still want to provide the closure with a valid
+        // entry before passing the error value.
+        let readdir = work.read_dir();
+
         let readdir = match readdir {
             Ok(readdir) => readdir,
             Err(err) => {
@@ -1698,9 +1706,6 @@ impl<'s> Worker<'s> {
             }
         };
 
-        if self.max_depth.map_or(false, |max| depth >= max) {
-            return WalkState::Skip;
-        }
         for result in readdir {
             let state = self.generate_work(
                 &work.ignore,


### PR DESCRIPTION
Fixes #2565

## Summary

Addresses #2565 in BurntSushi/ripgrep with a minimal, targeted change.

## Problem

When searching for git/ignore files (the one set with `.ignore` `.git_ignore` `.git_exclude`), the crate should not search the sub-directories if its at the max depth

## What changed

- crates/ignore/src/walk.rs

## Solution

Apply focused code changes in `crates/ignore/src/walk.rs` to remove the reported behavior from #2565.

## Why

Before: users hit the behavior described in #2565. After: behavior should follow issue expectations while keeping changes minimal and auditable.

## Tests

- `cargo check --workspace`
- `cargo test -p grep-printer --lib -- --nocapture`

## Scope

- Changed files (1): `crates/ignore/src/walk.rs`
- Root-cause gate verdict: `confirmed`
- Replay stability: `not_run`

## Validation

- Local validation gate verdict: `confirmed` (risk: `low`).
- Passed check in 1.1s: `cargo check --workspace`
- Passed check in 1.8s: `cargo test -p grep-printer --lib -- --nocapture`

## Limitations

Deterministic multi-replay was not executed in this run (`replay_stability_status=not_run`).
