### PR TITLE
Add support for `Rocq` .v files

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -232,6 +232,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["red"], &["*.r", "*.red", "*.reds"]),
     (&["rescript"], &["*.res", "*.resi"]),
     (&["robot"], &["*.robot"]),
+    (&["rocq"], &["*.v"]),
     (&["rst"], &["*.rst"]),
     (&["ruby"], &[
         // Idiomatic files


### PR DESCRIPTION
The Coq theorem prover has been renamed to Rocq [[1]](https://rocq-prover.org/about#Name), this adds the file type for Rocq files, while maintaining legacy support for Coq as well.