### PR TITLE
ignore: add --type-case-insensitive flag for case-insensitive type matching

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -421,6 +421,26 @@ alias rg="rg --type-add 'web:*.{html,css,js}'"
 or add `--type-add=web:*.{html,css,js}` to your ripgrep configuration file.
 ([Configuration files](#configuration-file) are covered in more detail later.)
 
+#### Case insensitive type matching
+
+By default, file type matching is case sensitive. This means that `-t html`
+will match `index.html` but not `index.HTML` or `index.HTM`. On
+case-insensitive filesystems (like those on Windows and macOS), you may have
+files with uppercase extensions. You can make type matching case insensitive
+with the `--type-case-insensitive` flag:
+
+```
+$ rg 'title' --type-case-insensitive -t html
+```
+
+This will match files with extensions like `.html`, `.HTML`, `.htm` and
+`.HTM`. If you always want case insensitive type matching, you can add it to
+your [configuration file](#configuration-file):
+
+```
+--type-case-insensitive
+```
+
 #### The special `all` file type
 
 A special option supported by the `--type` flag is `all`. `--type all` looks

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -138,6 +138,7 @@ pub(super) const FLAGS: &[&dyn Flag] = &[
     &TypeNot,
     &TypeAdd,
     &TypeClear,
+    &TypeCaseInsensitive,
     &TypeList,
     &Unrestricted,
     &Version,
@@ -7080,6 +7081,65 @@ fn test_type_clear() {
         ],
         args.type_changes
     );
+}
+
+/// --type-case-insensitive
+#[derive(Debug)]
+struct TypeCaseInsensitive;
+
+impl Flag for TypeCaseInsensitive {
+    fn is_switch(&self) -> bool {
+        true
+    }
+    fn name_long(&self) -> &'static str {
+        "type-case-insensitive"
+    }
+    fn name_negated(&self) -> Option<&'static str> {
+        Some("no-type-case-insensitive")
+    }
+    fn doc_category(&self) -> Category {
+        Category::Filter
+    }
+    fn doc_short(&self) -> &'static str {
+        r"Search all \flag{type} patterns case insensitively."
+    }
+    fn doc_long(&self) -> &'static str {
+        r"
+Process all file type patterns given with the \flag{type} flag case
+insensitively. For example, \fBrg --type-case-insensitive -t html\fP will
+match files with extensions \fB.html\fP, \fB.HTML\fP, \fB.htm\fP and
+\fB.HTM\fP.
+"
+    }
+
+    fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
+        args.type_case_insensitive = v.unwrap_switch();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_type_case_insensitive() {
+    let args = parse_low_raw(None::<&str>).unwrap();
+    assert_eq!(false, args.type_case_insensitive);
+
+    let args = parse_low_raw(["--type-case-insensitive"]).unwrap();
+    assert_eq!(true, args.type_case_insensitive);
+
+    let args = parse_low_raw([
+        "--type-case-insensitive",
+        "--no-type-case-insensitive",
+    ])
+    .unwrap();
+    assert_eq!(false, args.type_case_insensitive);
+
+    let args = parse_low_raw([
+        "--no-type-case-insensitive",
+        "--type-case-insensitive",
+    ])
+    .unwrap();
+    assert_eq!(true, args.type_case_insensitive);
 }
 
 /// --type-not

--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -1186,6 +1186,9 @@ impl BinaryDetection {
 fn types(low: &LowArgs) -> anyhow::Result<ignore::types::Types> {
     let mut builder = ignore::types::TypesBuilder::new();
     builder.add_defaults();
+    if low.type_case_insensitive {
+        builder.case_insensitive(true);
+    }
     for tychange in low.type_changes.iter() {
         match *tychange {
             TypeChange::Clear { ref name } => {

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -104,6 +104,7 @@ pub(crate) struct LowArgs {
     pub(crate) threads: Option<usize>,
     pub(crate) trim: bool,
     pub(crate) type_changes: Vec<TypeChange>,
+    pub(crate) type_case_insensitive: bool,
     pub(crate) unrestricted: usize,
     pub(crate) vimgrep: bool,
     pub(crate) with_filename: Option<bool>,

--- a/crates/ignore/src/types.rs
+++ b/crates/ignore/src/types.rs
@@ -305,6 +305,7 @@ impl Types {
 pub struct TypesBuilder {
     types: HashMap<String, FileTypeDef>,
     selections: Vec<Selection<()>>,
+    case_insensitive: bool,
 }
 
 impl TypesBuilder {
@@ -314,7 +315,20 @@ impl TypesBuilder {
     /// of default type definitions can be added with `add_defaults`, and
     /// additional type definitions can be added with `select` and `negate`.
     pub fn new() -> TypesBuilder {
-        TypesBuilder { types: HashMap::new(), selections: vec![] }
+        TypesBuilder {
+            types: HashMap::new(),
+            selections: vec![],
+            case_insensitive: false,
+        }
+    }
+
+    /// Enable or disable case insensitive matching for all file type globs.
+    ///
+    /// When enabled, a type like `html` will match files with extensions
+    /// `.html`, `.HTML`, `.htm`, `.HTM`, etc.
+    pub fn case_insensitive(&mut self, yes: bool) -> &mut TypesBuilder {
+        self.case_insensitive = yes;
+        self
     }
 
     /// Build the current set of file type definitions *and* selections into
@@ -338,6 +352,7 @@ impl TypesBuilder {
                 build_set.add(
                     GlobBuilder::new(glob)
                         .literal_separator(true)
+                        .case_insensitive(self.case_insensitive)
                         .build()
                         .map_err(|err| Error::Glob {
                             glob: Some(glob.to_string()),


### PR DESCRIPTION
## Approach
This is implemented as an **opt-in flag** rather than changing the default,
to avoid breaking changes on Linux where `.html` and `.HTML` are genuinely
different files with case-sensitive semantics.
The implementation mirrors the existing `--glob-case-insensitive` flag:
- Added `case_insensitive: bool` field and setter method to [TypesBuilder](cci:2://file:///home/souradip/Code/ripgrep/crates/ignore/src/types.rs:304:0-308:1)
  in the [ignore](cci:7://file:///home/souradip/Code/ripgrep/.ignore:0:0-0:0) crate. The flag is passed to each `GlobBuilder` during
  [build()](cci:1://file:///home/souradip/Code/ripgrep/crates/globset/src/lib.rs:577:4-582:5).
- Added `type_case_insensitive: bool` to [LowArgs](cci:2://file:///home/souradip/Code/ripgrep/crates/core/flags/lowargs.rs:32:0-110:1).
- Added [TypeCaseInsensitive](cci:2://file:///home/souradip/Code/ripgrep/crates/core/flags/defs.rs:7087:0-7087:27) flag struct to [defs.rs](cci:7://file:///home/souradip/Code/ripgrep/crates/core/flags/defs.rs:0:0-0:0).
- Wired the flag into the [types()](cci:1://file:///home/souradip/Code/ripgrep/crates/core/flags/hiargs.rs:1184:0-1208:1) builder function in [hiargs.rs](cci:7://file:///home/souradip/Code/ripgrep/crates/core/flags/hiargs.rs:0:0-0:0).
- Added documentation to [GUIDE.md](cci:7://file:///home/souradip/Code/ripgrep/GUIDE.md:0:0-0:0).
## Design question
I went with an opt-in flag for safety, but I can see a reasonable argument
for making this the default — since `--type` is a semantic abstraction over
file types, not a raw glob, it could be argued it should always be
case-insensitive. Happy to change the approach if that's preferred.
## Testing
- Added unit test [test_type_case_insensitive](cci:1://file:///home/souradip/Code/ripgrep/crates/core/flags/defs.rs:7120:0-7142:1) in [defs.rs](cci:7://file:///home/souradip/Code/ripgrep/crates/core/flags/defs.rs:0:0-0:0) for flag
  parsing (on/off/negation).
- All existing tests pass: `cargo test --all`.

Fixes https://github.com/BurntSushi/ripgrep/issues/3297