### PR TITLE
docs: fix typo in main comment

### DIFF
--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -427,7 +427,7 @@ fn eprint_nothing_searched() {
 /// The `started` time should be the time at which ripgrep started working.
 ///
 /// If an error occurs while writing, then writing stops and the error is
-/// returned. Note that callers should probably ignore this errror, since
+/// returned. Note that callers should probably ignore this error, since
 /// whether stats fail to print or not generally shouldn't cause ripgrep to
 /// enter into an "error" state. And usually the only way for this to fail is
 /// if writing to stdout itself fails.


### PR DESCRIPTION
## Summary
Fix a typo in a source comment by changing `errror` to `error` in `crates/core/main.rs`.

## Related issue
N/A

## Guideline alignment
Single-file comment-only change with no behavior change.

## Validation
Not run; comment-only change.
