### PR TITLE
json: split multiline matches into per line Match messages

### DIFF
--- a/crates/printer/src/json.rs
+++ b/crates/printer/src/json.rs
@@ -775,9 +775,7 @@ impl<'p, 's, M: Matcher, W: io::Write> Sink for JSONSink<'p, 's, M, W> {
                     let msg = jsont::Message::Match(jsont::Match {
                         path: self.path,
                         lines: line,
-                        line_number: mat
-                            .line_number()
-                            .map(|n| n + line_num),
+                        line_number: mat.line_number().map(|n| n + line_num),
                         absolute_offset: mat.absolute_byte_offset()
                             + line_start as u64,
                         submatches: submatches.as_slice(),

--- a/crates/printer/src/json.rs
+++ b/crates/printer/src/json.rs
@@ -733,22 +733,62 @@ impl<'p, 's, M: Matcher, W: io::Write> Sink for JSONSink<'p, 's, M, W> {
             mat.bytes_range_in_buffer(),
         )?;
         self.replace(searcher, mat.buffer(), mat.bytes_range_in_buffer())?;
-        self.stats.add_matches(self.json.matches.len() as u64);
-        self.stats.add_matched_lines(mat.lines().count() as u64);
 
-        let submatches = SubMatches::new(
-            mat.bytes(),
-            &self.json.matches,
-            self.replacer.replacement(),
-        );
-        let msg = jsont::Message::Match(jsont::Match {
-            path: self.path,
-            lines: mat.bytes(),
-            line_number: mat.line_number(),
-            absolute_offset: mat.absolute_byte_offset(),
-            submatches: submatches.as_slice(),
-        });
-        self.json.write_message(&msg)?;
+        let line_count = mat.lines().count();
+        self.stats.add_matches(self.json.matches.len() as u64);
+        self.stats.add_matched_lines(line_count as u64);
+
+        if line_count <= 1 {
+            let submatches = SubMatches::new(
+                mat.bytes(),
+                &self.json.matches,
+                self.replacer.replacement(),
+            );
+            let msg = jsont::Message::Match(jsont::Match {
+                path: self.path,
+                lines: mat.bytes(),
+                line_number: mat.line_number(),
+                absolute_offset: mat.absolute_byte_offset(),
+                submatches: submatches.as_slice(),
+            });
+            self.json.write_message(&msg)?;
+        } else {
+            let all_matches = self.json.matches.clone();
+            let mut line_offset: usize = 0;
+            let mut line_num: u64 = 0;
+            for line in mat.lines() {
+                let line_start = line_offset;
+                let line_end = line_offset + line.len();
+                let line_matches: Vec<Match> = all_matches
+                    .iter()
+                    .filter(|m| m.start() < line_end && m.end() > line_start)
+                    .map(|m| {
+                        let s = m.start().max(line_start) - line_start;
+                        let e = m.end().min(line_end) - line_start;
+                        Match::new(s, e)
+                    })
+                    .collect();
+
+                if !line_matches.is_empty() {
+                    let submatches =
+                        SubMatches::new(line, &line_matches, None);
+                    let msg = jsont::Message::Match(jsont::Match {
+                        path: self.path,
+                        lines: line,
+                        line_number: mat
+                            .line_number()
+                            .map(|n| n + line_num),
+                        absolute_offset: mat.absolute_byte_offset()
+                            + line_start as u64,
+                        submatches: submatches.as_slice(),
+                    });
+                    self.json.write_message(&msg)?;
+                }
+
+                line_offset = line_end;
+                line_num += 1;
+            }
+        }
         Ok(true)
     }
 

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -398,27 +398,39 @@ rgtest!(r1095_missing_crlf, |dir: Dir, mut cmd: TestCommand| {
 // See: https://github.com/BurntSushi/ripgrep/issues/1095
 //
 // This test checks that we don't return empty submatches when matching a `\n`
-// in CRLF mode.
+// in CRLF mode, and that multiline matches produce one message per line
 rgtest!(r1095_crlf_empty_match, |dir: Dir, mut cmd: TestCommand| {
     dir.create("foo", "test\r\n\n");
 
     // Check without --crlf flag.
+    // multiline match spans two lines so we expect two separate Match
+    // messages (one per line) rather than one message with two submatches
     let msgs = json_decode(&cmd.arg("-U").arg("--json").arg("\n").stdout());
-    assert_eq!(msgs.len(), 4);
+    assert_eq!(msgs.len(), 5);
 
     let m = msgs[1].unwrap_match();
-    assert_eq!(m.lines, Data::text("test\r\n\n"));
+    assert_eq!(m.lines, Data::text("test\r\n"));
+    assert_eq!(m.submatches.len(), 1);
     assert_eq!(m.submatches[0].m, Data::text("\n"));
-    assert_eq!(m.submatches[1].m, Data::text("\n"));
 
-    // Now check with --crlf flag.
+    let m = msgs[2].unwrap_match();
+    assert_eq!(m.lines, Data::text("\n"));
+    assert_eq!(m.submatches.len(), 1);
+    assert_eq!(m.submatches[0].m, Data::text("\n"));
+
+    // check with --crlf flag
     let msgs = json_decode(&cmd.arg("--crlf").stdout());
-    assert_eq!(msgs.len(), 4);
+    assert_eq!(msgs.len(), 5);
 
     let m = msgs[1].unwrap_match();
-    assert_eq!(m.lines, Data::text("test\r\n\n"));
+    assert_eq!(m.lines, Data::text("test\r\n"));
+    assert_eq!(m.submatches.len(), 1);
     assert_eq!(m.submatches[0].m, Data::text("\n"));
-    assert_eq!(m.submatches[1].m, Data::text("\n"));
+
+    let m = msgs[2].unwrap_match();
+    assert_eq!(m.lines, Data::text("\n"));
+    assert_eq!(m.submatches.len(), 1);
+    assert_eq!(m.submatches[0].m, Data::text("\n"));
 });
 
 // See: https://github.com/BurntSushi/ripgrep/issues/1412


### PR DESCRIPTION
## summary

the JSON printers `matched()` method in `crates/printer/src/json.rs` emitted a single `Match` message containing all submatches when a multiline search matched across multiple lines. The standard printer handled this correctly via `sink_slow_multi_line()`, but the JSON printer had no equivalent per-line splitting logic.

## changes 
`matched()` now splits multiline results into one `Match` message per line with correctly adjusted offsets and submatches. no change to single line matches

 ---
before: `rg --multiline --pcre2 --json 'foo'` on a file containing `foo\nfoo` produced one `Match` message with two submatches and both lines in `lines`.

after: two separate `Match` messages, each with one submatch and only the relevant line in `lines`.

Fixes #3364