### PR TITLE
cli: disambiguate filenames starting with '-' when invoking decompressors

### DIFF
--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -574,7 +574,10 @@ mod tests {
     #[test]
     fn disambiguate_leaves_normal_nested_paths_unchanged() {
         let p = PathBuf::from("dir/-10.gz");
-        assert_eq!(disambiguate_leading_dash(&p), OsString::from("dir/-10.gz"));
+        assert_eq!(
+            disambiguate_leading_dash(&p),
+            OsString::from("dir/-10.gz")
+        );
     }
 
     #[test]
@@ -589,12 +592,18 @@ mod tests {
         #[cfg(unix)]
         {
             let p = PathBuf::from("/tmp/-10.gz");
-            assert_eq!(disambiguate_leading_dash(&p), OsString::from("/tmp/-10.gz"));
+            assert_eq!(
+                disambiguate_leading_dash(&p),
+                OsString::from("/tmp/-10.gz")
+            );
         }
         #[cfg(windows)]
         {
             let p = PathBuf::from(r"C:\tmp\-10.gz");
-            assert_eq!(disambiguate_leading_dash(&p), OsString::from(r"C:\tmp\-10.gz"));
+            assert_eq!(
+                disambiguate_leading_dash(&p),
+                OsString::from(r"C:\tmp\-10.gz")
+            );
         }
     }
 }

--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -515,7 +515,6 @@ fn disambiguate_leading_dash(path: &Path) -> OsString {
     path.as_os_str().to_os_string()
 }
 
-
 fn default_decompression_commands() -> Vec<DecompressionCommand> {
     const ARGS_GZIP: &[&str] = &["gzip", "-d", "-c"];
     const ARGS_BZIP: &[&str] = &["bzip2", "-d", "-c"];

--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -226,7 +226,11 @@ impl DecompressionReaderBuilder {
         let Some(mut cmd) = self.matcher.command(path) else {
             return DecompressionReader::new_passthru(path);
         };
-        cmd.arg(path);
+        // If the path starts with `-`, decompression tools like gzip/bzip2
+        // will misinterpret it as an options bundle ("gzip: invalid option").
+        // Prepend `./` for relative paths so the path is unambiguously a
+        // filename. See https://github.com/BurntSushi/ripgrep/issues/3222.
+        cmd.arg(disambiguate_leading_dash(path));
 
         match self.command_builder.build(&mut cmd) {
             Ok(cmd_reader) => Ok(DecompressionReader { rdr: Ok(cmd_reader) }),
@@ -487,6 +491,31 @@ fn try_resolve_binary<P: AsRef<Path>>(
     return Err(CommandError::io(io::Error::new(io::ErrorKind::Other, msg)));
 }
 
+/// Ensures a path doesn't begin with a `-`, which would be mistaken for an
+/// options argument by most command-line decompression tools (gzip, bzip2,
+/// xz, etc.) and produce an "invalid option" error.
+///
+/// For relative paths that start with `-`, returns a new `OsString` with
+/// `./` prepended. For paths that don't start with `-`, or absolute paths,
+/// returns the original path unchanged.
+fn disambiguate_leading_dash(path: &Path) -> OsString {
+    // Absolute paths can never be misinterpreted as options.
+    if path.is_absolute() {
+        return path.as_os_str().to_os_string();
+    }
+    // On Unix, `-` in the first byte is the only ambiguity. On Windows,
+    // options are usually introduced with `/` but some tools also accept
+    // `-`-prefixed options, so we apply the fix uniformly.
+    let bytes = path.as_os_str().as_encoded_bytes();
+    if bytes.first() == Some(&b'-') {
+        let mut out = OsString::from("./");
+        out.push(path);
+        return out;
+    }
+    path.as_os_str().to_os_string()
+}
+
+
 fn default_decompression_commands() -> Vec<DecompressionCommand> {
     const ARGS_GZIP: &[&str] = &["gzip", "-d", "-c"];
     const ARGS_BZIP: &[&str] = &["bzip2", "-d", "-c"];
@@ -529,4 +558,43 @@ fn default_decompression_commands() -> Vec<DecompressionCommand> {
     add("*.zstd", ARGS_ZSTD, &mut cmds);
     add("*.Z", ARGS_UNCOMPRESS, &mut cmds);
     cmds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn disambiguate_leaves_normal_relative_paths_unchanged() {
+        let p = PathBuf::from("foo.gz");
+        assert_eq!(disambiguate_leading_dash(&p), OsString::from("foo.gz"));
+    }
+
+    #[test]
+    fn disambiguate_leaves_normal_nested_paths_unchanged() {
+        let p = PathBuf::from("dir/-10.gz");
+        assert_eq!(disambiguate_leading_dash(&p), OsString::from("dir/-10.gz"));
+    }
+
+    #[test]
+    fn disambiguate_prepends_dot_slash_for_leading_dash() {
+        let p = PathBuf::from("-10.gz");
+        assert_eq!(disambiguate_leading_dash(&p), OsString::from("./-10.gz"));
+    }
+
+    #[test]
+    fn disambiguate_leaves_absolute_paths_unchanged() {
+        // Absolute paths can never be mistaken for options.
+        #[cfg(unix)]
+        {
+            let p = PathBuf::from("/tmp/-10.gz");
+            assert_eq!(disambiguate_leading_dash(&p), OsString::from("/tmp/-10.gz"));
+        }
+        #[cfg(windows)]
+        {
+            let p = PathBuf::from(r"C:\tmp\-10.gz");
+            assert_eq!(disambiguate_leading_dash(&p), OsString::from(r"C:\tmp\-10.gz"));
+        }
+    }
 }


### PR DESCRIPTION
Fixes #3222.

## Problem

When ripgrep invokes an external decompression tool (gzip/bzip2/xz/zstd/lz4/unzstd) via `-z` to stream a compressed file, it passes the file path to the tool as-is via `cmd.arg(path)` in `crates/cli/src/decompress.rs`. For files whose relative path begins with `-` (e.g. `-10:29.log.gz`), the decompressor treats the path as an options bundle:

```
$ rg -z sometext
-------------------------------------------------------------------------------
gzip: invalid option -- '0'
Try `gzip --help' for more information.
-------------------------------------------------------------------------------
```

Reported with a reproducer in #3222: create `-10.txt`, gzip it, `rg -z sometext` fails.

## Fix

Prepend `./` to relative paths that start with `-` so the path is unambiguously a filename. Absolute paths are passed unchanged — they can't be mistaken for options.

```rust
// Before
cmd.arg(path);

// After
cmd.arg(disambiguate_leading_dash(path));
```

I chose `./` over the POSIX `--` end-of-options convention because (a) `disambiguate_leading_dash` works even for tools/ports that don't honor `--`, and (b) it keeps the existing single-arg call site unchanged; no two-arg rewrite of each `DecompressionCommand`.

## Tests

Added four unit tests in `crates/cli/src/decompress.rs`:

- `disambiguate_leaves_normal_relative_paths_unchanged` (`foo.gz`)
- `disambiguate_leaves_normal_nested_paths_unchanged` (`dir/-10.gz` — nested dash-starts not affected because only the leading byte matters)
- `disambiguate_prepends_dot_slash_for_leading_dash` (`-10.gz` → `./-10.gz`)
- `disambiguate_leaves_absolute_paths_unchanged` (cross-platform with `#[cfg(unix)]`/`#[cfg(windows)]`)

## Compatibility

Output of `rg` is unchanged for any path that doesn't start with `-`. For paths that do, the decompressor used to fail with "invalid option"; after this change it reads the file successfully.