### PR TITLE
Sanitize control bytes

### DIFF
--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -549,6 +549,7 @@ impl HiArgs {
         builder
             .color_specs(self.colors.clone())
             .hyperlink(self.hyperlink_config.clone())
+            .is_terminal(self.is_terminal_stdout)
             .separator(self.path_separator.clone())
             .terminator(self.path_terminator.unwrap_or(b'\n'));
         builder
@@ -616,6 +617,7 @@ impl HiArgs {
             .column(self.column)
             .heading(self.heading)
             .hyperlink(self.hyperlink_config.clone())
+            .is_terminal(self.is_terminal_stdout)
             .max_columns_preview(self.max_columns_preview)
             .max_columns(self.max_columns)
             .only_matching(self.only_matching)
@@ -656,6 +658,7 @@ impl HiArgs {
             .color_specs(self.colors.clone())
             .exclude_zero(!self.include_zero)
             .hyperlink(self.hyperlink_config.clone())
+            .is_terminal(self.is_terminal_stdout)
             .kind(kind)
             .path(self.with_filename)
             .path_terminator(self.path_terminator.clone())

--- a/crates/core/messages.rs
+++ b/crates/core/messages.rs
@@ -24,6 +24,20 @@ static IGNORE_MESSAGES: AtomicBool = AtomicBool::new(false);
 /// Flipped to true when an error message is printed.
 static ERRORED: AtomicBool = AtomicBool::new(false);
 
+// escape control bytes if stderr is a tty
+// filenames in errors cannot drive the terminal
+pub fn write_stderr<W: std::io::Write>(
+    w: &mut W,
+    buf: &[u8],
+) -> std::io::Result<()> {
+    use std::io::IsTerminal;
+    if std::io::stderr().is_terminal() {
+        w.write_all(&grep::printer::sanitize_control(buf))
+    } else {
+        w.write_all(buf)
+    }
+}
+
 /// Like eprintln, but locks stdout to prevent interleaving lines.
 ///
 /// This locks stdout, not stderr, even though this prints to stderr. This
@@ -47,14 +61,12 @@ macro_rules! eprintln_locked {
             // an error code because there isn't much else we can do.
             //
             // See: https://github.com/BurntSushi/ripgrep/issues/1966
-            if let Err(err) = write!(stderr, "rg: ") {
-                if err.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                } else {
-                    std::process::exit(2);
-                }
-            }
-            if let Err(err) = writeln!(stderr, $($tt)*) {
+            // format into a buffer then escape before writing
+            let mut buf: Vec<u8> = Vec::with_capacity(128);
+            let _ = write!(&mut buf, "rg: ");
+            let _ = write!(&mut buf, $($tt)*);
+            buf.push(b'\n');
+            if let Err(err) = $crate::messages::write_stderr(&mut stderr, &buf) {
                 if err.kind() == std::io::ErrorKind::BrokenPipe {
                     std::process::exit(0);
                 } else {

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -70,6 +70,7 @@ pub use crate::{
     standard::{Standard, StandardBuilder, StandardSink},
     stats::Stats,
     summary::{Summary, SummaryBuilder, SummaryKind, SummarySink},
+    util::sanitize_control,
 };
 
 #[cfg(feature = "serde")]

--- a/crates/printer/src/path.rs
+++ b/crates/printer/src/path.rs
@@ -155,7 +155,8 @@ impl<W: WriteColor> PathPrinter<W> {
         } else {
             let status = self.start_hyperlink(&ppath)?;
             self.wtr.set_color(self.config.colors.path())?;
-            self.wtr.write_all(ppath.as_bytes())?;
+            self.wtr
+                .write_all(&crate::util::sanitize_control(ppath.as_bytes()))?;
             self.wtr.reset()?;
             self.interpolator.finish(status, &mut self.wtr)?;
         }

--- a/crates/printer/src/path.rs
+++ b/crates/printer/src/path.rs
@@ -15,6 +15,8 @@ struct Config {
     hyperlink: HyperlinkConfig,
     separator: Option<u8>,
     terminator: u8,
+    /// True if output is going to an interactive terminal.
+    is_terminal: bool,
 }
 
 impl Default for Config {
@@ -24,6 +26,7 @@ impl Default for Config {
             hyperlink: HyperlinkConfig::default(),
             separator: None,
             terminator: b'\n',
+            is_terminal: false,
         }
     }
 }
@@ -120,6 +123,13 @@ impl PathPrinterBuilder {
         self.config.terminator = terminator;
         self
     }
+
+    /// Configure for output to an interactive terminal. When `true`,
+    /// printed paths are escaped to defang terminal control sequences.
+    pub fn is_terminal(&mut self, yes: bool) -> &mut PathPrinterBuilder {
+        self.config.is_terminal = yes;
+        self
+    }
 }
 
 /// A printer file paths, with optional color and hyperlink support.
@@ -150,13 +160,18 @@ impl<W: WriteColor> PathPrinter<W> {
     pub fn write(&mut self, path: &Path) -> io::Result<()> {
         let ppath = PrinterPath::new(path.as_ref())
             .with_separator(self.config.separator);
+        // Sanitize for tty; pipe output stays byte-exact.
+        let bytes_cow = if self.config.is_terminal {
+            crate::util::sanitize_control(ppath.as_bytes())
+        } else {
+            std::borrow::Cow::Borrowed(ppath.as_bytes())
+        };
         if !self.wtr.supports_color() {
-            self.wtr.write_all(ppath.as_bytes())?;
+            self.wtr.write_all(&bytes_cow)?;
         } else {
             let status = self.start_hyperlink(&ppath)?;
             self.wtr.set_color(self.config.colors.path())?;
-            self.wtr
-                .write_all(&crate::util::sanitize_control(ppath.as_bytes()))?;
+            self.wtr.write_all(&bytes_cow)?;
             self.wtr.reset()?;
             self.interpolator.finish(status, &mut self.wtr)?;
         }

--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -1433,7 +1433,11 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
     fn write_spec(&self, spec: &ColorSpec, buf: &[u8]) -> io::Result<()> {
         let mut wtr = self.wtr().borrow_mut();
         wtr.set_color(spec)?;
-        wtr.write_all(buf)?;
+        if wtr.supports_color() {
+            wtr.write_all(&crate::util::sanitize_control(buf))?;
+        } else {
+            wtr.write_all(buf)?;
+        }
         wtr.reset()?;
         Ok(())
     }
@@ -1441,7 +1445,11 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
     fn write_path(&self, path: &PrinterPath) -> io::Result<()> {
         let mut wtr = self.wtr().borrow_mut();
         wtr.set_color(self.config().colors.path())?;
-        wtr.write_all(path.as_bytes())?;
+        if wtr.supports_color() {
+            wtr.write_all(&crate::util::sanitize_control(path.as_bytes()))?;
+        } else {
+            wtr.write_all(path.as_bytes())?;
+        }
         wtr.reset()
     }
 
@@ -1517,7 +1525,12 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
     }
 
     fn write(&self, buf: &[u8]) -> io::Result<()> {
-        self.wtr().borrow_mut().write_all(buf)
+        let mut wtr = self.wtr().borrow_mut();
+        if wtr.supports_color() {
+            wtr.write_all(&crate::util::sanitize_control(buf))
+        } else {
+            wtr.write_all(buf)
+        }
     }
 
     fn trim_line_terminator(&self, buf: &[u8], line: &mut Match) {

--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -54,6 +54,8 @@ struct Config {
     separator_field_context: Arc<Vec<u8>>,
     separator_path: Option<u8>,
     path_terminator: Option<u8>,
+    /// True if output is going to an interactive terminal.
+    is_terminal: bool,
 }
 
 impl Default for Config {
@@ -79,6 +81,7 @@ impl Default for Config {
             separator_field_context: Arc::new(b"-".to_vec()),
             separator_path: None,
             path_terminator: None,
+            is_terminal: false,
         }
     }
 }
@@ -182,6 +185,14 @@ impl StandardBuilder {
         config: HyperlinkConfig,
     ) -> &mut StandardBuilder {
         self.config.hyperlink = config;
+        self
+    }
+
+    /// Configure for output to an interactive terminal. When `true`,
+    /// matched lines and printed paths are escaped to defang terminal
+    /// control sequences from filenames or file contents. Default `false`.
+    pub fn is_terminal(&mut self, yes: bool) -> &mut StandardBuilder {
+        self.config.is_terminal = yes;
         self
     }
 
@@ -1433,7 +1444,7 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
     fn write_spec(&self, spec: &ColorSpec, buf: &[u8]) -> io::Result<()> {
         let mut wtr = self.wtr().borrow_mut();
         wtr.set_color(spec)?;
-        if wtr.supports_color() {
+        if self.config().is_terminal {
             wtr.write_all(&crate::util::sanitize_control(buf))?;
         } else {
             wtr.write_all(buf)?;
@@ -1445,7 +1456,7 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
     fn write_path(&self, path: &PrinterPath) -> io::Result<()> {
         let mut wtr = self.wtr().borrow_mut();
         wtr.set_color(self.config().colors.path())?;
-        if wtr.supports_color() {
+        if self.config().is_terminal {
             wtr.write_all(&crate::util::sanitize_control(path.as_bytes()))?;
         } else {
             wtr.write_all(path.as_bytes())?;
@@ -1526,7 +1537,7 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
 
     fn write(&self, buf: &[u8]) -> io::Result<()> {
         let mut wtr = self.wtr().borrow_mut();
-        if wtr.supports_color() {
+        if self.config().is_terminal {
             wtr.write_all(&crate::util::sanitize_control(buf))
         } else {
             wtr.write_all(buf)
@@ -3996,5 +4007,59 @@ e
         let got = printer_contents(&mut printer);
         let expected = "hello\nworld\r\n";
         assert_eq_printed!(expected, got);
+    }
+
+    // Sanitization gating: gated on is_terminal, not supports_color.
+
+    #[test]
+    fn sanitize_is_terminal_true_no_color() {
+        let payload = b"safe\x1b]52;c;ZXZpbA==\x07line\n";
+        let matcher = RegexMatcher::new("safe").unwrap();
+        let mut printer = StandardBuilder::new()
+            .is_terminal(true)
+            .build(NoColor::new(vec![]));
+        SearcherBuilder::new()
+            .line_number(false)
+            .build()
+            .search_reader(&matcher, &payload[..], &mut printer.sink(&matcher))
+            .unwrap();
+        let got = printer.get_mut().get_ref().to_owned();
+        assert!(!got.contains(&0x1b), "ESC should not pass to a tty: {:?}", got);
+        assert!(!got.contains(&0x07), "BEL should not pass to a tty");
+    }
+
+    #[test]
+    fn sanitize_is_terminal_false_passes_through() {
+        let payload = b"safe\x1b]52;c;ZXZpbA==\x07line\n";
+        let matcher = RegexMatcher::new("safe").unwrap();
+        let mut printer = StandardBuilder::new()
+            .is_terminal(false)
+            .build(NoColor::new(vec![]));
+        SearcherBuilder::new()
+            .line_number(false)
+            .build()
+            .search_reader(&matcher, &payload[..], &mut printer.sink(&matcher))
+            .unwrap();
+        let got = printer.get_mut().get_ref().to_owned();
+        assert!(got.contains(&0x1b), "pipe output must be byte-exact");
+        assert!(got.contains(&0x07), "pipe output must be byte-exact");
+    }
+
+    #[test]
+    fn sanitize_is_terminal_true_with_color() {
+        let payload = b"safe\x1b]52;c;evil\x07after\n";
+        let matcher = RegexMatcher::new("safe").unwrap();
+        let mut printer = StandardBuilder::new()
+            .color_specs(ColorSpecs::default_with_color())
+            .is_terminal(true)
+            .build(Ansi::new(vec![]));
+        SearcherBuilder::new()
+            .line_number(false)
+            .build()
+            .search_reader(&matcher, &payload[..], &mut printer.sink(&matcher))
+            .unwrap();
+        let got = printer_contents_ansi(&mut printer);
+        assert!(!got.contains("\x1b]52"), "OSC52 must not pass: {:?}", got);
+        assert!(got.contains("\\x1B]"), "expected escaped ESC: {:?}", got);
     }
 }

--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -4024,7 +4024,11 @@ e
             .search_reader(&matcher, &payload[..], &mut printer.sink(&matcher))
             .unwrap();
         let got = printer.get_mut().get_ref().to_owned();
-        assert!(!got.contains(&0x1b), "ESC should not pass to a tty: {:?}", got);
+        assert!(
+            !got.contains(&0x1b),
+            "ESC should not pass to a tty: {:?}",
+            got
+        );
         assert!(!got.contains(&0x07), "BEL should not pass to a tty");
     }
 

--- a/crates/printer/src/summary.rs
+++ b/crates/printer/src/summary.rs
@@ -579,10 +579,13 @@ impl<'p, 's, M: Matcher, W: WriteColor> SummarySink<'p, 's, M, W> {
     fn write_path(&mut self) -> io::Result<()> {
         if self.path.is_some() {
             let status = self.start_hyperlink()?;
-            self.write_spec(
-                self.summary.config.colors.path(),
-                self.path.as_ref().unwrap().as_bytes(),
-            )?;
+            let path_bytes = self.path.as_ref().unwrap().as_bytes();
+            let spec = self.summary.config.colors.path();
+            if self.summary.wtr.borrow().supports_color() {
+                self.write_spec(spec, &crate::util::sanitize_control(path_bytes))?;
+            } else {
+                self.write_spec(spec, path_bytes)?;
+            }
             self.end_hyperlink(status)?;
         }
         Ok(())

--- a/crates/printer/src/summary.rs
+++ b/crates/printer/src/summary.rs
@@ -592,7 +592,10 @@ impl<'p, 's, M: Matcher, W: WriteColor> SummarySink<'p, 's, M, W> {
             let path_bytes = self.path.as_ref().unwrap().as_bytes();
             let spec = self.summary.config.colors.path();
             if self.summary.config.is_terminal {
-                self.write_spec(spec, &crate::util::sanitize_control(path_bytes))?;
+                self.write_spec(
+                    spec,
+                    &crate::util::sanitize_control(path_bytes),
+                )?;
             } else {
                 self.write_spec(spec, path_bytes)?;
             }

--- a/crates/printer/src/summary.rs
+++ b/crates/printer/src/summary.rs
@@ -36,6 +36,8 @@ struct Config {
     separator_field: Arc<Vec<u8>>,
     separator_path: Option<u8>,
     path_terminator: Option<u8>,
+    /// True if output is going to an interactive terminal.
+    is_terminal: bool,
 }
 
 impl Default for Config {
@@ -50,6 +52,7 @@ impl Default for Config {
             separator_field: Arc::new(b":".to_vec()),
             separator_path: None,
             path_terminator: None,
+            is_terminal: false,
         }
     }
 }
@@ -238,6 +241,13 @@ impl SummaryBuilder {
         config: HyperlinkConfig,
     ) -> &mut SummaryBuilder {
         self.config.hyperlink = config;
+        self
+    }
+
+    /// Configure for output to an interactive terminal. When `true`,
+    /// printed paths are escaped to defang terminal control sequences.
+    pub fn is_terminal(&mut self, yes: bool) -> &mut SummaryBuilder {
+        self.config.is_terminal = yes;
         self
     }
 
@@ -581,7 +591,7 @@ impl<'p, 's, M: Matcher, W: WriteColor> SummarySink<'p, 's, M, W> {
             let status = self.start_hyperlink()?;
             let path_bytes = self.path.as_ref().unwrap().as_bytes();
             let spec = self.summary.config.colors.path();
-            if self.summary.wtr.borrow().supports_color() {
+            if self.summary.config.is_terminal {
                 self.write_spec(spec, &crate::util::sanitize_control(path_bytes))?;
             } else {
                 self.write_spec(spec, path_bytes)?;

--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -588,6 +588,53 @@ where
     Ok(())
 }
 
+// rewrite dangerous control bytes to \xNN
+// preserves tab LF and CRLF but escapes bare or midline CR
+#[allow(missing_docs)]
+pub fn sanitize_control<'b>(
+    bytes: &'b [u8],
+) -> std::borrow::Cow<'b, [u8]> {
+    fn is_danger(b: u8) -> bool {
+        (b < 0x20 && b != b'\t' && b != b'\n' && b != b'\r') || b == 0x7F
+    }
+    // quick scan: anything to do
+    let mut need = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if is_danger(b) { need = true; break; }
+        if b == b'\r' {
+            if i + 1 >= bytes.len() || bytes[i + 1] != b'\n' {
+                need = true; break;
+            }
+            i += 2; continue;
+        }
+        i += 1;
+    }
+    if !need {
+        return std::borrow::Cow::Borrowed(bytes);
+    }
+    let mut out = Vec::with_capacity(bytes.len() + 8);
+    const HEX: &[u8] = b"0123456789ABCDEF";
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        let escape = is_danger(b)
+            || (b == b'\r'
+                && (i + 1 >= bytes.len() || bytes[i + 1] != b'\n'));
+        if escape {
+            out.push(b'\\');
+            out.push(b'x');
+            out.push(HEX[(b >> 4) as usize]);
+            out.push(HEX[(b & 0xF) as usize]);
+        } else {
+            out.push(b);
+        }
+        i += 1;
+    }
+    std::borrow::Cow::Owned(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -604,5 +651,41 @@ mod tests {
         for n in ints {
             assert_eq!(std(n), fmt(n));
         }
+    }
+
+    #[test]
+    fn sanitize_passthrough() {
+        let input: &[u8] = b"hello\tworld\nline\r\ndone\r\n";
+        let out = sanitize_control(input);
+        assert_eq!(&*out, input);
+        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn sanitize_escapes_esc_bel_del() {
+        let input: &[u8] = b"a\x1bb\x07c\x7fd";
+        let out = sanitize_control(input);
+        assert_eq!(&*out, &b"a\\x1Bb\\x07c\\x7Fd"[..]);
+    }
+
+    #[test]
+    fn sanitize_escapes_midline_cr() {
+        let input: &[u8] = b"SAFE=0\rEVIL=1\n";
+        let out = sanitize_control(input);
+        assert_eq!(&*out, &b"SAFE=0\\x0DEVIL=1\n"[..]);
+    }
+
+    #[test]
+    fn sanitize_escapes_trailing_cr() {
+        let input: &[u8] = b"hello\r";
+        let out = sanitize_control(input);
+        assert_eq!(&*out, &b"hello\\x0D"[..]);
+    }
+
+    #[test]
+    fn sanitize_preserves_utf8() {
+        let input: &[u8] = "héllo\x1bworld".as_bytes();
+        let out = sanitize_control(input);
+        assert_eq!(&*out, &b"h\xC3\xA9llo\\x1Bworld"[..]);
     }
 }

--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -614,9 +614,7 @@ const SANITIZE_TABLE: [u8; 256] = {
 // Rewrite C0 (except HT/LF/CR), DEL, and C1 (raw and UTF-8) to \xNN.
 // Returns Cow::Borrowed and skips allocation when the input is clean.
 #[allow(missing_docs)]
-pub fn sanitize_control<'b>(
-    bytes: &'b [u8],
-) -> std::borrow::Cow<'b, [u8]> {
+pub fn sanitize_control<'b>(bytes: &'b [u8]) -> std::borrow::Cow<'b, [u8]> {
     let mut i = 0;
     let mut need = false;
     while i < bytes.len() {

--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -588,28 +588,65 @@ where
     Ok(())
 }
 
-// rewrite dangerous control bytes to \xNN
-// preserves tab LF and CRLF but escapes bare or midline CR
+// Maps each byte to a sanitize action: 0 = pass, 1 = escape,
+// 2 = 0xC2 (lookahead for UTF-8 C1), 3 = CR (CRLF passthrough).
+const SANITIZE_TABLE: [u8; 256] = {
+    let mut t = [0u8; 256];
+    let mut i = 0;
+    while i < 256 {
+        let b = i as u8;
+        if b < 0x20 && b != b'\t' && b != b'\n' && b != b'\r' {
+            t[i] = 1;
+        } else if b == 0x7F {
+            t[i] = 1;
+        } else if b >= 0x80 && b <= 0x9F {
+            t[i] = 1;
+        } else if b == 0xC2 {
+            t[i] = 2;
+        } else if b == b'\r' {
+            t[i] = 3;
+        }
+        i += 1;
+    }
+    t
+};
+
+// Rewrite C0 (except HT/LF/CR), DEL, and C1 (raw and UTF-8) to \xNN.
+// Returns Cow::Borrowed and skips allocation when the input is clean.
 #[allow(missing_docs)]
 pub fn sanitize_control<'b>(
     bytes: &'b [u8],
 ) -> std::borrow::Cow<'b, [u8]> {
-    fn is_danger(b: u8) -> bool {
-        (b < 0x20 && b != b'\t' && b != b'\n' && b != b'\r') || b == 0x7F
-    }
-    // quick scan: anything to do
-    let mut need = false;
     let mut i = 0;
+    let mut need = false;
     while i < bytes.len() {
         let b = bytes[i];
-        if is_danger(b) { need = true; break; }
-        if b == b'\r' {
-            if i + 1 >= bytes.len() || bytes[i + 1] != b'\n' {
-                need = true; break;
+        match SANITIZE_TABLE[b as usize] {
+            0 => {
+                i += 1;
             }
-            i += 2; continue;
+            1 => {
+                need = true;
+                break;
+            }
+            2 => {
+                if i + 1 < bytes.len()
+                    && bytes[i + 1] >= 0x80
+                    && bytes[i + 1] <= 0x9F
+                {
+                    need = true;
+                    break;
+                }
+                i += 1;
+            }
+            _ => {
+                if i + 1 >= bytes.len() || bytes[i + 1] != b'\n' {
+                    need = true;
+                    break;
+                }
+                i += 2;
+            }
         }
-        i += 1;
     }
     if !need {
         return std::borrow::Cow::Borrowed(bytes);
@@ -619,18 +656,48 @@ pub fn sanitize_control<'b>(
     let mut i = 0;
     while i < bytes.len() {
         let b = bytes[i];
-        let escape = is_danger(b)
-            || (b == b'\r'
-                && (i + 1 >= bytes.len() || bytes[i + 1] != b'\n'));
-        if escape {
-            out.push(b'\\');
-            out.push(b'x');
-            out.push(HEX[(b >> 4) as usize]);
-            out.push(HEX[(b & 0xF) as usize]);
-        } else {
-            out.push(b);
+        match SANITIZE_TABLE[b as usize] {
+            0 => {
+                out.push(b);
+                i += 1;
+            }
+            1 => {
+                out.push(b'\\');
+                out.push(b'x');
+                out.push(HEX[(b >> 4) as usize]);
+                out.push(HEX[(b & 0xF) as usize]);
+                i += 1;
+            }
+            2 => {
+                if i + 1 < bytes.len()
+                    && bytes[i + 1] >= 0x80
+                    && bytes[i + 1] <= 0x9F
+                {
+                    let c1 = bytes[i + 1];
+                    out.push(b'\\');
+                    out.push(b'x');
+                    out.push(HEX[(c1 >> 4) as usize]);
+                    out.push(HEX[(c1 & 0xF) as usize]);
+                    i += 2;
+                } else {
+                    out.push(b);
+                    i += 1;
+                }
+            }
+            _ => {
+                if i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
+                    out.push(b'\r');
+                    out.push(b'\n');
+                    i += 2;
+                } else {
+                    out.push(b'\\');
+                    out.push(b'x');
+                    out.push(HEX[(b >> 4) as usize]);
+                    out.push(HEX[(b & 0xF) as usize]);
+                    i += 1;
+                }
+            }
         }
-        i += 1;
     }
     std::borrow::Cow::Owned(out)
 }
@@ -687,5 +754,49 @@ mod tests {
         let input: &[u8] = "héllo\x1bworld".as_bytes();
         let out = sanitize_control(input);
         assert_eq!(&*out, &b"h\xC3\xA9llo\\x1Bworld"[..]);
+    }
+
+    #[test]
+    fn sanitize_escapes_raw_c1() {
+        // raw 0x9B (CSI) and 0x9D (OSC) — used as 8-bit introducers.
+        let input: &[u8] = b"a\x9b31mb\x9d52;c;evil\x9c";
+        let out = sanitize_control(input);
+        assert_eq!(&*out, &b"a\\x9B31mb\\x9D52;c;evil\\x9C"[..]);
+    }
+
+    #[test]
+    fn sanitize_escapes_utf8_c1() {
+        // UTF-8 form of the same. 0xC2 0x9D = U+009D (OSC). VTE-family
+        // terminals act on this even when raw 0x9D and ESC are blocked.
+        let input: &[u8] = b"safe\xC2\x9D52;c;evil\xC2\x9C.txt";
+        let out = sanitize_control(input);
+        assert_eq!(&*out, &b"safe\\x9D52;c;evil\\x9C.txt"[..]);
+    }
+
+    #[test]
+    fn sanitize_keeps_latin1_above_c1() {
+        // 0xC2 0xA0 onwards is non-breaking space and other Latin-1
+        // letters, which must pass through unchanged.
+        let input: &[u8] = "café résumé\u{00A0}word".as_bytes();
+        let out = sanitize_control(input);
+        assert_eq!(&*out, input);
+        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn sanitize_lone_c2_at_end() {
+        // a stray 0xC2 with nothing after must not panic and must pass
+        // through unchanged (it is not a complete UTF-8 C1 sequence).
+        let input: &[u8] = b"name\xC2";
+        let out = sanitize_control(input);
+        assert_eq!(&*out, input);
+    }
+
+    #[test]
+    fn sanitize_lone_c2_middle() {
+        // a stray 0xC2 not followed by a C1 byte must pass through.
+        let input: &[u8] = b"name\xC2hello";
+        let out = sanitize_control(input);
+        assert_eq!(&*out, input);
     }
 }


### PR DESCRIPTION
Filenames and file contents can contain terminal control sequences like OSC52 clipboard writes, OSC8 hyperlink injection, cursor moves that spoof output. When ripgrep prints them to a tty, the terminal acts on them. This PR sanitizes the relevant sequences before they reach the terminal.

Sanitization is gated on whether stdout is an interactive tty. Pipe output is left byte-exact so `rg | xargs`, `rg | jq`, `rg --files |
xargs -0`, and similar pipelines see exactly the bytes they see today.

Implementation is a 256-byte lookup table with a four-way branch. The fast path returns Cow::Borrowed without allocating. On a 50 MB / ~80k-match Rust corpus the tty path runs within the noise of the unsanitized baseline.

Library API change is additive: one is_terminal(bool) method per printer (Standard, Summary, PathPrinter), default false. Existing embedders see no behavior change unless they opt in.

Covers: matched-line content, printed paths in standard/summary/path-list output, and stderr error messages from .gitignore parsing (see issue #1992). JSON output is unaffected.

@BurntSushi I know you had some resevationas bout filters in the past but I hope this approach with interactive vs piped matches how you want ripgrep to behave while we can also address the relevant risks. There is no measurable performance impact