### PR TITLE
doc: fix typos in internal doc comments

### DIFF
--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -222,7 +222,7 @@ impl HiArgs {
         let mmap_choice = {
             // SAFETY: Memory maps are difficult to impossible to encapsulate
             // safely in a portable way that doesn't simultaneously negate some
-            // of the benfits of using memory maps. For ripgrep's use, we never
+            // of the benefits of using memory maps. For ripgrep's use, we never
             // mutate a memory map and generally never store the contents of
             // memory map in a data structure that depends on immutability.
             // Generally speaking, the worst thing that can happen is a SIGBUS
@@ -1144,7 +1144,7 @@ impl Paths {
 /// ripgrep actually uses two different binary detection heuristics depending
 /// on whether a file is explicitly being searched (e.g., via a CLI argument)
 /// or implicitly searched (e.g., via directory traversal). In general, the
-/// former can never use a heuristic that lets it "quit" seaching before
+/// former can never use a heuristic that lets it "quit" searching before
 /// either getting EOF or finding a match. (Because doing otherwise would be
 /// considered a filter, and ripgrep follows the rule that an explicitly given
 /// file is always searched.)

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -109,7 +109,7 @@ pub(crate) struct LowArgs {
     pub(crate) with_filename: Option<bool>,
 }
 
-/// A "special" mode that supercedes everything else.
+/// A "special" mode that supersedes everything else.
 ///
 /// When one of these modes is present, it overrides everything else and causes
 /// ripgrep to short-circuit. In particular, we avoid converting low-level
@@ -255,9 +255,9 @@ pub(crate) enum BinaryMode {
 /// Indicates what kind of boundary mode to use (line or word).
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum BoundaryMode {
-    /// Only allow matches when surrounded by line bounaries.
+    /// Only allow matches when surrounded by line boundaries.
     Line,
-    /// Only allow matches when surrounded by word bounaries.
+    /// Only allow matches when surrounded by word boundaries.
     Word,
 }
 
@@ -490,7 +490,7 @@ impl ContextSeparator {
         Ok(ContextSeparator(Some(Vec::unescape_bytes(string).into())))
     }
 
-    /// Creates a new separator that intructs the printer to disable contextual
+    /// Creates a new separator that instructs the printer to disable contextual
     /// separators entirely.
     pub(crate) fn disabled() -> ContextSeparator {
         ContextSeparator(None)

--- a/crates/core/flags/mod.rs
+++ b/crates/core/flags/mod.rs
@@ -67,7 +67,7 @@ mod parse;
 /// by a single implementation of this trait.
 ///
 /// ripgrep only supports flags that are switches or flags that accept a single
-/// value. Flags that accept multiple values are an unsupported abberation.
+/// value. Flags that accept multiple values are an unsupported aberration.
 trait Flag: Debug + Send + Sync + UnwindSafe + RefUnwindSafe + 'static {
     /// Returns true if this flag is a switch. When a flag is a switch, the
     /// CLI parser will not look for a value after the flag is seen.

--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -427,7 +427,7 @@ fn eprint_nothing_searched() {
 /// The `started` time should be the time at which ripgrep started working.
 ///
 /// If an error occurs while writing, then writing stops and the error is
-/// returned. Note that callers should probably ignore this errror, since
+/// returned. Note that callers should probably ignore this error, since
 /// whether stats fail to print or not generally shouldn't cause ripgrep to
 /// enter into an "error" state. And usually the only way for this to fail is
 /// if writing to stdout itself fails.

--- a/crates/searcher/src/searcher/mod.rs
+++ b/crates/searcher/src/searcher/mod.rs
@@ -450,7 +450,7 @@ impl SearcherBuilder {
     ///
     /// If a heap limit is set to `0`, then no heap space is used. If there are
     /// no alternative strategies available for searching without heap space
-    /// (e.g., memory maps are disabled), then the searcher wil return an error
+    /// (e.g., memory maps are disabled), then the searcher will return an error
     /// immediately.
     ///
     /// By default, no limit is set.


### PR DESCRIPTION

**Repo:** BurntSushi/ripgrep (⭐ 50000)
**Type:** docs
**Files changed:** 5
**Lines:** +9/-9

## What
Fixes several typos in internal Rust doc comments across `crates/core` and
`crates/searcher`: `errror`→`error`, `benfits`→`benefits`, `seaching`→`searching`,
`supercedes`→`supersedes`, `bounaries`→`boundaries`, `intructs`→`instructs`,
`abberation`→`aberration`, and `wil`→`will`.

## Why
Comment-only typos surfaced by `codespell`. They don't change behavior but
make doc comments easier to read and grep. Low-noise cleanup consistent with
the repo's prior typo-fix commits.

## Testing
All edits are inside `///` doc-comment text — no code paths altered. Re-ran
`codespell` against the touched files; the targeted misspellings are gone.

## Risk
Low — comment-only changes, no identifiers or behavior touched.
