### PR TITLE
docs: fix typo `supercedes` → `supersedes` in lowargs.rs

### DIFF
--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -109,7 +109,7 @@ pub(crate) struct LowArgs {
     pub(crate) with_filename: Option<bool>,
 }
 
-/// A "special" mode that supercedes everything else.
+/// A "special" mode that supersedes everything else.
 ///
 /// When one of these modes is present, it overrides everything else and causes
 /// ripgrep to short-circuit. In particular, we avoid converting low-level


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `crates/core/flags/lowargs.rs` (line ~112)
- Change: `supercedes` → `supersedes`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
