### PR TITLE
Fix multi-root .gitignore bug (issues #3376 and #3320)

### DIFF
--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -101,7 +101,10 @@ struct IgnoreInner {
     /// Note that this is never used during matching, only when adding new
     /// parent directory matchers. This avoids needing to rebuild glob sets for
     /// parent directories if many paths are being searched.
-    compiled: Arc<RwLock<HashMap<OsString, Weak<IgnoreInner>>>>,
+    ///
+    /// The key is a Vec<OsString> = [parent_path, absolute_base_path]
+    /// to ensure different root paths get distinct cache entries.
+    compiled: Arc<RwLock<HashMap<Vec<OsString>, Weak<IgnoreInner>>>>,
     /// The path to the directory that this matcher was built from.
     dir: PathBuf,
     /// An override matcher (default is empty).
@@ -212,7 +215,15 @@ impl Ignore {
         let mut ig = self.clone();
         for parent in parents.into_iter().rev() {
             let mut compiled = self.0.compiled.write().unwrap();
-            if let Some(weak) = compiled.get(parent.as_os_str()) {
+            // Use (parent, absolute_base) as cache key so different root paths
+            // get distinct cache entries. This fixes the multi-root gitignore
+            // bug where cached entries from earlier search paths had stale
+            // absolute_base values pointing to a different root directory.
+            let cache_key = vec![
+                parent.as_os_str().to_os_string(),
+                (**absolute_base).as_os_str().to_os_string(),
+            ];
+            if let Some(weak) = compiled.get(&cache_key) {
                 if let Some(prebuilt) = weak.upgrade() {
                     ig = Ignore(prebuilt);
                     continue;
@@ -230,10 +241,7 @@ impl Ignore {
                 };
             let ig_arc = Arc::new(igtmp);
             ig = Ignore(ig_arc.clone());
-            compiled.insert(
-                parent.as_os_str().to_os_string(),
-                Arc::downgrade(&ig_arc),
-            );
+            compiled.insert(cache_key, Arc::downgrade(&ig_arc));
         }
         (ig, errs.into_error_option())
     }

--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -102,7 +102,7 @@ struct IgnoreInner {
     /// parent directory matchers. This avoids needing to rebuild glob sets for
     /// parent directories if many paths are being searched.
     ///
-    /// The key is a Vec<OsString> = [parent_path, absolute_base_path]
+    /// The key is a Vec\<OsString\> = [parent_path, absolute_base_path]
     /// to ensure different root paths get distinct cache entries.
     compiled: Arc<RwLock<HashMap<Vec<OsString>, Weak<IgnoreInner>>>>,
     /// The path to the directory that this matcher was built from.


### PR DESCRIPTION
## Summary

When multiple search paths are provided to ripgrep (e.g., `rg pattern src/ tests/`), the compiled gitignore cache was keyed only by parent directory path. This caused entries cached from the first search path to be incorrectly reused when processing subsequent paths, even though the `absolute_base` (the root search directory) was different.

This resulted in `.gitignore` rules from the first path's root being applied with incorrect path prefixes to files in later paths' roots, causing files that should be ignored to instead be searched.

## Root Cause

In `crates/ignore/src/dir.rs`, the `add_parents()` function used `parent.as_os_str()` as the cache key. When the same parent directory (e.g., the repo root) was encountered while processing different root paths, the cached `Ignore` from the first path was reused, but it had the wrong `absolute_base` value.

## Fix

Change the cache key from just the parent path to a tuple of `(parent_path, absolute_base_path)`. This ensures different root paths get distinct cache entries.

**Before:**


**After:**


## Test Results

All tests pass (329 tests), and manual testing confirms:

| Command | Before fix | After fix |
|---------|------------|-----------|
| `rg this src/ tests/` | src/invalid found (buggy) | src/invalid excluded (correct) |
| `rg this tests/ src/` | Correct | Correct |
| `rg this src tests` | Correct | Correct |

## References

- Fixes #3376
- Fixes #3320