### PR TITLE
Remove redundant entry from excluded paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ exclude = [
   "/pkg/brew",
   "/benchsuite/",
   "/scripts/",
-  "/crates/fuzz",
 ]
 build = "build.rs"
 autotests = false


### PR DESCRIPTION
It should be a typo originated from 52115ab633c, but it does nothing actually so it's redundant.

I have compared the outputs of below cmd

```bash
$ cargo package --list --allow-dirty | rg fuzz
```
 before/after my change to make sure it's not packaged either way.