### PR TITLE
docs(ignore): remove stale io_error link

### DIFF
--- a/crates/ignore/src/lib.rs
+++ b/crates/ignore/src/lib.rs
@@ -190,18 +190,10 @@ impl Error {
     /// following symbolic links.
     ///
     /// This method returns a borrowed value that is bound to the lifetime of the [`Error`]. To
-    /// obtain an owned value, the [`into_io_error`] can be used instead.
-    ///
-    /// > This is the original [`std::io::Error`] and is _not_ the same as
-    /// > [`impl From<Error> for std::io::Error`][impl] which contains
-    /// > additional context about the error.
+    /// obtain an owned value, [`Self::into_io_error`] can be used instead.
     ///
     /// [`None`]: https://doc.rust-lang.org/stable/std/option/enum.Option.html#variant.None
     /// [`std::io::Error`]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
-    /// [`From`]: https://doc.rust-lang.org/stable/std/convert/trait.From.html
-    /// [`Error`]: struct.Error.html
-    /// [`into_io_error`]: struct.Error.html#method.into_io_error
-    /// [impl]: struct.Error.html#impl-From%3CError%3E
     pub fn io_error(&self) -> Option<&std::io::Error> {
         match *self {
             Error::Partial(ref errs) => {


### PR DESCRIPTION
Summary:
- Removes the stale `impl From<Error> for std::io::Error` reference from the `ignore::Error::io_error` docs.
- Updates nearby intra-crate rustdoc links for `Error` to point at the enum page.

Verification:
- `git diff --check`
