### PR TITLE
doc: remove dangling ignore error link

### DIFF
--- a/crates/ignore/src/lib.rs
+++ b/crates/ignore/src/lib.rs
@@ -192,16 +192,10 @@ impl Error {
     /// This method returns a borrowed value that is bound to the lifetime of the [`Error`]. To
     /// obtain an owned value, the [`into_io_error`] can be used instead.
     ///
-    /// > This is the original [`std::io::Error`] and is _not_ the same as
-    /// > [`impl From<Error> for std::io::Error`][impl] which contains
-    /// > additional context about the error.
-    ///
     /// [`None`]: https://doc.rust-lang.org/stable/std/option/enum.Option.html#variant.None
     /// [`std::io::Error`]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
-    /// [`From`]: https://doc.rust-lang.org/stable/std/convert/trait.From.html
     /// [`Error`]: struct.Error.html
     /// [`into_io_error`]: struct.Error.html#method.into_io_error
-    /// [impl]: struct.Error.html#impl-From%3CError%3E
     pub fn io_error(&self) -> Option<&std::io::Error> {
         match *self {
             Error::Partial(ref errs) => {


### PR DESCRIPTION
## Summary

- remove the `ignore::Error::io_error` rustdoc paragraph that references a non-existent `impl From<Error> for std::io::Error`
- remove the now-unused rustdoc link references for that paragraph

Closes #3235.

## Validation

Passed locally:

- `cargo fmt --all -- --check`
- `cargo doc -p ignore --no-deps`
- `cargo test -p ignore`
- `cargo check`

Notes:

- I also tried `cargo clippy --all-targets -- -D warnings`, but with my local Rust 1.94 toolchain it reports warnings in untouched crates unrelated to this rustdoc-only change.
- I also tried `cargo test --all`, but my local checkout ran out of disk space while compiling full-workspace dependencies (`No space left on device`).
