### PR TITLE
docs: fix the ignore::Error::io_error intra-doc link

### DIFF
--- a/crates/ignore/src/lib.rs
+++ b/crates/ignore/src/lib.rs
@@ -201,7 +201,7 @@ impl Error {
     /// [`From`]: https://doc.rust-lang.org/stable/std/convert/trait.From.html
     /// [`Error`]: struct.Error.html
     /// [`into_io_error`]: struct.Error.html#method.into_io_error
-    /// [impl]: struct.Error.html#impl-From%3CError%3E
+    /// [impl]: enum.Error.html#impl-From%3CError%3E
     pub fn io_error(&self) -> Option<&std::io::Error> {
         match *self {
             Error::Partial(ref errs) => {


### PR DESCRIPTION
## Summary

- fix the dangling intra-doc link in `ignore::Error::io_error`

## Related issue

- Addresses #3235

## Guideline alignment

- no `CONTRIBUTING` guide or PR template was present in the repo root scan, so I kept this to a single-file docs-only fix on `master`

## Validation

- not run (docs-only change)
