### PR TITLE
Fix compression tool argument parsing for files starting with dash

### DIFF
--- a/crates/cli/src/decompress.rs
+++ b/crates/cli/src/decompress.rs
@@ -226,6 +226,7 @@ impl DecompressionReaderBuilder {
         let Some(mut cmd) = self.matcher.command(path) else {
             return DecompressionReader::new_passthru(path);
         };
+        cmd.arg("--");
         cmd.arg(path);
 
         match self.command_builder.build(&mut cmd) {


### PR DESCRIPTION
## Summary

When decompressing files with names starting with a dash (e.g., `-10.txt.gz`), the filename was being passed as an argument without the `--` separator. This caused gzip to interpret the filename as a string of options.

## Problem

For a file named `-10.txt.gz`, the command executed was:
```
gzip -d -c -10.txt.gz
```

But gzip interprets `-10.txt.gz` as a series of options (`-1`, `-0`, etc.), causing the error:
```
gzip: invalid option -- '0'
```

## Fix

Added `--` separator before the filename argument:
```
gzip -d -c -- -10.txt.gz
```

This ensures the compression tool knows that all following arguments are filenames, not options.

## Changes

- Modified `DecompressionReaderBuilder::build()` to add `--` before the path argument

Fixes issue #3222