### PR TITLE
resolve relative paths in GitignoreBuilder::add relative to root

### DIFF
--- a/crates/ignore/src/gitignore.rs
+++ b/crates/ignore/src/gitignore.rs
@@ -386,13 +386,17 @@ impl GitignoreBuilder {
     ///
     /// The file given should be formatted as a `gitignore` file.
     ///
+    /// If `path` is relative, it is resolved relative to the root path
+    /// given to [`GitignoreBuilder::new`]. Absolute paths are used as-is.
+    ///
     /// Note that partial errors can be returned. For example, if there was
     /// a problem adding one glob, an error for that will be returned, but
     /// all other valid globs will still be added.
     pub fn add<P: AsRef<Path>>(&mut self, path: P) -> Option<Error> {
         let path = path.as_ref();
-        let file = match File::open(path) {
-            Err(err) => return Some(Error::Io(err).with_path(path)),
+        let path = self.root.join(path);
+        let file = match File::open(&path) {
+            Err(err) => return Some(Error::Io(err).with_path(&path)),
             Ok(file) => file,
         };
         log::debug!("opened gitignore file: {}", path.display());
@@ -403,7 +407,7 @@ impl GitignoreBuilder {
             let line = match line {
                 Ok(line) => line,
                 Err(err) => {
-                    errs.push(Error::Io(err).tagged(path, lineno));
+                    errs.push(Error::Io(err).tagged(&path, lineno));
                     break;
                 }
             };
@@ -414,7 +418,7 @@ impl GitignoreBuilder {
                 if i == 0 { line.trim_start_matches(UTF8_BOM) } else { &line };
 
             if let Err(err) = self.add_line(Some(path.to_path_buf()), &line) {
-                errs.push(err.tagged(path, lineno));
+                errs.push(err.tagged(&path, lineno));
             }
         }
         errs.into_error_option()

--- a/crates/ignore/tests/gitignore_matched_path_or_any_parents_tests.rs
+++ b/crates/ignore/tests/gitignore_matched_path_or_any_parents_tests.rs
@@ -7,7 +7,10 @@ const IGNORE_FILE: &'static str =
 
 fn get_gitignore() -> Gitignore {
     let mut builder = GitignoreBuilder::new("ROOT");
-    let error = builder.add(IGNORE_FILE);
+    // Use absolute path so it works regardless of the synthetic root used
+    // for path matching.
+    let absolute = std::env::current_dir().unwrap().join(IGNORE_FILE);
+    let error = builder.add(&absolute);
     assert!(error.is_none(), "failed to open gitignore file");
     builder.build().unwrap()
 }

--- a/crates/ignore/tests/gitignore_skip_bom.rs
+++ b/crates/ignore/tests/gitignore_skip_bom.rs
@@ -9,7 +9,8 @@ const IGNORE_FILE: &'static str = "tests/gitignore_skip_bom.gitignore";
 #[test]
 fn gitignore_skip_bom() {
     let mut builder = GitignoreBuilder::new("ROOT");
-    let error = builder.add(IGNORE_FILE);
+    let absolute = std::env::current_dir().unwrap().join(IGNORE_FILE);
+    let error = builder.add(&absolute);
     assert!(error.is_none(), "failed to open gitignore file");
     let g = builder.build().unwrap();
 


### PR DESCRIPTION
`GitignoreBuilder::add` takes a path and does `File::open(path)` directly without joining with the root. The docs say paths should be relative to the root given to `GitignoreBuilder::new`, but the code ignores the root entirely.

So if you do:
```rust
let builder = GitignoreBuilder::new("/some/repo");
builder.add(".gitignore");  // Tries to open .gitignore relative to CWD, instead of /some/repo
```

Can be fixed by joining the path with `self.root`. Absolute paths pass through `join` unchanged  (continue to work as they previously did).