### PR TITLE
globset: fix duplicated "the" in glob.rs comment

### DIFF
--- a/crates/globset/src/glob.rs
+++ b/crates/globset/src/glob.rs
@@ -589,7 +589,7 @@ impl<'a> GlobBuilder<'a> {
         };
         p.parse()?;
         if p.branches.is_empty() {
-            // OK because of how the the branches/alternate_stack are managed.
+            // OK because of how the branches/alternate_stack are managed.
             // If we end up here, then there *must* be a bug in the parser
             // somewhere.
             unreachable!()


### PR DESCRIPTION
One-line typo fix in `crates/globset/src/glob.rs`: the comment "OK because of how the the branches/alternate_stack are managed." duplicates the word "the". This PR removes the duplicate. No code/behavior change.