### PR TITLE
chore: improve ripgrep maintenance path

### DIFF
--- a/crates/cli/src/human.rs
+++ b/crates/cli/src/human.rs
@@ -64,7 +64,7 @@ impl std::fmt::Display for ParseSizeError {
 
 impl From<ParseSizeError> for std::io::Error {
     fn from(size_err: ParseSizeError) -> std::io::Error {
-        std::io::Error::new(std::io::ErrorKind::Other, size_err)
+        std::io::Error::other(size_err)
     }
 }
 

--- a/crates/cli/src/pattern.rs
+++ b/crates/cli/src/pattern.rs
@@ -38,7 +38,7 @@ impl std::fmt::Display for InvalidPatternError {
 
 impl From<InvalidPatternError> for io::Error {
     fn from(paterr: InvalidPatternError) -> io::Error {
-        io::Error::new(io::ErrorKind::Other, paterr)
+        io::Error::other(paterr)
     }
 }
 
@@ -82,16 +82,10 @@ pub fn pattern_from_bytes(
 pub fn patterns_from_path<P: AsRef<Path>>(path: P) -> io::Result<Vec<String>> {
     let path = path.as_ref();
     let file = std::fs::File::open(path).map_err(|err| {
-        io::Error::new(
-            io::ErrorKind::Other,
-            format!("{}: {}", path.display(), err),
-        )
+        io::Error::other(format!("{}: {}", path.display(), err))
     })?;
     patterns_from_reader(file).map_err(|err| {
-        io::Error::new(
-            io::ErrorKind::Other,
-            format!("{}:{}", path.display(), err),
-        )
+        io::Error::other(format!("{}:{}", path.display(), err))
     })
 }
 
@@ -105,7 +99,7 @@ pub fn patterns_from_stdin() -> io::Result<Vec<String>> {
     let stdin = io::stdin();
     let locked = stdin.lock();
     patterns_from_reader(locked).map_err(|err| {
-        io::Error::new(io::ErrorKind::Other, format!("<stdin>:{}", err))
+        io::Error::other(format!("<stdin>:{}", err))
     })
 }
 
@@ -148,10 +142,7 @@ pub fn patterns_from_reader<R: io::Read>(rdr: R) -> io::Result<Vec<String>> {
                 patterns.push(pattern.to_string());
                 Ok(true)
             }
-            Err(err) => Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("{}: {}", line_number, err),
-            )),
+            Err(err) => Err(io::Error::other(format!("{}: {}", line_number, err))),
         }
     })?;
     Ok(patterns)

--- a/crates/cli/src/process.rs
+++ b/crates/cli/src/process.rs
@@ -73,7 +73,7 @@ impl From<CommandError> for io::Error {
         match cmderr.kind {
             CommandErrorKind::Io(ioerr) => ioerr,
             CommandErrorKind::Stderr(_) => {
-                io::Error::new(io::ErrorKind::Other, cmderr)
+                io::Error::other(cmderr)
             }
         }
     }


### PR DESCRIPTION
Summary:
- Make a small, focused maintenance improvement in the ripgrep codebase.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.