### PR TITLE
doc: improve man page option anchor generation

### DIFF
--- a/crates/core/flags/doc/man.rs
+++ b/crates/core/flags/doc/man.rs
@@ -45,19 +45,34 @@ pub(crate) fn generate() -> String {
 /// Writes `roff` formatted documentation for `flag` to `out`.
 fn generate_flag(flag: &'static dyn Flag, out: &mut String) {
     writeln!(out, ".TP 12");
-    if let Some(byte) = flag.name_short() {
-        let name = char::from(byte);
-        write!(out, r"\fB\-{name}\fP");
+    let short = flag.name_short().map(char::from);
+    let name = flag.name_long().replace("-", r"\-");
+
+    if short.map(|c| c.is_ascii_alphanumeric()).unwrap_or(false) {
+        let short = short.unwrap();
+        write!(out, r"\fB\-{short}\fP");
         if let Some(var) = flag.doc_variable() {
             write!(out, r" \fI{var}\fP");
         }
         write!(out, r", ");
-    }
 
-    let name = flag.name_long().replace("-", r"\-");
-    write!(out, r"\fB\-\-{name}\fP");
-    if let Some(var) = flag.doc_variable() {
-        write!(out, r"=\fI{var}\fP");
+        write!(out, r"\fB\-\-{name}\fP");
+        if let Some(var) = flag.doc_variable() {
+            write!(out, r"=\fI{var}\fP");
+        }
+    } else {
+        write!(out, r"\fB\-\-{name}\fP");
+        if let Some(var) = flag.doc_variable() {
+            write!(out, r"=\fI{var}\fP");
+        }
+
+        if let Some(short) = short {
+            write!(out, r", ");
+            write!(out, r"\fB\-{short}\fP");
+            if let Some(var) = flag.doc_variable() {
+                write!(out, r" \fI{var}\fP");
+            }
+        }
     }
     write!(out, "\n");
 

--- a/crates/core/flags/doc/man.rs
+++ b/crates/core/flags/doc/man.rs
@@ -44,6 +44,7 @@ pub(crate) fn generate() -> String {
 
 /// Writes `roff` formatted documentation for `flag` to `out`.
 fn generate_flag(flag: &'static dyn Flag, out: &mut String) {
+    writeln!(out, ".TP 12");
     if let Some(byte) = flag.name_short() {
         let name = char::from(byte);
         write!(out, r"\fB\-{name}\fP");


### PR DESCRIPTION
## Summary
- Improve roff man page generation so option anchors are more linkable/consistent.
- Minor cleanup in flag config/defs and default_types.

## Test plan
- [x] `cargo test -p ripgrep` (local)