### PR TITLE
Fix line numbers for adjacent multiline replacements

### DIFF
--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -1044,9 +1044,15 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
         let mut stepper = LineStep::new(line_term, 0, bytes.len());
         while let Some((start, end)) = stepper.next(bytes) {
             let mut line = Match::new(start, end);
+            let line_number = self.line_number_for_match(
+                line_term,
+                Self::first_match_in_line(matches, midx, line),
+                line.start(),
+                count,
+            );
             self.write_prelude(
                 self.sunk.absolute_byte_offset() + line.start() as u64,
-                self.sunk.line_number().map(|n| n + count),
+                line_number,
                 Some(matches[0].start() as u64 + 1),
             )?;
             count += 1;
@@ -1089,9 +1095,15 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
                     line = line.with_start(upto);
                 } else {
                     let upto = cmp::min(line.end(), m.end());
+                    let line_number = self.line_number_for_match(
+                        line_term,
+                        Some(midx),
+                        line.start(),
+                        count,
+                    );
                     self.write_prelude(
                         self.sunk.absolute_byte_offset() + m.start() as u64,
-                        self.sunk.line_number().map(|n| n + count),
+                        line_number,
                         Some(m.start() as u64 + 1),
                     )?;
 
@@ -1116,7 +1128,7 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
         let line_term = self.searcher.line_terminator().as_byte();
         let spec = self.config().colors.matched();
         let bytes = self.sunk.bytes();
-        for &m in self.sunk.matches() {
+        for (match_index, &m) in self.sunk.matches().iter().enumerate() {
             let mut count = 0;
             let mut stepper = LineStep::new(line_term, 0, bytes.len());
             while let Some((start, end)) = stepper.next(bytes) {
@@ -1127,9 +1139,15 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
                     count += 1;
                     continue;
                 }
+                let line_number = self.line_number_for_match(
+                    line_term,
+                    Some(match_index),
+                    line.start(),
+                    count,
+                );
                 self.write_prelude(
                     self.sunk.absolute_byte_offset() + line.start() as u64,
-                    self.sunk.line_number().map(|n| n + count),
+                    line_number,
                     Some(m.start().saturating_sub(line.start()) as u64 + 1),
                 )?;
                 count += 1;
@@ -1167,6 +1185,36 @@ impl<'a, M: Matcher, W: WriteColor> StandardImpl<'a, M, W> {
             }
         }
         Ok(())
+    }
+
+    fn first_match_in_line(
+        matches: &[Match],
+        start_index: usize,
+        line: Match,
+    ) -> Option<usize> {
+        matches.iter().enumerate().skip(start_index).find_map(|(i, m)| {
+            if m.start() >= line.end() {
+                None
+            } else if m.end() > line.start() {
+                Some(i)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn line_number_for_match(
+        &self,
+        line_term: u8,
+        match_index: Option<usize>,
+        line_start: usize,
+        line_count: u64,
+    ) -> Option<u64> {
+        match_index
+            .and_then(|i| {
+                self.sunk.replacement_line_number(line_term, i, line_start)
+            })
+            .or_else(|| self.sunk.line_number().map(|n| n + line_count))
     }
 
     /// Write the beginning part of a matching line. This (may) include things

--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -168,6 +168,8 @@ impl<M: Matcher> Replacer<M> {
 #[derive(Debug)]
 pub(crate) struct Sunk<'a> {
     bytes: &'a [u8],
+    original_bytes: &'a [u8],
+    replaced: bool,
     absolute_byte_offset: u64,
     line_number: Option<u64>,
     context_kind: Option<&'a SinkContextKind>,
@@ -180,6 +182,8 @@ impl<'a> Sunk<'a> {
     pub(crate) fn empty() -> Sunk<'static> {
         Sunk {
             bytes: &[],
+            original_bytes: &[],
+            replaced: false,
             absolute_byte_offset: 0,
             line_number: None,
             context_kind: None,
@@ -194,10 +198,14 @@ impl<'a> Sunk<'a> {
         original_matches: &'a [Match],
         replacement: Option<(&'a [u8], &'a [Match])>,
     ) -> Sunk<'a> {
+        let original_bytes = sunk.bytes();
+        let replaced = replacement.is_some();
         let (bytes, matches) =
-            replacement.unwrap_or_else(|| (sunk.bytes(), original_matches));
+            replacement.unwrap_or_else(|| (original_bytes, original_matches));
         Sunk {
             bytes,
+            original_bytes,
+            replaced,
             absolute_byte_offset: sunk.absolute_byte_offset(),
             line_number: sunk.line_number(),
             context_kind: None,
@@ -212,10 +220,14 @@ impl<'a> Sunk<'a> {
         original_matches: &'a [Match],
         replacement: Option<(&'a [u8], &'a [Match])>,
     ) -> Sunk<'a> {
+        let original_bytes = sunk.bytes();
+        let replaced = replacement.is_some();
         let (bytes, matches) =
-            replacement.unwrap_or_else(|| (sunk.bytes(), original_matches));
+            replacement.unwrap_or_else(|| (original_bytes, original_matches));
         Sunk {
             bytes,
+            original_bytes,
+            replaced,
             absolute_byte_offset: sunk.absolute_byte_offset(),
             line_number: sunk.line_number(),
             context_kind: Some(sunk.kind()),
@@ -257,6 +269,44 @@ impl<'a> Sunk<'a> {
     #[inline]
     pub(crate) fn line_number(&self) -> Option<u64> {
         self.line_number
+    }
+
+    #[inline]
+    pub(crate) fn replacement_line_number(
+        &self,
+        line_term: u8,
+        match_index: usize,
+        replacement_line_start: usize,
+    ) -> Option<u64> {
+        if !self.replaced {
+            return None;
+        }
+        let line_number = self.line_number?;
+        let original_match = self.original_matches.get(match_index)?;
+        let replacement_match = self.matches.get(match_index)?;
+        let original_before_match =
+            &self.original_bytes[..original_match.start()];
+        let original_preceding_lines = original_before_match
+            .iter()
+            .filter(|&&byte| byte == line_term)
+            .count() as u64;
+        let replacement_preceding_lines = if replacement_line_start
+            <= replacement_match.start()
+        {
+            0
+        } else {
+            let end =
+                std::cmp::min(replacement_line_start, replacement_match.end());
+            self.bytes[replacement_match.start()..end]
+                .iter()
+                .filter(|&&byte| byte == line_term)
+                .count() as u64
+        };
+        Some(
+            line_number
+                + original_preceding_lines
+                + replacement_preceding_lines,
+        )
     }
 }
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -946,6 +946,46 @@ rgtest!(r1311_multi_line_term_replace, |dir: Dir, mut cmd: TestCommand| {
     );
 });
 
+// See: https://github.com/BurntSushi/ripgrep/issues/2779
+rgtest!(
+    r2779_adjacent_multiline_replace_line_numbers,
+    |dir: Dir, mut cmd: TestCommand| {
+        dir.create(
+            "input",
+            "\
+:properties:
+:id: fnord
+:end:
+:properties:
+:id: boccob
+:end:
+:properties:
+:id: d321fdddffff
+:end:
+:properties:
+:id: clowns
+:end:
+",
+        );
+        eqnice!(
+            "\
+1:fnord
+4:boccob
+7:d321fdddffff
+10:clowns
+",
+            cmd.args(&[
+                "-nU",
+                "^:properties:\\n:id: (.*)\\n:end:",
+                "-r",
+                "$1",
+                "input",
+            ])
+            .stdout()
+        );
+    }
+);
+
 // See: https://github.com/BurntSushi/ripgrep/issues/1319
 rgtest!(r1319, |dir: Dir, mut cmd: TestCommand| {
     dir.create("input", "CCAGCTACTCGGGAGGCTGAGGCTGGAGGATCGCTTGAGTCCAGGAGTTC");


### PR DESCRIPTION
Fixes #2779.\n\nSummary:\n- Preserve original bytes for replaced printer output so replacement matches can map back to original line numbers.\n- Use original match line numbers for replacement output, while preserving normal line-count behavior for non-replacement multiline output.\n- Add a regression test for adjacent multiline replacements that collapse to one output line each.\n\nTests:\n- cargo test --all