### PR TITLE
core: add --base64 and --base64url flags

### DIFF
--- a/crates/core/base64.rs
+++ b/crates/core/base64.rs
@@ -1,0 +1,285 @@
+/*!
+Enumerate every fixed-string encoding of a literal byte query under a base64
+alphabet.
+
+Base64 packs 8-bit bytes into 6-bit groups, so the same literal can appear in
+encoded output at three different bit offsets (0, 2, or 4 leading bits owned
+by a neighboring byte). For each offset we enumerate the unknown leading and
+trailing bits, encode the resulting padded buffer, and trim the chars that
+cover those unknown bits. The disjunction of all such encodings is what we
+want to search for; we return the literals themselves so callers can feed
+them into ripgrep's fixed-strings path and build an `Hir::alternation` of
+`Hir::literal` directly.
+*/
+
+/// The standard base64 alphabet (RFC 4648 Section 4).
+const STANDARD: &[u8; 64] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// The URL- and filename-safe base64 alphabet (RFC 4648 Section 5).
+const URL_SAFE: &[u8; 64] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+/// Which base64 alphabet to use when generating a search regex.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Alphabet {
+    /// RFC 4648 Section 4 — uses `+/`.
+    Standard,
+    /// RFC 4648 Section 5 — uses `-_` instead of `+/`.
+    UrlSafe,
+}
+
+impl Alphabet {
+    fn table(self) -> &'static [u8; 64] {
+        match self {
+            Alphabet::Standard => STANDARD,
+            Alphabet::UrlSafe => URL_SAFE,
+        }
+    }
+}
+
+/// Expand each pattern in `patterns` into every literal substring its base64
+/// encoding can take, across all 3-byte alignments and all possible
+/// surrounding bits.
+///
+/// The result is intended to be passed as fixed-string patterns to a regex
+/// matcher with `fixed_strings(true)`, which will build an `Hir::alternation`
+/// of `Hir::literal` directly and skip regex parsing entirely.
+pub(crate) fn expand_patterns(
+    alphabet: Alphabet,
+    patterns: Vec<String>,
+) -> Vec<String> {
+    patterns
+        .into_iter()
+        .flat_map(|q| pattern_literals(alphabet, q.as_bytes()))
+        .collect()
+}
+
+/// Returns every literal substring that the encoded form of `query` can take
+/// in a base64 stream, across all 3-byte alignments and all possible
+/// surrounding bits. Each `(offset, lead, trail)` tuple produces a distinct
+/// bit pattern, so the result is naturally free of duplicates.
+///
+/// Returns an empty vector if `query` is empty.
+fn pattern_literals(alphabet: Alphabet, query: &[u8]) -> Vec<String> {
+    if query.is_empty() {
+        return Vec::new();
+    }
+
+    let table = alphabet.table();
+    // Worst case is 1*4 + 4*1 + 16*16 = 264 alternatives (sum of
+    // lead_count * trail_count across offsets 0/1/2), attained when the
+    // query length is 2 mod 3.
+    let mut alternatives: Vec<String> = Vec::with_capacity(264);
+    let mut encoded = String::new();
+    // `+ 3` covers `offset` leading pad bytes (up to 2) plus one trailing
+    // byte appended in the inner loop.
+    let mut padded: Vec<u8> = Vec::with_capacity(query.len() + 3);
+
+    // Each base64 character encodes 6 bits, so the query can start at one of
+    // three bit alignments relative to the encoder's 3-byte groups: 0, 2 or
+    // 4 leading bits owned by a preceding byte.
+    for offset in 0..3usize {
+        let lead_bits = 2 * offset;
+        let lead_count = 1u32 << lead_bits;
+
+        padded.clear();
+        padded.resize(offset, 0);
+        padded.extend_from_slice(query);
+
+        // Number of bits at the tail of the encoding that are owned by a
+        // following byte we haven't placed yet. A value of 6 means the query
+        // ends exactly on a 6-bit boundary, so no trailing byte is needed.
+        let total_bits = padded.len() * 8;
+        let trail_bits = 6 - (total_bits % 6);
+
+        for lead in 0..lead_count {
+            if offset > 0 {
+                // The lead value occupies the least-significant `lead_bits`
+                // bits of the byte immediately before the query.
+                padded[offset - 1] = lead as u8;
+            }
+            if trail_bits < 6 {
+                let trail_count = 1u32 << trail_bits;
+                for trail in 0..trail_count {
+                    // The trail value occupies the most-significant
+                    // `trail_bits` bits of the byte immediately after the
+                    // query.
+                    let tb = (trail as u8) << (8 - trail_bits);
+                    padded.push(tb);
+                    encoded.clear();
+                    encode(table, &padded, &mut encoded);
+                    // Skip the leading chars covered by `lead` and drop the
+                    // trailing char covered by `trail`; what remains is the
+                    // run of characters that `query` actually contributes to
+                    // the output stream at this alignment.
+                    let slice = &encoded[offset..encoded.len() - 1];
+                    alternatives.push(slice.to_string());
+                    padded.pop();
+                }
+            } else {
+                encoded.clear();
+                encode(table, &padded, &mut encoded);
+                // Skip the leading chars covered by `lead`. No trailing
+                // char to drop: the query ends on a 6-bit boundary.
+                alternatives.push(encoded[offset..].to_string());
+            }
+        }
+    }
+
+    alternatives
+}
+
+/// Encode `input` into `out` using raw (unpadded) base64 with the given
+/// 64-byte alphabet table.
+fn encode(table: &[u8; 64], input: &[u8], out: &mut String) {
+    let mut i = 0;
+    while i + 3 <= input.len() {
+        let n = (u32::from(input[i]) << 16)
+            | (u32::from(input[i + 1]) << 8)
+            | u32::from(input[i + 2]);
+        out.push(table[((n >> 18) & 0x3f) as usize] as char);
+        out.push(table[((n >> 12) & 0x3f) as usize] as char);
+        out.push(table[((n >> 6) & 0x3f) as usize] as char);
+        out.push(table[(n & 0x3f) as usize] as char);
+        i += 3;
+    }
+    match input.len() - i {
+        0 => {}
+        1 => {
+            let n = u32::from(input[i]) << 16;
+            out.push(table[((n >> 18) & 0x3f) as usize] as char);
+            out.push(table[((n >> 12) & 0x3f) as usize] as char);
+        }
+        2 => {
+            let n =
+                (u32::from(input[i]) << 16) | (u32::from(input[i + 1]) << 8);
+            out.push(table[((n >> 18) & 0x3f) as usize] as char);
+            out.push(table[((n >> 12) & 0x3f) as usize] as char);
+            out.push(table[((n >> 6) & 0x3f) as usize] as char);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode_string(table: &[u8; 64], input: &[u8]) -> String {
+        let mut s = String::new();
+        encode(table, input, &mut s);
+        s
+    }
+
+    #[test]
+    fn encode_known_answers_standard() {
+        // RFC 4648 test vectors (raw, no padding).
+        assert_eq!(encode_string(STANDARD, b""), "");
+        assert_eq!(encode_string(STANDARD, b"f"), "Zg");
+        assert_eq!(encode_string(STANDARD, b"fo"), "Zm8");
+        assert_eq!(encode_string(STANDARD, b"foo"), "Zm9v");
+        assert_eq!(encode_string(STANDARD, b"foob"), "Zm9vYg");
+        assert_eq!(encode_string(STANDARD, b"fooba"), "Zm9vYmE");
+        assert_eq!(encode_string(STANDARD, b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn encode_url_safe_swaps_chars() {
+        // Bytes that produce `+` and `/` under the standard alphabet must
+        // produce `-` and `_` under the URL-safe alphabet.
+        // 0xfb, 0xff packs to indices 0x3e (`+` / `-`) and 0x3f (`/` / `_`).
+        assert_eq!(encode_string(STANDARD, &[0xfb, 0xff, 0xff]), "+///");
+        assert_eq!(encode_string(URL_SAFE, &[0xfb, 0xff, 0xff]), "-___");
+    }
+
+    #[test]
+    fn empty_query_returns_no_literals() {
+        assert!(pattern_literals(Alphabet::Standard, b"").is_empty());
+        assert!(pattern_literals(Alphabet::UrlSafe, b"").is_empty());
+    }
+
+    #[test]
+    fn aligned_encoding_is_a_literal() {
+        // For a 3-byte query (aligned), the unpadded encoding must be one of
+        // the returned literals.
+        let lits = pattern_literals(Alphabet::Standard, b"foo");
+        assert!(lits.iter().any(|s| s == "Zm9v"), "missing Zm9v in {lits:?}");
+    }
+
+    #[test]
+    fn literals_are_unique() {
+        // The (offset, lead, trail) enumeration is supposed to produce
+        // distinct bit patterns. If a future change breaks that invariant,
+        // we'd silently bloat the matcher with duplicate literals.
+        use std::collections::HashSet;
+        for alphabet in [Alphabet::Standard, Alphabet::UrlSafe] {
+            for q in [&b"a"[..], b"foo", b"hello", b"secret-token-1234"] {
+                let lits = pattern_literals(alphabet, q);
+                let set: HashSet<&String> = lits.iter().collect();
+                assert_eq!(
+                    set.len(),
+                    lits.len(),
+                    "duplicate literals for alphabet={alphabet:?}, \
+                     query={q:?}: produced {} but only {} unique",
+                    lits.len(),
+                    set.len(),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn url_safe_literals_have_no_standard_only_chars() {
+        // URL-safe literals must never contain `+` or `/`.
+        let lits =
+            pattern_literals(Alphabet::UrlSafe, b"any old secret 12345");
+        for lit in &lits {
+            assert!(!lit.contains('+'), "url-safe literal has '+': {lit}");
+            assert!(!lit.contains('/'), "url-safe literal has '/': {lit}");
+        }
+    }
+
+    /// Every encoded instance of the query, at any 3-byte alignment with any
+    /// surrounding bytes, must be matched when the returned literals are fed
+    /// to a regex matcher with `fixed_strings(true)`.
+    #[test]
+    fn matches_every_alignment() {
+        use grep::matcher::Matcher;
+        use grep::regex::RegexMatcherBuilder;
+
+        let queries: &[&[u8]] =
+            &[b"foo", b"hello", b"hi", b"a", b"secret-token-1234"];
+        let prefixes: &[&[u8]] =
+            &[b"", b"\x00", b"\xff", b"\x00\x00", b"\xff\xff"];
+        let suffixes: &[&[u8]] =
+            &[b"", b"\x00", b"\xff", b"\x00\x00", b"\xff\xff"];
+
+        for alphabet in [Alphabet::Standard, Alphabet::UrlSafe] {
+            let table = alphabet.table();
+            for q in queries {
+                let lits = pattern_literals(alphabet, q);
+                let matcher = RegexMatcherBuilder::new()
+                    .fixed_strings(true)
+                    .build_many(&lits)
+                    .unwrap();
+                for p in prefixes {
+                    for s in suffixes {
+                        let mut bytes = Vec::new();
+                        bytes.extend_from_slice(p);
+                        bytes.extend_from_slice(q);
+                        bytes.extend_from_slice(s);
+                        let mut encoded = String::new();
+                        encode(table, &bytes, &mut encoded);
+                        assert!(
+                            matcher.is_match(encoded.as_bytes()).unwrap(),
+                            "matcher did not match {encoded:?} \
+                             (alphabet={alphabet:?}, query={q:?}, \
+                             prefix={p:?}, suffix={s:?})",
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/core/base64.rs
+++ b/crates/core/base64.rs
@@ -71,7 +71,6 @@ fn pattern_literals(alphabet: Alphabet, query: &[u8]) -> Vec<String> {
     // lead_count * trail_count across offsets 0/1/2), attained when the
     // query length is 2 mod 3.
     let mut alternatives: Vec<String> = Vec::with_capacity(264);
-    let mut encoded = String::new();
     // `+ 3` covers `offset` leading pad bytes (up to 2) plus one trailing
     // byte appended in the inner loop.
     let mut padded: Vec<u8> = Vec::with_capacity(query.len() + 3);
@@ -107,21 +106,19 @@ fn pattern_literals(alphabet: Alphabet, query: &[u8]) -> Vec<String> {
                     // query.
                     let tb = (trail as u8) << (8 - trail_bits);
                     padded.push(tb);
-                    encoded.clear();
-                    encode(table, &padded, &mut encoded);
+                    let encoded = encode(table, &padded);
                     // Skip the leading chars covered by `lead` and drop the
                     // trailing char covered by `trail`; what remains is the
                     // run of characters that `query` actually contributes to
                     // the output stream at this alignment.
-                    let slice = &encoded[offset..encoded.len() - 1];
-                    alternatives.push(slice.to_string());
+                    alternatives
+                        .push(encoded[offset..encoded.len() - 1].to_string());
                     padded.pop();
                 }
             } else {
-                encoded.clear();
-                encode(table, &padded, &mut encoded);
                 // Skip the leading chars covered by `lead`. No trailing
                 // char to drop: the query ends on a 6-bit boundary.
+                let encoded = encode(table, &padded);
                 alternatives.push(encoded[offset..].to_string());
             }
         }
@@ -130,58 +127,61 @@ fn pattern_literals(alphabet: Alphabet, query: &[u8]) -> Vec<String> {
     alternatives
 }
 
-/// Encode `input` into `out` using raw (unpadded) base64 with the given
+/// Returns the raw (unpadded) base64 encoding of `input` using the given
 /// 64-byte alphabet table.
-fn encode(table: &[u8; 64], input: &[u8], out: &mut String) {
-    let mut i = 0;
-    while i + 3 <= input.len() {
-        let n = (u32::from(input[i]) << 16)
-            | (u32::from(input[i + 1]) << 8)
-            | u32::from(input[i + 2]);
-        out.push(table[((n >> 18) & 0x3f) as usize] as char);
-        out.push(table[((n >> 12) & 0x3f) as usize] as char);
-        out.push(table[((n >> 6) & 0x3f) as usize] as char);
-        out.push(table[(n & 0x3f) as usize] as char);
-        i += 3;
+fn encode(alphabet: &[u8; 64], bytes: &[u8]) -> String {
+    let mut out = String::new();
+    let mut it = bytes.chunks_exact(3);
+    while let Some(chunk) = it.next() {
+        let group24 = (usize::from(chunk[0]) << 16)
+            | (usize::from(chunk[1]) << 8)
+            | usize::from(chunk[2]);
+        let index1 = (group24 >> 18) & 0b111_111;
+        let index2 = (group24 >> 12) & 0b111_111;
+        let index3 = (group24 >> 6) & 0b111_111;
+        let index4 = (group24 >> 0) & 0b111_111;
+        out.push(char::from(alphabet[index1]));
+        out.push(char::from(alphabet[index2]));
+        out.push(char::from(alphabet[index3]));
+        out.push(char::from(alphabet[index4]));
     }
-    match input.len() - i {
-        0 => {}
-        1 => {
-            let n = u32::from(input[i]) << 16;
-            out.push(table[((n >> 18) & 0x3f) as usize] as char);
-            out.push(table[((n >> 12) & 0x3f) as usize] as char);
+    match it.remainder() {
+        &[] => {}
+        &[byte0] => {
+            let group8 = usize::from(byte0);
+            let index1 = (group8 >> 2) & 0b111_111;
+            let index2 = (group8 << 4) & 0b111_111;
+            out.push(char::from(alphabet[index1]));
+            out.push(char::from(alphabet[index2]));
         }
-        2 => {
-            let n =
-                (u32::from(input[i]) << 16) | (u32::from(input[i + 1]) << 8);
-            out.push(table[((n >> 18) & 0x3f) as usize] as char);
-            out.push(table[((n >> 12) & 0x3f) as usize] as char);
-            out.push(table[((n >> 6) & 0x3f) as usize] as char);
+        &[byte0, byte1] => {
+            let group16 = (usize::from(byte0) << 8) | usize::from(byte1);
+            let index1 = (group16 >> 10) & 0b111_111;
+            let index2 = (group16 >> 4) & 0b111_111;
+            let index3 = (group16 << 2) & 0b111_111;
+            out.push(char::from(alphabet[index1]));
+            out.push(char::from(alphabet[index2]));
+            out.push(char::from(alphabet[index3]));
         }
-        _ => unreachable!(),
+        _ => unreachable!("remainder must have length < 3"),
     }
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn encode_string(table: &[u8; 64], input: &[u8]) -> String {
-        let mut s = String::new();
-        encode(table, input, &mut s);
-        s
-    }
-
     #[test]
     fn encode_known_answers_standard() {
         // RFC 4648 test vectors (raw, no padding).
-        assert_eq!(encode_string(STANDARD, b""), "");
-        assert_eq!(encode_string(STANDARD, b"f"), "Zg");
-        assert_eq!(encode_string(STANDARD, b"fo"), "Zm8");
-        assert_eq!(encode_string(STANDARD, b"foo"), "Zm9v");
-        assert_eq!(encode_string(STANDARD, b"foob"), "Zm9vYg");
-        assert_eq!(encode_string(STANDARD, b"fooba"), "Zm9vYmE");
-        assert_eq!(encode_string(STANDARD, b"foobar"), "Zm9vYmFy");
+        assert_eq!(encode(STANDARD, b""), "");
+        assert_eq!(encode(STANDARD, b"f"), "Zg");
+        assert_eq!(encode(STANDARD, b"fo"), "Zm8");
+        assert_eq!(encode(STANDARD, b"foo"), "Zm9v");
+        assert_eq!(encode(STANDARD, b"foob"), "Zm9vYg");
+        assert_eq!(encode(STANDARD, b"fooba"), "Zm9vYmE");
+        assert_eq!(encode(STANDARD, b"foobar"), "Zm9vYmFy");
     }
 
     #[test]
@@ -189,8 +189,8 @@ mod tests {
         // Bytes that produce `+` and `/` under the standard alphabet must
         // produce `-` and `_` under the URL-safe alphabet.
         // 0xfb, 0xff packs to indices 0x3e (`+` / `-`) and 0x3f (`/` / `_`).
-        assert_eq!(encode_string(STANDARD, &[0xfb, 0xff, 0xff]), "+///");
-        assert_eq!(encode_string(URL_SAFE, &[0xfb, 0xff, 0xff]), "-___");
+        assert_eq!(encode(STANDARD, &[0xfb, 0xff, 0xff]), "+///");
+        assert_eq!(encode(URL_SAFE, &[0xfb, 0xff, 0xff]), "-___");
     }
 
     #[test]
@@ -269,8 +269,7 @@ mod tests {
                         bytes.extend_from_slice(p);
                         bytes.extend_from_slice(q);
                         bytes.extend_from_slice(s);
-                        let mut encoded = String::new();
-                        encode(table, &bytes, &mut encoded);
+                        let encoded = encode(table, &bytes);
                         assert!(
                             matcher.is_match(encoded.as_bytes()).unwrap(),
                             "matcher did not match {encoded:?} \

--- a/crates/core/flags/complete/rg.zsh
+++ b/crates/core/flags/complete/rg.zsh
@@ -45,6 +45,12 @@ _rg() {
     '(: * -)'{-V,--version}'[display version information]'
     '(: * -)'--pcre2-version'[print the version of PCRE2 used by ripgrep, if available]'
 
+    + '(base64)' # Base64-encoded pattern options
+    '--base64[search for base64-encoded patterns]'
+    $no"--no-base64[disable base64-encoded pattern search]"
+    '--base64url[search for URL-safe base64-encoded patterns]'
+    $no"--no-base64url[disable URL-safe base64-encoded pattern search]"
+
     + '(buffered)' # buffering options
     '--line-buffered[force line buffering]'
     $no"--no-line-buffered[don't force line buffering]"

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -24,10 +24,10 @@ use {anyhow::Context as AnyhowContext, bstr::ByteVec};
 use crate::flags::{
     Category, Flag, FlagValue,
     lowargs::{
-        BinaryMode, BoundaryMode, BufferMode, CaseMode, ColorChoice,
-        ContextMode, EncodingMode, EngineChoice, GenerateMode, LoggingMode,
-        LowArgs, MmapMode, Mode, PatternSource, SearchMode, SortMode,
-        SortModeKind, SpecialMode, TypeChange,
+        Base64Mode, BinaryMode, BoundaryMode, BufferMode, CaseMode,
+        ColorChoice, ContextMode, EncodingMode, EngineChoice, GenerateMode,
+        LoggingMode, LowArgs, MmapMode, Mode, PatternSource, SearchMode,
+        SortMode, SortModeKind, SpecialMode, TypeChange,
     },
 };
 
@@ -47,6 +47,8 @@ pub(super) const FLAGS: &[&dyn Flag] = &[
     &Regexp,
     &File,
     &AfterContext,
+    &Base64,
+    &Base64Url,
     &BeforeContext,
     &Binary,
     &BlockBuffered,
@@ -334,6 +336,142 @@ fn test_auto_hybrid_regex() {
     let args =
         parse_low_raw(["--auto-hybrid-regex", "--engine=default"]).unwrap();
     assert_eq!(EngineChoice::Default, args.engine);
+}
+
+/// --base64
+#[derive(Debug)]
+struct Base64;
+
+impl Flag for Base64 {
+    fn is_switch(&self) -> bool {
+        true
+    }
+    fn name_long(&self) -> &'static str {
+        "base64"
+    }
+    fn name_negated(&self) -> Option<&'static str> {
+        Some("no-base64")
+    }
+    fn doc_category(&self) -> Category {
+        Category::Search
+    }
+    fn doc_short(&self) -> &'static str {
+        r"Search for base64-encoded patterns."
+    }
+    fn doc_long(&self) -> &'static str {
+        r"
+When this flag is set, each pattern is treated as a literal byte string and is
+transformed into a regex that matches any base64 encoding of that string,
+using the standard alphabet defined in RFC 4648 (with \fB+\fP and \fB/\fP). This is useful for searching for
+credentials, tokens or other literal byte sequences that may be embedded
+inside base64-encoded blobs such as JWTs, JSON payloads, certificates or
+environment dumps.
+.sp
+Because base64 packs 8-bit bytes into 6-bit groups, the same literal can
+appear in encoded output at three different bit offsets depending on what
+bytes surround it. The generated regex enumerates every such alignment, so a
+match will be found regardless of where the literal sits relative to the
+encoder's 3-byte boundary.
+.sp
+This flag implies \flag{fixed-strings}: each pattern is read as a literal
+byte string and the expanded encodings are then matched as literals. Combining
+\flag{base64} with \flag{ignore-case} or \flag{word-regexp} is usually not
+meaningful, since base64 is case-sensitive and word boundaries do not align
+with encoded data.
+.sp
+This flag overrides \flag{base64url}.
+"
+    }
+
+    fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
+        args.base64 = if v.unwrap_switch() {
+            Base64Mode::Standard
+        } else {
+            Base64Mode::Off
+        };
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_base64() {
+    let args = parse_low_raw(None::<&str>).unwrap();
+    assert_eq!(Base64Mode::Off, args.base64);
+
+    let args = parse_low_raw(["--base64"]).unwrap();
+    assert_eq!(Base64Mode::Standard, args.base64);
+
+    let args = parse_low_raw(["--base64", "--no-base64"]).unwrap();
+    assert_eq!(Base64Mode::Off, args.base64);
+
+    let args = parse_low_raw(["--no-base64", "--base64"]).unwrap();
+    assert_eq!(Base64Mode::Standard, args.base64);
+
+    let args = parse_low_raw(["--base64url", "--base64"]).unwrap();
+    assert_eq!(Base64Mode::Standard, args.base64);
+}
+
+/// --base64url
+#[derive(Debug)]
+struct Base64Url;
+
+impl Flag for Base64Url {
+    fn is_switch(&self) -> bool {
+        true
+    }
+    fn name_long(&self) -> &'static str {
+        "base64url"
+    }
+    fn name_negated(&self) -> Option<&'static str> {
+        Some("no-base64url")
+    }
+    fn doc_category(&self) -> Category {
+        Category::Search
+    }
+    fn doc_short(&self) -> &'static str {
+        r"Search for URL-safe base64-encoded patterns."
+    }
+    fn doc_long(&self) -> &'static str {
+        r"
+Like \flag{base64}, but uses the URL- and filename-safe alphabet from RFC
+4648 (\fB-\fP and \fB_\fP instead of \fB+\fP and \fB/\fP). This variant is
+what appears in JSON Web Tokens (JWTs), OIDC ID tokens, signed URLs, S3
+pre-signed requests and other contexts where the encoded data needs to
+survive a URL or file path without escaping.
+.sp
+See \flag{base64} for the full description of how the rewritten regex is
+built.
+.sp
+This flag overrides \flag{base64}.
+"
+    }
+
+    fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
+        args.base64 = if v.unwrap_switch() {
+            Base64Mode::UrlSafe
+        } else {
+            Base64Mode::Off
+        };
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_base64url() {
+    let args = parse_low_raw(None::<&str>).unwrap();
+    assert_eq!(Base64Mode::Off, args.base64);
+
+    let args = parse_low_raw(["--base64url"]).unwrap();
+    assert_eq!(Base64Mode::UrlSafe, args.base64);
+
+    let args = parse_low_raw(["--base64url", "--no-base64url"]).unwrap();
+    assert_eq!(Base64Mode::Off, args.base64);
+
+    // The two flags override each other; last one wins.
+    let args = parse_low_raw(["--base64", "--base64url"]).unwrap();
+    assert_eq!(Base64Mode::UrlSafe, args.base64);
 }
 
 /// -B/--before-context

--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -13,6 +13,7 @@ use {
 };
 
 use crate::{
+    base64,
     flags::lowargs::{
         BinaryMode, BoundaryMode, BufferMode, CaseMode, ColorChoice,
         ContextMode, ContextSeparator, EncodingMode, EngineChoice,
@@ -141,6 +142,22 @@ impl HiArgs {
 
         let mut state = State::new()?;
         let patterns = Patterns::from_low_args(&mut state, &mut low)?;
+        // --base64 / --base64url reinterprets each pattern as a literal byte
+        // string and expands it into the set of literal substrings its
+        // base64-encoded form can take across every 3-byte alignment. This
+        // also implies -F/--fixed-strings.
+        let (patterns, fixed_strings) = match low.base64.alphabet() {
+            None => (patterns, low.fixed_strings),
+            Some(alphabet) => (
+                Patterns {
+                    patterns: base64::expand_patterns(
+                        alphabet,
+                        patterns.patterns,
+                    ),
+                },
+                true,
+            ),
+        };
         let paths = Paths::from_low_args(&mut state, &patterns, &mut low)?;
 
         let binary = BinaryDetection::from_low_args(&state, &low);
@@ -270,7 +287,7 @@ impl HiArgs {
             field_context_separator: low.field_context_separator,
             field_match_separator: low.field_match_separator,
             file_separator,
-            fixed_strings: low.fixed_strings,
+            fixed_strings,
             follow: low.follow,
             heading,
             hidden: low.hidden,

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -37,6 +37,7 @@ pub(crate) struct LowArgs {
     pub(crate) positional: Vec<OsString>,
     pub(crate) patterns: Vec<PatternSource>,
     // Everything else, sorted lexicographically.
+    pub(crate) base64: Base64Mode,
     pub(crate) binary: BinaryMode,
     pub(crate) boundary: Option<BoundaryMode>,
     pub(crate) buffer: BufferMode,
@@ -226,6 +227,34 @@ pub(crate) enum GenerateMode {
     CompleteFish,
     /// Completions for PowerShell.
     CompletePowerShell,
+}
+
+/// Indicates whether patterns should be rewritten to match a base64 encoding
+/// of the literal, and if so, which alphabet to use.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) enum Base64Mode {
+    /// Patterns are used as-is.
+    #[default]
+    Off,
+    /// Patterns are rewritten to match any base64 encoding (RFC 4648
+    /// Section 4, standard alphabet `+/`) of their literal byte contents.
+    Standard,
+    /// Patterns are rewritten to match any base64 encoding (RFC 4648
+    /// Section 5, URL- and filename-safe alphabet `-_`) of their literal
+    /// byte contents.
+    UrlSafe,
+}
+
+impl Base64Mode {
+    /// Returns the base64 alphabet implied by this mode, or `None` if base64
+    /// rewriting is disabled.
+    pub(crate) fn alphabet(self) -> Option<crate::base64::Alphabet> {
+        match self {
+            Base64Mode::Off => None,
+            Base64Mode::Standard => Some(crate::base64::Alphabet::Standard),
+            Base64Mode::UrlSafe => Some(crate::base64::Alphabet::UrlSafe),
+        }
+    }
 }
 
 /// Indicates how ripgrep should treat binary data.

--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -11,6 +11,7 @@ use crate::flags::{HiArgs, SearchMode};
 #[macro_use]
 mod messages;
 
+mod base64;
 mod flags;
 mod haystack;
 mod logger;


### PR DESCRIPTION
This feature allows you to search for strings in base64 or base64url-encoded data, for example leaked credentials:

> $ rg admin --base64    
> coredns/plugin/test/file.go
> 53:AwwKa3ViZS**1hZG1pbj**CCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMTw

It works by adding all possible patterns (with all lead/trail bytes) to the patterns list, before passing it to the engine. Setting any of the options implies `--fixed-strings`:

- `--base64` uses the standard alphabet (RFC 4648, +/)
- `--base64url` uses the URL- and filename-safe alphabet (RFC 4648, -_)

(The difference between the two really only appears when searching for text with many bits set, eg. `"?"`.)

Disclaimer: the original prototype was written by me by hand in Golang, but I've used Claude Code to help me ramp up on the ripgrep codebase and its use of Rust idioms. In particular, it wrote the base64-encoder, instead of adding a new dep on the `base64` crate.

There's room for improvement: when searching for a string, the generated patterns will contain the variants that are preceded by 1 and by 2 bytes (2 resp. 4 trailing bits), but the final (fixed-string) patterns do not require any prefix. Because of this, short search strings (length≤2) will have many false positives.

By the way, the existing `fn base64_standard` could not be reused, because it pads the result with `=`, which we don't want here. There's some dedup options, but not worth it IMHO. 