### PR TITLE
feat: support RIPGREP_THREADS environment variable

### DIFF
--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -6734,6 +6734,11 @@ impl Flag for Threads {
 This flag sets the approximate number of threads to use. A value of \fB0\fP
 (which is the default) causes ripgrep to choose the thread count using
 heuristics.
+
+Setting the \fBRIPGREP_THREADS\fP environment variable has the same effect as
+passing this flag when \fB--threads\fP is not explicitly set on the command
+line. A value of \fB0\fP in the environment variable also selects the default
+heuristic thread count.
 "
     }
 

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -6734,7 +6734,6 @@ impl Flag for Threads {
 This flag sets the approximate number of threads to use. A value of \fB0\fP
 (which is the default) causes ripgrep to choose the thread count using
 heuristics.
-
 Setting the \fBRIPGREP_THREADS\fP environment variable has the same effect as
 passing this flag when \fB--threads\fP is not explicitly set on the command
 line. A value of \fB0\fP in the environment variable also selects the default

--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -7,6 +7,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use anyhow::Context;
+
 use {
     bstr::BString,
     grep::printer::{ColorSpecs, SummaryKind},
@@ -105,6 +107,21 @@ pub(crate) struct HiArgs {
     with_filename: bool,
 }
 
+fn default_thread_count() -> usize {
+    std::thread::available_parallelism().map_or(1, |n| n.get()).min(12)
+}
+
+fn threads_from_env() -> anyhow::Result<Option<usize>> {
+    let Some(raw) = std::env::var_os("RIPGREP_THREADS") else {
+        return Ok(None);
+    };
+    let raw = raw.to_string_lossy();
+    let threads = raw.parse::<usize>().with_context(|| {
+        format!("invalid RIPGREP_THREADS value: {raw:?}")
+    })?;
+    Ok(if threads == 0 { None } else { Some(threads) })
+}
+
 impl HiArgs {
     /// Convert low level arguments into high level arguments.
     ///
@@ -165,12 +182,19 @@ impl HiArgs {
         };
         let path_terminator = if low.null { Some(b'\x00') } else { None };
         let quit_after_match = stats.is_none() && low.quiet;
+        let env_threads = if low.threads.is_none() {
+            threads_from_env()?
+        } else {
+            None
+        };
         let threads = if low.sort.is_some() || paths.is_one_file {
             1
         } else if let Some(threads) = low.threads {
             threads
+        } else if let Some(threads) = env_threads {
+            threads
         } else {
-            std::thread::available_parallelism().map_or(1, |n| n.get()).min(12)
+            default_thread_count()
         };
         log::debug!("using {threads} thread(s)");
         let with_filename = low

--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -116,9 +116,9 @@ fn threads_from_env() -> anyhow::Result<Option<usize>> {
         return Ok(None);
     };
     let raw = raw.to_string_lossy();
-    let threads = raw.parse::<usize>().with_context(|| {
-        format!("invalid RIPGREP_THREADS value: {raw:?}")
-    })?;
+    let threads = raw
+        .parse::<usize>()
+        .with_context(|| format!("invalid RIPGREP_THREADS value: {raw:?}"))?;
     Ok(if threads == 0 { None } else { Some(threads) })
 }
 
@@ -182,11 +182,8 @@ impl HiArgs {
         };
         let path_terminator = if low.null { Some(b'\x00') } else { None };
         let quit_after_match = stats.is_none() && low.quiet;
-        let env_threads = if low.threads.is_none() {
-            threads_from_env()?
-        } else {
-            None
-        };
+        let env_threads =
+            if low.threads.is_none() { threads_from_env()? } else { None };
         let threads = if low.sort.is_some() || paths.is_one_file {
             1
         } else if let Some(threads) = low.threads {

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -627,21 +627,27 @@ rgtest!(f3317_ripgrep_threads_env, |dir: Dir, mut cmd: TestCommand| {
 });
 
 // See: https://github.com/BurntSushi/ripgrep/issues/3317
-rgtest!(f3317_ripgrep_threads_env_invalid, |dir: Dir, mut cmd: TestCommand| {
-    dir.create("a", "needle");
-    dir.create("b", "needle");
-    cmd.cmd().env("RIPGREP_THREADS", "nope");
-    cmd.arg("needle").arg(".");
-    cmd.assert_exit_code(2);
-});
+rgtest!(
+    f3317_ripgrep_threads_env_invalid,
+    |dir: Dir, mut cmd: TestCommand| {
+        dir.create("a", "needle");
+        dir.create("b", "needle");
+        cmd.cmd().env("RIPGREP_THREADS", "nope");
+        cmd.arg("needle").arg(".");
+        cmd.assert_exit_code(2);
+    }
+);
 
 // See: https://github.com/BurntSushi/ripgrep/issues/3317
-rgtest!(f3317_ripgrep_threads_cli_overrides_env, |dir: Dir, mut cmd: TestCommand| {
-    dir.create("file", "needle");
-    cmd.cmd().env("RIPGREP_THREADS", "nope");
-    cmd.arg("--threads").arg("1").arg("needle").arg("file");
-    cmd.assert_exit_code(0);
-});
+rgtest!(
+    f3317_ripgrep_threads_cli_overrides_env,
+    |dir: Dir, mut cmd: TestCommand| {
+        dir.create("file", "needle");
+        cmd.cmd().env("RIPGREP_THREADS", "nope");
+        cmd.arg("--threads").arg("1").arg("needle").arg("file");
+        cmd.assert_exit_code(0);
+    }
+);
 
 // See: https://github.com/BurntSushi/ripgrep/issues/917
 rgtest!(f917_trim, |dir: Dir, mut cmd: TestCommand| {

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -618,6 +618,31 @@ rgtest!(f948_exit_code_error, |dir: Dir, mut cmd: TestCommand| {
     cmd.assert_exit_code(2);
 });
 
+// See: https://github.com/BurntSushi/ripgrep/issues/3317
+rgtest!(f3317_ripgrep_threads_env, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("file", "needle haystack");
+    cmd.cmd().env("RIPGREP_THREADS", "1");
+    cmd.arg("needle").arg("file");
+    cmd.assert_exit_code(0);
+});
+
+// See: https://github.com/BurntSushi/ripgrep/issues/3317
+rgtest!(f3317_ripgrep_threads_env_invalid, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("a", "needle");
+    dir.create("b", "needle");
+    cmd.cmd().env("RIPGREP_THREADS", "nope");
+    cmd.arg("needle").arg(".");
+    cmd.assert_exit_code(2);
+});
+
+// See: https://github.com/BurntSushi/ripgrep/issues/3317
+rgtest!(f3317_ripgrep_threads_cli_overrides_env, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("file", "needle");
+    cmd.cmd().env("RIPGREP_THREADS", "nope");
+    cmd.arg("--threads").arg("1").arg("needle").arg("file");
+    cmd.assert_exit_code(0);
+});
+
 // See: https://github.com/BurntSushi/ripgrep/issues/917
 rgtest!(f917_trim, |dir: Dir, mut cmd: TestCommand| {
     const SHERLOCK: &'static str = "\


### PR DESCRIPTION
## Summary
- Add `RIPGREP_THREADS` to set a default thread count when `-j`/`--threads` is not passed
- `0` in the environment variable keeps the existing heuristic default
- `--threads` on the command line takes precedence and ignores invalid env values
- Document the variable in the `--threads` flag help text

Fixes #3317

## Test plan
- [x] `cargo test -p ripgrep f3317`
- [x] `cargo test -p ripgrep test_threads`