### PR TITLE
fix(cli): ignore decompressor errors after stdout is consumed (fixes #3382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Unreleased changes. Release notes have not yet been written.
 
 Bug fixes:
 
+* [BUG #3382](https://github.com/BurntSushi/ripgrep/issues/3382):
+  Ignore failing exit statuses from decompressors after their stdout has been
+  fully consumed, so truncated compressed files can still be searched and
+  counted.
+
 * [BUG #3212](https://github.com/BurntSushi/ripgrep/pull/3212):
   Don't check for the existence of `.jj` when `--no-ignore` is used.
 

--- a/crates/cli/src/process.rs
+++ b/crates/cli/src/process.rs
@@ -114,7 +114,7 @@ impl CommandReaderBuilder {
         } else {
             StderrReader::sync(child.stderr.take().unwrap())
         };
-        Ok(CommandReader { child, stderr, eof: false })
+        Ok(CommandReader { child, stderr, eof: false, read_any: false })
     }
 
     /// When enabled, the reader will asynchronously read the contents of the
@@ -175,6 +175,8 @@ pub struct CommandReader {
     /// set and we close the reader, then we anticipate a pipe error when
     /// reaping the child process and silence it.
     eof: bool,
+    /// Whether any bytes were read from the child's stdout.
+    read_any: bool,
 }
 
 impl CommandReader {
@@ -228,14 +230,11 @@ impl CommandReader {
             Ok(())
         } else {
             let err = self.stderr.read_to_end();
-            // In the specific case where we haven't consumed the full data
-            // from the child process, then closing stdout above results in
-            // a pipe signal being thrown in most cases. But I don't think
-            // there is any reliable and portable way of detecting it. Instead,
-            // if we know we haven't hit EOF (so we anticipate a broken pipe
-            // error) and if stderr otherwise doesn't have anything on it, then
-            // we assume total success.
-            if !self.eof && err.is_empty() {
+            // If stdout was exhausted, treat a failing exit status from the
+            // child as non-fatal when we got useful output. Some decompressors
+            // (notably zstd) exit with an error after reporting a truncated
+            // frame even though all available output was produced.
+            if (self.eof && self.read_any) || (!self.eof && err.is_empty()) {
                 return Ok(());
             }
             Err(io::Error::from(err))
@@ -258,6 +257,9 @@ impl io::Read for CommandReader {
             Some(ref mut stdout) => stdout,
         };
         let nread = stdout.read(buf)?;
+        if nread > 0 {
+            self.read_any = true;
+        }
         if nread == 0 {
             self.eof = true;
             self.close().map(|_| 0)

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -982,6 +982,38 @@ be, to a very large extent, the result of luck. Sherlock Holmes
     eqnice!(expected, cmd.stdout());
 });
 
+rgtest!(compressed_zstd_truncated_count, |dir: Dir, mut cmd: TestCommand| {
+    use std::process::Command;
+
+    if !cmd_exists("zstd") {
+        return;
+    }
+
+    dir.create("needle.txt", "aardvarks\nline two\n");
+    let zst_path = dir.path().join("trunc.zst");
+    let txt_path = dir.path().join("needle.txt");
+    let status = Command::new("zstd")
+        .arg("-f")
+        .arg("-q")
+        .arg(&txt_path)
+        .arg("-o")
+        .arg(&zst_path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let mut bytes = std::fs::read(&zst_path).unwrap();
+    bytes.truncate(bytes.len().saturating_sub(4));
+    std::fs::write(&zst_path, bytes).unwrap();
+
+    cmd.arg("-z")
+        .arg("-c")
+        .arg("aardvarks")
+        .arg("trunc.zst")
+        .arg("--no-messages");
+    assert_eq!("1\n", cmd.stdout());
+});
+
 rgtest!(compressed_uncompress, |dir: Dir, mut cmd: TestCommand| {
     if !cmd_exists("uncompress") {
         return;


### PR DESCRIPTION
## Summary

When searching compressed files with `-z`, some decompressors (notably `zstd`) exit with a non-zero status after reporting a truncated frame, even after emitting all recoverable output. ripgrep previously treated this as a hard failure in `CommandReader::close`, which caused:

- `rg -zc` to print nothing for truncated `.zst` files with matches
- parallel `-z` searches over multiple truncated files to drop results

This change treats a failing child exit status as non-fatal once stdout has been fully consumed **and** at least one byte was read. Invalid compressed files that produce no output still surface an error.

Fixes #3382

## Test plan

- [x] `cargo test --test integration` — 321 passed
- [x] Added `compressed_zstd_truncated_count` integration test
- [x] Existing `compressed_failing_gzip` regression test still passes

Made with [Cursor](https://cursor.com)