### PR TITLE
fix(core): avoid panic when stdout pipe is closed on Windows (fixes #3372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Unreleased changes. Release notes have not yet been written.
 
 Bug fixes:
 
+* [BUG #3372](https://github.com/BurntSushi/ripgrep/issues/3372):
+  Avoid panicking on Windows when emitting error messages while stdout's pipe
+  is closed.
+
 * [BUG #3212](https://github.com/BurntSushi/ripgrep/pull/3212):
   Don't check for the existence of `.jj` when `--no-ignore` is used.
 

--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -54,7 +54,7 @@ fn main() -> ExitCode {
             // terminate.
             for cause in err.chain() {
                 if let Some(ioerr) = cause.downcast_ref::<std::io::Error>() {
-                    if ioerr.kind() == std::io::ErrorKind::BrokenPipe {
+                    if messages::is_output_pipe_closed(ioerr) {
                         return ExitCode::from(0);
                     }
                 }

--- a/crates/core/messages.rs
+++ b/crates/core/messages.rs
@@ -15,6 +15,7 @@ indicating that at least one error occurred. When ripgrep exits, this flag is
 consulted to determine what the exit status ought to be.
 */
 
+use std::io::{IsTerminal, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// When false, "messages" will not be printed.
@@ -24,6 +25,56 @@ static IGNORE_MESSAGES: AtomicBool = AtomicBool::new(false);
 /// Flipped to true when an error message is printed.
 static ERRORED: AtomicBool = AtomicBool::new(false);
 
+/// Returns true when an I/O error indicates that an output pipe was closed.
+///
+/// On Windows, a closed pipe may surface as `ERROR_NO_DATA` (os error 232)
+/// instead of `ErrorKind::BrokenPipe`.
+pub(crate) fn is_output_pipe_closed(err: &std::io::Error) -> bool {
+    if err.kind() == std::io::ErrorKind::BrokenPipe {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        if err.raw_os_error() == Some(232) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Writes a single `rg: ...` line to stderr.
+///
+/// When stdout is a TTY, stdout is locked first to avoid interleaving with
+/// search output. When stdout is not a TTY, locking stdout is skipped so that
+/// error messages can still be emitted when stdout's pipe has been closed.
+pub(crate) fn write_locked_message(message: &str) {
+    let write_message =
+        |stderr: &mut std::io::StderrLock<'_>| -> std::io::Result<()> {
+            write!(stderr, "rg: ")?;
+            writeln!(stderr, "{message}")?;
+            Ok(())
+        };
+    if std::io::stdout().is_terminal() {
+        let stdout = std::io::stdout().lock();
+        let mut stderr = std::io::stderr().lock();
+        if let Err(err) = write_message(&mut stderr) {
+            if is_output_pipe_closed(&err) {
+                std::process::exit(0);
+            }
+            std::process::exit(2);
+        }
+        drop(stdout);
+    } else {
+        let mut stderr = std::io::stderr().lock();
+        if let Err(err) = write_message(&mut stderr) {
+            if is_output_pipe_closed(&err) {
+                std::process::exit(0);
+            }
+            std::process::exit(2);
+        }
+    }
+}
+
 /// Like eprintln, but locks stdout to prevent interleaving lines.
 ///
 /// This locks stdout, not stderr, even though this prints to stderr. This
@@ -32,37 +83,7 @@ static ERRORED: AtomicBool = AtomicBool::new(false);
 #[macro_export]
 macro_rules! eprintln_locked {
     ($($tt:tt)*) => {{
-        {
-            use std::io::Write;
-
-            // This is a bit of an abstraction violation because we explicitly
-            // lock stdout before printing to stderr. This avoids interleaving
-            // lines within ripgrep because `search_parallel` uses `termcolor`,
-            // which accesses the same stdout lock when writing lines.
-            let stdout = std::io::stdout().lock();
-            let mut stderr = std::io::stderr().lock();
-            // We specifically ignore any errors here. One plausible error we
-            // can get in some cases is a broken pipe error. And when that
-            // occurs, we should exit gracefully. Otherwise, just abort with
-            // an error code because there isn't much else we can do.
-            //
-            // See: https://github.com/BurntSushi/ripgrep/issues/1966
-            if let Err(err) = write!(stderr, "rg: ") {
-                if err.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                } else {
-                    std::process::exit(2);
-                }
-            }
-            if let Err(err) = writeln!(stderr, $($tt)*) {
-                if err.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                } else {
-                    std::process::exit(2);
-                }
-            }
-            drop(stdout);
-        }
+        $crate::messages::write_locked_message(&format!($($tt)*));
     }}
 }
 


### PR DESCRIPTION
## Summary

Fixes #3372.

On Windows cmd.exe, `eza --help | rg` (with no search pattern) panicked while printing the expected usage error:

```
failed printing to stdout: The pipe is being closed. (os error 232)
```

`eprintln_locked!` always locked stdout before writing to stderr to avoid interleaving with search output. When stdout is piped and the downstream reader has closed the pipe, dropping the stdout lock can panic on Windows.

## Changes

- Only lock stdout when it is a TTY (when interleaving avoidance is actually needed)
- Add `is_output_pipe_closed` helper that treats Windows os error 232 as a closed pipe
- Use the helper in `main`'s top-level error handler

## Test plan

- [x] `cargo test --test integration` (320 passed)
- [ ] Manual: on Windows cmd.exe, `eza --help | rg` should print the missing-pattern error and exit 2 without panicking

Made with [Cursor](https://cursor.com)