### PR TITLE
ci: add support for `aarch64-unknown-linux-musl`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
           os: ubuntu-latest
           rust: stable
           target: aarch64-unknown-linux-gnu
+        - build: stable-aarch64-musl
+          os: ubuntu-latest
+          rust: stable
+          target: aarch64-unknown-linux-musl
         - build: stable-arm-gnueabihf
           os: ubuntu-latest
           rust: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,12 @@ jobs:
           target: aarch64-unknown-linux-gnu
           strip: aarch64-linux-gnu-strip
           qemu: qemu-aarch64
+        - build: stable-aarch64-musl
+          os: ubuntu-latest
+          rust: stable
+          target: aarch64-unknown-linux-musl
+          strip: aarch64-linux-musl-strip
+          qemu: qemu-aarch64
         - build: stable-arm-gnueabihf
           os: ubuntu-latest
           rust: stable


### PR DESCRIPTION
This includes running tests and binary artifacts.

Fixes #2739
