### PR TITLE
Support -tproto for filtering to protobuf files

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -212,7 +212,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["pod"], &["*.pod"]),
     (&["postscript"], &["*.eps", "*.ps"]),
     (&["prolog"], &["*.pl", "*.pro", "*.prolog", "*.P"]),
-    (&["protobuf"], &["*.proto"]),
+    (&["protobuf", "proto"], &["*.proto"]),
     (&["ps"], &["*.cdxml", "*.ps1", "*.ps1xml", "*.psd1", "*.psm1"]),
     (&["puppet"], &["*.epp", "*.erb", "*.pp", "*.rb"]),
     (&["purs"], &["*.purs"]),


### PR DESCRIPTION
Hello!

This is a pretty simple update, I've just wanted to be able to search over protobuf files with the `-tproto` shorthand rather than `-tprotobuf`. This PR adds support for that. 

I tested locally with the following commands: 

```sh
$ tmp="$(mktemp -d)"
$ printf 'needle\n' > "$tmp/schema.proto"
$ printf 'needle\n' > "$tmp/schema.txt"

$ cargo run -- -tproto needle "$tmp"
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/rg -tproto needle /var/folders/fc/k3chjv0d7w50hlcn7mw9fsk80000gn/T/tmp.gPYZQBYSA0`
/var/folders/fc/k3chjv0d7w50hlcn7mw9fsk80000gn/T/tmp.gPYZQBYSA0/schema.proto
1:needle
```