### PR TITLE
fix(types): use BTreeMap instead of HashMap for deterministic ordering

### DIFF
--- a/crates/ignore/src/types.rs
+++ b/crates/ignore/src/types.rs
@@ -84,7 +84,7 @@ assert!(matcher.matched("y.cpp", false).is_whitelist());
 ```
 */
 
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 use {
     globset::{GlobBuilder, GlobSet, GlobSetBuilder},
@@ -303,7 +303,7 @@ impl Types {
 /// TypesBuilder builds a type matcher from a set of file type definitions and
 /// a set of file type selections.
 pub struct TypesBuilder {
-    types: HashMap<String, FileTypeDef>,
+    types: BTreeMap<String, FileTypeDef>,
     selections: Vec<Selection<()>>,
 }
 
@@ -314,7 +314,7 @@ impl TypesBuilder {
     /// of default type definitions can be added with `add_defaults`, and
     /// additional type definitions can be added with `select` and `negate`.
     pub fn new() -> TypesBuilder {
-        TypesBuilder { types: HashMap::new(), selections: vec![] }
+        TypesBuilder { types: BTreeMap::new(), selections: vec![] }
     }
 
     /// Build the current set of file type definitions *and* selections into
@@ -371,7 +371,6 @@ impl TypesBuilder {
             def.globs.sort();
             defs.push(def);
         }
-        defs.sort_by(|def1, def2| def1.name().cmp(def2.name()));
         defs
     }
 

--- a/crates/ignore/src/types.rs
+++ b/crates/ignore/src/types.rs
@@ -580,4 +580,21 @@ mod tests {
             assert_eq!(btypes.definitions(), original_defs);
         }
     }
+    #[test]
+    fn test_deterministic_order() {
+        // Verify that building types produces the same order
+        // regardless of HashMap iteration quirks. BTreeMap
+        // guarantees deterministic ordering by name.
+        let mut btypes = TypesBuilder::new();
+        for tydef in types() {
+            btypes.add_def(tydef).unwrap();
+        }
+        let _ = btypes.build().unwrap();
+        let defs = btypes.definitions();
+        let names: Vec<&str> = defs.iter().map(|d| d.name()).collect();
+        assert_eq!(names, vec![
+            "combo", "foo", "html", "js", "py", "python", "rust",
+        ]);
+    }
+
 }


### PR DESCRIPTION
Replace `HashMap` with `BTreeMap` in `TypesBuilder` to ensure deterministic iteration order. This eliminates redundant sorting operations and makes the output reproducible across runs.

The change is purely organizational — the matching behavior is identical. It improves determinism for build systems and CI pipelines.