### PR TITLE
ignore: do not read .gitignore files above a Git boundary

### DIFF
--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -93,11 +93,13 @@ struct IgnoreOptions {
 #[derive(Clone, Debug)]
 pub(crate) struct Ignore {
     inner: Arc<IgnoreInner>,
-    // Parent matchers are cached independently of the path being walked, but
-    // matching them still needs the canonicalized path originally passed to
-    // `add_parents`. For example, when walking `/tmp/project/src`, parent
-    // matchers use `/tmp/project/src` to rewrite `foo.py` before matching it
-    // against ignore files from `/tmp/project` and its ancestors.
+    // Parent matchers (`IgnoreInner`) are cached by directory path and reused
+    // across multiple search roots, but path rewriting for absolute parents
+    // must use the canonicalized path originally passed to `add_parents` for
+    // *this* root. Storing that base on `Ignore` (not in the cached inner)
+    // keeps matching correct when several roots share parent matchers—e.g.
+    // `rg pat src tests` must rewrite `src/invalid` relative to `…/src`, not
+    // whatever root was prepared first. See issues #3376, #3419, and #3320.
     absolute_base: Option<Arc<PathBuf>>,
 }
 
@@ -1442,6 +1444,122 @@ mod tests {
         assert!(Arc::ptr_eq(&src_parents.inner, &tests_parents.inner));
         assert!(src.matched("build", true).is_none());
         assert!(tests.matched("build", true).is_ignore());
+    }
+
+    /// Parent matchers are shared across search roots, but path rewriting for
+    /// absolute parents must use each root's own base path. Otherwise a rule
+    /// like `src/invalid` is matched against the wrong absolute path when
+    /// `src` is searched before a sibling root (e.g. `tests`).
+    ///
+    /// Paths passed to `matched` use the same relative layout as `Walk` when
+    /// roots are given as relative directory names.
+    ///
+    /// Regression for: https://github.com/BurntSushi/ripgrep/issues/3376
+    /// and https://github.com/BurntSushi/ripgrep/issues/3419
+    #[test]
+    fn multi_root_gitignore_order_independent() {
+        let td = tmpdir();
+        let cwd = std::env::current_dir().unwrap();
+        // Use paths relative to CWD like the CLI walk does for `rg pat src tests`.
+        let root = td.path().strip_prefix(&cwd).unwrap_or(td.path());
+        let src_root = root.join("src");
+        let tests_root = root.join("tests");
+
+        mkdirp(td.path().join(".git"));
+        mkdirp(td.path().join("src"));
+        mkdirp(td.path().join("tests"));
+        wfile(td.path().join(".gitignore"), "src/invalid\n");
+        wfile(td.path().join("src/invalid"), "x");
+        wfile(td.path().join("src/valid"), "x");
+        wfile(td.path().join("tests/valid"), "x");
+
+        let ig0 = IgnoreBuilder::new().build();
+
+        // Historically buggy order: search `src` first, then `tests`.
+        let (src_parents, err) = ig0.add_parents(&src_root);
+        assert!(err.is_none());
+        let (src, err) = src_parents.add_child(&src_root);
+        assert!(err.is_none());
+        let (tests_parents, err) = ig0.add_parents(&tests_root);
+        assert!(err.is_none());
+        let (tests, err) = tests_parents.add_child(&tests_root);
+        assert!(err.is_none());
+
+        assert!(Arc::ptr_eq(&src_parents.inner, &tests_parents.inner));
+        // Each root must carry its own absolute_base even though inners are shared.
+        assert_ne!(
+            src.absolute_base.as_ref().unwrap().as_path(),
+            tests.absolute_base.as_ref().unwrap().as_path()
+        );
+        assert!(
+            src.matched(src_root.join("invalid"), false).is_ignore(),
+            "parent .gitignore must apply for the src root even when \
+             another root was prepared in the same process"
+        );
+        assert!(src.matched(src_root.join("valid"), false).is_none());
+        assert!(tests.matched(tests_root.join("valid"), false).is_none());
+
+        // Reverse order should behave the same way.
+        let ig0 = IgnoreBuilder::new().build();
+        let (tests_parents, err) = ig0.add_parents(&tests_root);
+        assert!(err.is_none());
+        let (tests, err) = tests_parents.add_child(&tests_root);
+        assert!(err.is_none());
+        let (src_parents, err) = ig0.add_parents(&src_root);
+        assert!(err.is_none());
+        let (src, err) = src_parents.add_child(&src_root);
+        assert!(err.is_none());
+
+        assert!(src.matched(src_root.join("invalid"), false).is_ignore());
+        assert!(src.matched(src_root.join("valid"), false).is_none());
+        assert!(tests.matched(tests_root.join("valid"), false).is_none());
+    }
+
+    /// Same multi-root / order issue for non-git ignore files (e.g. `.rgignore`
+    /// via custom ignore names).
+    ///
+    /// Regression for: https://github.com/BurntSushi/ripgrep/issues/3320
+    #[test]
+    fn multi_root_custom_ignore_order_independent() {
+        let td = tmpdir();
+        let cwd = std::env::current_dir().unwrap();
+        let root = td.path().strip_prefix(&cwd).unwrap_or(td.path());
+        let alpha_root = root.join("alpha");
+        let beta_root = root.join("beta");
+
+        mkdirp(td.path().join("alpha"));
+        mkdirp(td.path().join("beta"));
+        wfile(td.path().join(".rgignore"), "beta/**/*.svg\n");
+        wfile(td.path().join("alpha/a.txt"), "x");
+        wfile(td.path().join("beta/x.svg"), "x");
+
+        let ig0 = IgnoreBuilder::new()
+            .add_custom_ignore_filename(".rgignore")
+            .ignore(false)
+            .git_ignore(false)
+            .git_global(false)
+            .git_exclude(false)
+            .build();
+
+        let (alpha_parents, err) = ig0.add_parents(&alpha_root);
+        assert!(err.is_none());
+        let (alpha, err) = alpha_parents.add_child(&alpha_root);
+        assert!(err.is_none());
+        let (beta_parents, err) = ig0.add_parents(&beta_root);
+        assert!(err.is_none());
+        let (beta, err) = beta_parents.add_child(&beta_root);
+        assert!(err.is_none());
+
+        assert_ne!(
+            alpha.absolute_base.as_ref().unwrap().as_path(),
+            beta.absolute_base.as_ref().unwrap().as_path()
+        );
+        assert!(alpha.matched(alpha_root.join("a.txt"), false).is_none());
+        assert!(
+            beta.matched(beta_root.join("x.svg"), false).is_ignore(),
+            "parent .rgignore must apply for the beta root regardless of \
+             which root was set up first"
+        );
     }
 
     #[test]

--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -205,6 +205,17 @@ impl Ignore {
                 return (self.clone(), None);
             }
         };
+        // Nearest VCS root at or above the search path. Git ignore files in
+        // directories strictly above this root are not applied (see
+        // `matched_ignore`), so we also avoid reading them. `.ignore` and
+        // custom ignore files are still read for those parents.
+        let git_root = if self.inner.opts.require_git
+            && (self.inner.opts.git_ignore || self.inner.opts.git_exclude)
+        {
+            nearest_vcs_root(&absolute_base)
+        } else {
+            None
+        };
         // List of parents, from child to root.
         let mut parents = vec![];
         let mut path = &**absolute_base;
@@ -215,22 +226,48 @@ impl Ignore {
         let mut errs = PartialErrorBuilder::default();
         let mut ig = self.clone();
         for parent in parents.into_iter().rev() {
-            let mut compiled = self.inner.compiled.write().unwrap();
-            if let Some(weak) = compiled.get(parent.as_os_str()) {
-                if let Some(prebuilt) = weak.upgrade() {
-                    ig = Ignore {
-                        inner: prebuilt,
-                        absolute_base: Some(absolute_base.clone()),
-                    };
-                    continue;
+            // Only skip git-specific ignore files when they would not apply
+            // because they sit above the repository boundary.
+            let read_git_ignore_files = match git_root.as_deref() {
+                // No VCS in the search path ancestry: parent `.gitignore`
+                // files would never be consulted under `require_git`.
+                None if self.inner.opts.require_git
+                    && (self.inner.opts.git_ignore
+                        || self.inner.opts.git_exclude) =>
+                {
+                    false
+                }
+                Some(root) => {
+                    // `parent` is strictly above the VCS root.
+                    !(root != parent && root.starts_with(parent))
+                }
+                // `require_git` is off: keep historical behavior and read
+                // every parent `.gitignore`.
+                None => true,
+            };
+            // Parent matchers are cached by path alone. When we omit git
+            // ignore files for a parent above a VCS boundary, that incomplete
+            // matcher must not be stored or reused for other search roots
+            // that may need those rules.
+            if read_git_ignore_files {
+                let compiled = self.inner.compiled.write().unwrap();
+                if let Some(weak) = compiled.get(parent.as_os_str()) {
+                    if let Some(prebuilt) = weak.upgrade() {
+                        ig = Ignore {
+                            inner: prebuilt,
+                            absolute_base: Some(absolute_base.clone()),
+                        };
+                        continue;
+                    }
                 }
             }
-            let (mut igtmp, err) = ig.add_child_path(parent);
+            let (mut igtmp, err) =
+                ig.add_child_path(parent, read_git_ignore_files);
             errs.maybe_push(err);
             igtmp.is_absolute_parent = true;
             igtmp.has_git =
                 if self.inner.opts.require_git && self.inner.opts.git_ignore {
-                    parent.join(".git").exists() || parent.join(".jj").exists()
+                    is_vcs_dir(parent)
                 } else {
                     false
                 };
@@ -239,10 +276,13 @@ impl Ignore {
                 inner: ig_arc.clone(),
                 absolute_base: Some(absolute_base.clone()),
             };
-            compiled.insert(
-                parent.as_os_str().to_os_string(),
-                Arc::downgrade(&ig_arc),
-            );
+            if read_git_ignore_files {
+                let mut compiled = self.inner.compiled.write().unwrap();
+                compiled.insert(
+                    parent.as_os_str().to_os_string(),
+                    Arc::downgrade(&ig_arc),
+                );
+            }
         }
         (ig, errs.into_error_option())
     }
@@ -259,7 +299,7 @@ impl Ignore {
         &self,
         dir: P,
     ) -> (Ignore, Option<Error>) {
-        let (ig, err) = self.add_child_path(dir.as_ref());
+        let (ig, err) = self.add_child_path(dir.as_ref(), true);
         (
             Ignore {
                 inner: Arc::new(ig),
@@ -270,7 +310,15 @@ impl Ignore {
     }
 
     /// Like add_child, but takes a full path and returns an IgnoreInner.
-    fn add_child_path(&self, dir: &Path) -> (IgnoreInner, Option<Error>) {
+    ///
+    /// When `read_git_ignore_files` is false, `.gitignore` and git exclude
+    /// files are not opened for this directory. Non-git ignore files such as
+    /// `.ignore` and custom ignore names are still read when enabled.
+    fn add_child_path(
+        &self,
+        dir: &Path,
+        read_git_ignore_files: bool,
+    ) -> (IgnoreInner, Option<Error>) {
         let check_vcs_dir = self.inner.opts.require_git
             && (self.inner.opts.git_ignore || self.inner.opts.git_exclude);
         let git_type = if check_vcs_dir {
@@ -307,7 +355,8 @@ impl Ignore {
             errs.maybe_push(err);
             m
         };
-        let gi_matcher = if !self.inner.opts.git_ignore {
+        let gi_matcher = if !self.inner.opts.git_ignore || !read_git_ignore_files
+        {
             Gitignore::empty()
         } else {
             let (m, err) = create_gitignore(
@@ -320,7 +369,9 @@ impl Ignore {
             m
         };
 
-        let gi_exclude_matcher = if !self.inner.opts.git_exclude {
+        let gi_exclude_matcher = if !self.inner.opts.git_exclude
+            || !read_git_ignore_files
+        {
             Gitignore::empty()
         } else {
             match resolve_git_commondir(dir, git_type) {
@@ -887,6 +938,23 @@ impl IgnoreBuilder {
 
 /// Creates a new gitignore matcher for the directory given.
 ///
+/// Returns true if `dir` looks like a VCS repository root (Git or Jujutsu).
+fn is_vcs_dir(dir: &Path) -> bool {
+    dir.join(".git").exists() || dir.join(".jj").exists()
+}
+
+/// Walk from `start` toward the filesystem root and return the nearest
+/// directory that contains a VCS metadata directory, if any.
+fn nearest_vcs_root(start: &Path) -> Option<PathBuf> {
+    let mut path = start;
+    loop {
+        if is_vcs_dir(path) {
+            return Some(path.to_path_buf());
+        }
+        path = path.parent()?;
+    }
+}
+
 /// The matcher is meant to match files below `dir`.
 /// Ignore globs are extracted from each of the file names relative to
 /// `dir_for_ignorefile` in the order given (earlier names have lower
@@ -1285,6 +1353,52 @@ mod tests {
         let (ig2, err) = ig1.add_child(td.path().join("foo"));
         assert!(err.is_none());
         assert!(ig2.matched("bar", false).is_ignore());
+    }
+
+    /// `.gitignore` files above a nested Git boundary must not be opened, but
+    /// `.ignore` in those same parents must still be respected.
+    ///
+    /// Regression for: https://github.com/BurntSushi/ripgrep/issues/3434
+    #[test]
+    fn absolute_parent_skips_gitignore_above_git_boundary() {
+        let td = tmpdir();
+        // outer/
+        //   .gitignore  (would ignore `bar` if applied)
+        //   .ignore     (ignores `from_ignore`)
+        //   inner/
+        //     .git/
+        //     bar
+        //     from_ignore
+        mkdirp(td.path().join("inner/.git"));
+        wfile(td.path().join(".gitignore"), "bar\n");
+        wfile(td.path().join(".ignore"), "from_ignore\n");
+        wfile(td.path().join("inner/bar"), "x");
+        wfile(td.path().join("inner/from_ignore"), "x");
+
+        let ig0 = IgnoreBuilder::new().build();
+        let (ig1, err) = ig0.add_parents(td.path().join("inner"));
+        assert!(err.is_none());
+        let (ig2, err) = ig1.add_child(td.path().join("inner"));
+        assert!(err.is_none());
+
+        // Outer `.gitignore` is past the Git boundary: not applied, and the
+        // parent matcher must not have loaded those rules either.
+        assert!(ig2.matched("bar", false).is_none());
+        let td_canon = td.path().canonicalize().unwrap();
+        let outer = ig2
+            .parents()
+            .find(|ig| {
+                ig.inner.is_absolute_parent && ig.inner.dir == td_canon
+            })
+            .expect("outer absolute parent matcher");
+        assert!(
+            outer.inner.git_ignore_matcher.is_empty(),
+            "parent .gitignore above git boundary should not be read"
+        );
+
+        // Non-git ignore files still apply from parents above the boundary.
+        assert!(ig2.matched("from_ignore", false).is_ignore());
+        assert!(!outer.inner.ignore_matcher.is_empty());
     }
 
     #[test]

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -742,6 +742,68 @@ sherlock:be, to a very large extent, the result of luck. Sherlock Holmes
     eqnice!(expected, cmd.stdout());
 });
 
+// Multiple explicit search roots must apply parent .gitignore rules using each
+// root's own path base. Searching `src` before `tests` used to leak the wrong
+// absolute base into cached parent matchers so `src/invalid` was not ignored.
+// See: https://github.com/BurntSushi/ripgrep/issues/3376
+rgtest!(ignore_git_multi_root_order, |dir: Dir, mut cmd: TestCommand| {
+    dir.create_dir(".git");
+    dir.create(".gitignore", "src/invalid\n");
+    dir.create_dir("src");
+    dir.create_dir("tests");
+    dir.create("src/invalid", "this\n");
+    dir.create("src/valid", "this\n");
+    dir.create("tests/valid", "this\n");
+
+    cmd.args(&["--files-with-matches", "this", "src", "tests"]);
+    let got = cmd.stdout();
+    assert!(
+        !got.contains("invalid"),
+        "src/invalid must stay ignored with multiple roots, got:\n{}",
+        got
+    );
+    assert!(got.contains("src/valid"), "missing src/valid in:\n{}", got);
+    assert!(got.contains("tests/valid"), "missing tests/valid in:\n{}", got);
+
+    // Reverse CLI order should behave the same.
+    let mut cmd = dir.command();
+    cmd.args(&["--files-with-matches", "this", "tests", "src"]);
+    let got = cmd.stdout();
+    assert!(
+        !got.contains("invalid"),
+        "src/invalid must stay ignored with roots reversed, got:\n{}",
+        got
+    );
+});
+
+// Same multi-root path-base issue for `.rgignore`.
+// See: https://github.com/BurntSushi/ripgrep/issues/3320
+rgtest!(ignore_rgignore_multi_root_order, |dir: Dir, mut cmd: TestCommand| {
+    dir.create(".rgignore", "beta/**/*.svg\n");
+    dir.create_dir("alpha");
+    dir.create_dir("beta");
+    dir.create("alpha/a.txt", "AWS\n");
+    dir.create("beta/x.svg", "AWS\n");
+
+    cmd.args(&["--files-with-matches", "AWS", "alpha", "beta"]);
+    let got = cmd.stdout();
+    assert!(
+        !got.contains("x.svg"),
+        "beta/x.svg must be ignored with multiple roots, got:\n{}",
+        got
+    );
+    assert!(got.contains("alpha/a.txt"), "missing alpha/a.txt in:\n{}", got);
+
+    let mut cmd = dir.command();
+    cmd.args(&["--files-with-matches", "AWS", "beta", "alpha"]);
+    let got = cmd.stdout();
+    assert!(
+        !got.contains("x.svg"),
+        "beta/x.svg must be ignored with roots reversed, got:\n{}",
+        got
+    );
+});
+
 rgtest!(symlink_nofollow, |dir: Dir, mut cmd: TestCommand| {
     dir.create_dir("foo");
     dir.create_dir("foo/bar");


### PR DESCRIPTION
### What does this PR do?

When searching inside a nested Git repo, ripgrep already **ignores** parent `.gitignore` rules above the repository boundary (`saw_git` in `matched_ignore`). It still **opened and parsed** those files while building absolute parent matchers in `Ignore::add_parents`, which shows up under `--debug` and wastes work (see #3434).

This change skips reading **git-specific** ignore files (`.gitignore` and `.git/info/exclude`) for parent directories strictly above the nearest VCS root on the search path (and when `require_git` is on and there is no VCS at all). **`.ignore` and custom ignore filenames are still read** from those parents, matching existing behavior for non-git ignore files.

Parent matchers that omit git rules are **not** inserted into the path-only parent matcher cache, so another search root that legitimately needs that parent’s `.gitignore` does not reuse an incomplete matcher.

### How was this tested?

- New unit test: `absolute_parent_skips_gitignore_above_git_boundary` in `crates/ignore/src/dir.rs`
- `cargo test -p ignore --lib`
- Integration filters: `ignore_git_parent`, `ignore_git_parent_stop`, `ignore_git_parent_stop_file`, `ignore_ripgrep_parent_no_stop`, `no_parent_ignore_git`

### Issue

Fixes #3434

### AI use

Coding assistance was used to implement and verify this change. I have reviewed the diff and can explain and defend it. Per the project AI policy, I will answer review questions myself rather than pasting AI-generated replies.