### PR TITLE
[codex] Reduce owned path copying in globset

### DIFF
--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -380,10 +380,10 @@ impl GlobSet {
         self.matches_all_candidate(&Candidate::new(path.as_ref()))
     }
 
-    /// Returns ture if all globs in this set match the path given.
+    /// Returns true if all globs in this set match the path given.
     ///
     /// This takes a Candidate as input, which can be used to amortize the cost
-    /// of peparing a path for matching.
+    /// of preparing a path for matching.
     ///
     /// This will return true if the set of globs is empty, as in that case all
     /// `0` of the globs will match.

--- a/crates/globset/src/pathutil.rs
+++ b/crates/globset/src/pathutil.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use bstr::{ByteSlice, ByteVec};
+use bstr::ByteSlice;
 
 /// The final component of the path, if it is a normal file.
 ///
@@ -13,11 +13,7 @@ pub(crate) fn file_name<'a>(path: &Cow<'a, [u8]>) -> Option<Cow<'a, [u8]>> {
     let last_slash = path.rfind_byte(b'/').map(|i| i + 1).unwrap_or(0);
     let got = match *path {
         Cow::Borrowed(path) => Cow::Borrowed(&path[last_slash..]),
-        Cow::Owned(ref path) => {
-            let mut path = path.clone();
-            path.drain_bytes(..last_slash);
-            Cow::Owned(path)
-        }
+        Cow::Owned(ref path) => Cow::Owned(path[last_slash..].to_vec()),
     };
     if got == &b".."[..] {
         return None;
@@ -53,11 +49,7 @@ pub(crate) fn file_name_ext<'a>(
     };
     Some(match *name {
         Cow::Borrowed(name) => Cow::Borrowed(&name[last_dot_at..]),
-        Cow::Owned(ref name) => {
-            let mut name = name.clone();
-            name.drain_bytes(..last_dot_at);
-            Cow::Owned(name)
-        }
+        Cow::Owned(ref name) => Cow::Owned(name[last_dot_at..].to_vec()),
     })
 }
 
@@ -90,7 +82,23 @@ mod tests {
 
     use bstr::{B, ByteVec};
 
-    use super::{file_name_ext, normalize_path};
+    use super::{file_name, file_name_ext, normalize_path};
+
+    macro_rules! name {
+        ($name:ident, $path:expr, $expected:expr) => {
+            #[test]
+            fn $name() {
+                let bs = Vec::from($path);
+                let got = file_name(&Cow::Owned(bs));
+                assert_eq!($expected.map(|s| Cow::Borrowed(B(s))), got);
+            }
+        };
+    }
+
+    name!(name1, "foo/bar", Some("bar"));
+    name!(name2, "foo", Some("foo"));
+    name!(name3, "foo/..", None::<&str>);
+    name!(name4, "", None::<&str>);
 
     macro_rules! ext {
         ($name:ident, $file_name:expr, $ext:expr) => {


### PR DESCRIPTION
## Summary
- Copy only the needed filename or extension tail for owned paths in globset path utilities.

## Validation
- globset targeted tests, full globset tests, globset bench, and diff check passed in Docker.

## Notes
- Opened as a draft PR for maintainer review.
