### PR TITLE
changelog: document unreleased changes since 15.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,25 @@ TBD
 ===
 Unreleased changes. Release notes have not yet been written.
 
+Platform support:
+
+* [FEATURE #2739](https://github.com/BurntSushi/ripgrep/issues/2739):
+  Add `aarch64-unknown-linux-musl` tests and release artifacts.
+
 Bug fixes:
 
 * [BUG #3212](https://github.com/BurntSushi/ripgrep/pull/3212):
   Don't check for the existence of `.jj` when `--no-ignore` is used.
+* [BUG #3419](https://github.com/BurntSushi/ripgrep/issues/3419):
+  Fix parent gitignore matching when searching multiple roots that share
+  cached parent matchers.
+
+Feature enhancements:
+
+* [FEATURE #3271](https://github.com/BurntSushi/ripgrep/pull/3271):
+  Add a `container` file type covering `Dockerfile` and `Containerfile`.
+* [FEATURE #3444](https://github.com/BurntSushi/ripgrep/pull/3444):
+  Add a `hurl` file type.
 
 
 15.1.0


### PR DESCRIPTION
## Summary

Fills in the `TBD` section of `CHANGELOG.md` for commits already on `master` since 15.1.0 that are user-facing:

| Entry | Source |
| --- | --- |
| `aarch64-unknown-linux-musl` tests/artifacts | Fixes #2739 (`48a6ad9`) |
| Parent gitignore matching across multi-root walks | Fixes #3419 (`43e2f08` / #3420) |
| `container` file type (`Dockerfile` / `Containerfile`) | #3271 (`9b84e15`) |
| `hurl` file type | #3444 (`dfe4a81`) |
| Existing: skip `.jj` stat under `--no-ignore` | #3212 (`85edf4c`) — already listed |

Docs-only / internal / CI-test commits (AI policy, GUIDE lexopt wording, QEMU `cmd_exists`, crate renames, etc.) intentionally omitted to match prior changelog practice.

## Context for reviewers / handoff

This continues interrupted release-prep work in a local checkout of `BurntSushi/ripgrep` at `dfe4a81` (in sync with `origin/master`).

**Not in this PR (and not on disk anymore):** earlier experimental sessions implemented (1) an internal search-execution telemetry framework and (2) library API cleanups (`globset` 0.5 / `ignore` 0.5 deprecations). Those were discarded under a release-risk-minimization pass; only this changelog documentation remained as durable local work. There is **no** open PR for telemetry or those API bumps.

**GitHub checks performed:** no open/draft/merged PR already documents this TBD batch; remote `CHANGELOG.md` on `master` still only lists #3212 under TBD.

## Test plan

- [x] Diff entries against `git log` since `36b7597` (start of TBD section)
- [x] Cross-check issue/PR numbers via GitHub API (states closed/merged as expected)
- [x] Confirm `master` tip matches `origin/master` / GitHub `dfe4a81`
- [ ] Maintainer review of wording / categorization only (no code changes)