### PR TITLE
feat[ignore]: Always include depth in errors from WalkDir

### DIFF
--- a/crates/ignore/src/lib.rs
+++ b/crates/ignore/src/lib.rs
@@ -294,7 +294,10 @@ impl Error {
             };
         }
         let path = err.path().map(|p| p.to_path_buf());
-        let mut ig_err = Error::Io(std::io::Error::from(err));
+        let mut ig_err = Error::WithDepth {
+            depth,
+            err: Box::new(Error::Io(std::io::Error::from(err))),
+        };
         if let Some(path) = path {
             ig_err = Error::WithPath { path, err: Box::new(ig_err) };
         }


### PR DESCRIPTION
Include the depth in I/O errors from WalkDir as well, so that the consumer can handle the error differently depending on depth. For example, this would allow ignore broken symlinks that don't match certain depth criteria.

Fixes: #3453