### PR TITLE
core: report pattern file source in regex errors

### DIFF
--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -4,11 +4,12 @@ Provides the definition of high level arguments from CLI flags.
 
 use std::{
     collections::HashSet,
+    io,
     path::{Path, PathBuf},
 };
 
 use {
-    bstr::BString,
+    bstr::{BString, io::BufReadExt},
     grep::printer::{ColorSpecs, SummaryKind},
 };
 
@@ -443,7 +444,17 @@ impl HiArgs {
             if self.crlf {
                 builder.crlf(true);
             }
-            let m = builder.build_many(&self.patterns.patterns)?;
+            let m = match builder.build_many(&self.patterns.patterns) {
+                Ok(m) => m,
+                Err(err) => {
+                    anyhow::bail!(
+                        self.patterns
+                            .with_source_for_error(err.to_string(), |pat| {
+                                builder.build(pat).map(|_| ())
+                            },)
+                    );
+                }
+            };
             Ok(PatternMatcher::PCRE2(m))
         }
         #[cfg(not(feature = "pcre2"))]
@@ -507,7 +518,12 @@ impl HiArgs {
         let m = match builder.build_many(&self.patterns.patterns) {
             Ok(m) => m,
             Err(err) => {
-                anyhow::bail!(suggest_text(suggest_multiline(err.to_string())))
+                let msg = self
+                    .patterns
+                    .with_source_for_error(err.to_string(), |pat| {
+                        builder.build(pat).map(|_| ())
+                    });
+                anyhow::bail!(suggest_text(suggest_multiline(msg)))
             }
         };
         Ok(PatternMatcher::RustRegex(m))
@@ -966,7 +982,19 @@ impl State {
 #[derive(Debug)]
 struct Patterns {
     /// The actual patterns to match.
-    patterns: Vec<String>,
+    patterns: Vec<Pattern>,
+}
+
+#[derive(Debug)]
+struct Pattern {
+    text: String,
+    source: Option<String>,
+}
+
+impl AsRef<str> for Pattern {
+    fn as_ref(&self) -> &str {
+        &self.text
+    }
 }
 
 impl Patterns {
@@ -1002,7 +1030,9 @@ impl Patterns {
             let Ok(pat) = ospat.into_string() else {
                 anyhow::bail!("pattern given is not valid UTF-8")
             };
-            return Ok(Patterns { patterns: vec![pat] });
+            return Ok(Patterns {
+                patterns: vec![Pattern { text: pat, source: None }],
+            });
         }
         // Otherwise, we need to slurp up our patterns from -e/--regexp and
         // -f/--file. We de-duplicate as we go. If we don't de-duplicate,
@@ -1016,15 +1046,16 @@ impl Patterns {
         // big impact on real world data.
         let mut seen = HashSet::new();
         let mut patterns = Vec::with_capacity(low.patterns.len());
-        let mut add = |pat: String| {
-            if !seen.contains(&pat) {
-                seen.insert(pat.clone());
+        let mut add = |pat: Pattern| {
+            if seen.insert(pat.text.clone()) {
                 patterns.push(pat);
             }
         };
         for source in low.patterns.drain(..) {
             match source {
-                PatternSource::Regexp(pat) => add(pat),
+                PatternSource::Regexp(pat) => {
+                    add(Pattern { text: pat, source: None })
+                }
                 PatternSource::File(path) => {
                     if path == Path::new("-") {
                         anyhow::ensure!(
@@ -1032,12 +1063,12 @@ impl Patterns {
                             "error reading -f/--file from stdin: stdin \
                              has already been consumed"
                         );
-                        for pat in grep::cli::patterns_from_stdin()? {
+                        for pat in patterns_from_stdin()? {
                             add(pat);
                         }
                         state.stdin_consumed = true;
                     } else {
-                        for pat in grep::cli::patterns_from_path(&path)? {
+                        for pat in patterns_from_path(&path)? {
                             add(pat);
                         }
                     }
@@ -1046,6 +1077,70 @@ impl Patterns {
         }
         Ok(Patterns { patterns })
     }
+
+    fn with_source_for_error<E, F>(
+        &self,
+        fallback: String,
+        mut build: F,
+    ) -> String
+    where
+        E: std::fmt::Display,
+        F: FnMut(&str) -> Result<(), E>,
+    {
+        for pattern in self.patterns.iter() {
+            if let Err(err) = build(&pattern.text) {
+                return match pattern.source {
+                    Some(ref source) => format!("{source}: {err}"),
+                    None => fallback,
+                };
+            }
+        }
+        fallback
+    }
+}
+
+fn patterns_from_path(path: &Path) -> io::Result<Vec<Pattern>> {
+    let file = std::fs::File::open(path).map_err(|err| {
+        io::Error::other(format!("{}: {}", path.display(), err))
+    })?;
+    patterns_from_reader(file, |line_number| {
+        format!("{}:{line_number}", path.display())
+    })
+    .map_err(|err| io::Error::other(format!("{}:{}", path.display(), err)))
+}
+
+fn patterns_from_stdin() -> io::Result<Vec<Pattern>> {
+    let stdin = io::stdin();
+    patterns_from_reader(stdin.lock(), |line_number| {
+        format!("<stdin>:{line_number}")
+    })
+    .map_err(|err| io::Error::other(format!("<stdin>:{err}")))
+}
+
+fn patterns_from_reader<R, F>(
+    rdr: R,
+    mut source: F,
+) -> io::Result<Vec<Pattern>>
+where
+    R: io::Read,
+    F: FnMut(usize) -> String,
+{
+    let mut patterns = vec![];
+    let mut line_number = 0;
+    io::BufReader::new(rdr).for_byte_line(|line| {
+        line_number += 1;
+        match grep::cli::pattern_from_bytes(line) {
+            Ok(pattern) => {
+                patterns.push(Pattern {
+                    text: pattern.to_string(),
+                    source: Some(source(line_number)),
+                });
+                Ok(true)
+            }
+            Err(err) => Err(io::Error::other(format!("{line_number}: {err}"))),
+        }
+    })?;
+    Ok(patterns)
 }
 
 /// The collection of paths we want to search for.

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -762,15 +762,22 @@ rgtest!(r829_2933, |dir: Dir, mut cmd: TestCommand| {
 
 // See: https://github.com/BurntSushi/ripgrep/issues/478
 rgtest!(r478, |dir: Dir, mut cmd: TestCommand| {
-    dir.create("patterns", "foo\nbar(wat\nquux\n");
+    dir.create("patterns1", "foo\n");
+    dir.create("patterns2", "bar\nbar(wat\nquux\n");
     dir.create("haystack", "foo\n");
 
-    let output = cmd.arg("-f").arg("patterns").arg("haystack").raw_output();
+    let output = cmd
+        .arg("-f")
+        .arg("patterns1")
+        .arg("-f")
+        .arg("patterns2")
+        .arg("haystack")
+        .raw_output();
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(!output.status.success(), "{stderr}");
-    assert!(stderr.contains("patterns:2:"), "{stderr}");
-    assert!(stderr.contains("unclosed group"), "{stderr}");
+    assert!(stderr.contains("patterns2:2:"), "{stderr}");
+    assert!(!stderr.contains("foo|bar|bar(wat|quux"), "{stderr}");
 });
 
 // See: https://github.com/BurntSushi/ripgrep/issues/900

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -760,6 +760,19 @@ rgtest!(r829_2933, |dir: Dir, mut cmd: TestCommand| {
     cmd.args(args).assert_err();
 });
 
+// See: https://github.com/BurntSushi/ripgrep/issues/478
+rgtest!(r478, |dir: Dir, mut cmd: TestCommand| {
+    dir.create("patterns", "foo\nbar(wat\nquux\n");
+    dir.create("haystack", "foo\n");
+
+    let output = cmd.arg("-f").arg("patterns").arg("haystack").raw_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "{stderr}");
+    assert!(stderr.contains("patterns:2:"), "{stderr}");
+    assert!(stderr.contains("unclosed group"), "{stderr}");
+});
+
 // See: https://github.com/BurntSushi/ripgrep/issues/900
 rgtest!(r900, |dir: Dir, mut cmd: TestCommand| {
     dir.create("sherlock", SHERLOCK);


### PR DESCRIPTION
Fixes #478.

## Summary

When a regex parse error comes from a pattern loaded via `-f`, ripgrep now prefixes the original regex error with the pattern source path and line number.

The normal path still uses the existing `build_many` matcher construction. On compile failure, ripgrep checks individual patterns only to identify whether the failing pattern came from `-f`.

## Example

Given two pattern files:

```text
# patterns1
foo
```

```text
# patterns2
bar
bar(wat
quux
```

Running:

```console
$ rg -f patterns1 -f patterns2 haystack
```

Previously reported the error against the alternation built from all patterns:

```text
rg: regex parse error:
    (?:foo)|(?:bar)|(?:bar(wat)|(?:quux)
                    ^
error: unclosed group
```

Now the error points back to the pattern file and line:

```text
rg: patterns2:2: regex parse error:
    (?:bar(wat)
    ^
error: unclosed group
```

PCRE2 keeps its own error text with the same `patterns2:2:` source prefix.

## Notes

- `-f -` is reported as `<stdin>:line`.
- `-e` and positional patterns keep the existing fallback error behavior.
- This preserves the regex error details that were lost in #590.

## Tests

```console
$ cargo fmt --all -- --check
$ git diff --check origin/master..HEAD
$ cargo test -p ripgrep --test integration
$ cargo test -p ripgrep --test integration --features pcre2
$ cargo test --workspace --features pcre2
```
