### PR TITLE
update AI policy link to point to the one in the ripgrep project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,6 @@
 ## Use of AI
 
 All use of AI in contributions must follow the
-[AI Policy](https://github.com/BurntSushi/jiff/blob/master/AI_POLICY.md).
+[AI Policy](https://github.com/BurntSushi/ripgrep/blob/master/AI_POLICY.md).
 
 Contributions not following the AI Policy will be closed.


### PR DESCRIPTION
Noticed this while I was getting inspiration for my own AI policy document, doesn't _really_ change much but eh might as well point to the right url.