### PR TITLE
docs: fix typos in code comments

### DIFF
--- a/crates/printer/src/util.rs
+++ b/crates/printer/src/util.rs
@@ -514,7 +514,7 @@ where
         // Otherwise, it's possible for the regex (via look-around) to observe
         // the line terminator and not match because of it.
         let mut m = Match::new(0, range.end);
-        // No need to rember the line terminator as we aren't doing a replace
+        // No need to remember the line terminator as we aren't doing a replace
         // here.
         trim_line_terminator(searcher, bytes, &mut m);
         bytes = &bytes[..m.end()];

--- a/crates/searcher/src/searcher/mod.rs
+++ b/crates/searcher/src/searcher/mod.rs
@@ -450,7 +450,7 @@ impl SearcherBuilder {
     ///
     /// If a heap limit is set to `0`, then no heap space is used. If there are
     /// no alternative strategies available for searching without heap space
-    /// (e.g., memory maps are disabled), then the searcher wil return an error
+    /// (e.g., memory maps are disabled), then the searcher will return an error
     /// immediately.
     ///
     /// By default, no limit is set.


### PR DESCRIPTION
Fixes two small spelling mistakes in comments (no functional change):

| File | Before | After |
|------|--------|-------|
| `crates/printer/src/util.rs` | `rember` | `remember` |
| `crates/searcher/src/searcher/mod.rs` | `wil` | `will` |

Both are in a code comment and a doc comment respectively. No code behavior is affected.