### PR TITLE
docs: update OpenSubtitles benchmark corpus URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ doing equivalent work:
 
 Now we'll move to searching on single large file. Here is a straight-up
 comparison between ripgrep, ugrep and GNU grep on a file cached in memory
-(~13GB, [`OpenSubtitles.raw.en.gz`](http://opus.nlpl.eu/download.php?f=OpenSubtitles/v2018/mono/OpenSubtitles.raw.en.gz), decompressed):
+(~13GB, [`OpenSubtitles.raw.en.gz`](https://object.pouta.csc.fi/OPUS-OpenSubtitles/v2018/mono/en.txt.gz), decompressed):
 
 | Tool | Command | Line count | Time |
 | ---- | ------- | ---------- | ---- |


### PR DESCRIPTION
## Summary

The README benchmark section linked to the OpenSubtitles v2018 English corpus via OPUS `download.php`, which now 404s. This updates the link to the live OPUS object-storage URL for the same corpus:

`https://object.pouta.csc.fi/OPUS-OpenSubtitles/v2018/mono/en.txt.gz`

Fixes #3471

## Test plan

- `curl -I` on the old URL returns 404 after redirect.
- `curl -I` on the new URL returns HTTP 200 with content-length ~3.6GB.
- README no longer contains the dead `download.php` URL.
