### PR TITLE
Add rust-version to published sub-crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ exclude = [
 ]
 build = "build.rs"
 autotests = false
-edition = "2024"
-rust-version = "1.96"
+edition.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 bench = false
@@ -48,6 +48,10 @@ members = [
   "crates/searcher",
   "crates/ignore",
 ]
+
+[workspace.package]
+edition = "2024"
+rust-version = "1.96"
 
 [dependencies]
 anyhow = "1.0.75"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/cli"
 readme = "README.md"
 keywords = ["regex", "grep", "cli", "utility", "util"]
 license = "Unlicense OR MIT"
-edition = "2024"
-rust-version = "1.85"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 bstr = { version = "1.6.2", features = ["std"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords = ["regex", "grep", "cli", "utility", "util"]
 license = "Unlicense OR MIT"
 edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 bstr = { version = "1.6.2", features = ["std"] }

--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/globset"
 readme = "README.md"
 keywords = ["regex", "glob", "multiple", "set", "pattern"]
 license = "Unlicense OR MIT"
-edition = "2024"
-rust-version = "1.85"
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "globset"

--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 keywords = ["regex", "glob", "multiple", "set", "pattern"]
 license = "Unlicense OR MIT"
 edition = "2024"
+rust-version = "1.85"
 
 [lib]
 name = "globset"

--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 keywords = ["regex", "glob", "multiple", "set", "pattern"]
 license = "Unlicense OR MIT"
 edition.workspace = true
-rust-version.workspace = true
+rust-version = "1.88"
 
 [lib]
 name = "globset"

--- a/crates/grep/Cargo.toml
+++ b/crates/grep/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords = ["regex", "grep", "egrep", "search", "pattern"]
 license = "Unlicense OR MIT"
 edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 grep-cli = { version = "0.1.12", path = "../cli" }

--- a/crates/grep/Cargo.toml
+++ b/crates/grep/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/grep"
 readme = "README.md"
 keywords = ["regex", "grep", "egrep", "search", "pattern"]
 license = "Unlicense OR MIT"
-edition = "2024"
-rust-version = "1.85"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 grep-cli = { version = "0.1.12", path = "../cli" }

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 keywords = ["glob", "ignore", "gitignore", "pattern", "file"]
 license = "Unlicense OR MIT"
 edition.workspace = true
-rust-version.workspace = true
+rust-version = "1.88"
 
 [lib]
 name = "ignore"

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore"
 readme = "README.md"
 keywords = ["glob", "ignore", "gitignore", "pattern", "file"]
 license = "Unlicense OR MIT"
-edition = "2024"
-rust-version = "1.85"
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "ignore"

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 keywords = ["glob", "ignore", "gitignore", "pattern", "file"]
 license = "Unlicense OR MIT"
 edition = "2024"
+rust-version = "1.85"
 
 [lib]
 name = "ignore"

--- a/crates/matcher/Cargo.toml
+++ b/crates/matcher/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 keywords = ["regex", "pattern", "trait"]
 license = "Unlicense OR MIT"
 autotests = false
-edition = "2024"
-rust-version = "1.85"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 memchr = "2.6.3"

--- a/crates/matcher/Cargo.toml
+++ b/crates/matcher/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["regex", "pattern", "trait"]
 license = "Unlicense OR MIT"
 autotests = false
 edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 memchr = "2.6.3"

--- a/crates/pcre2/Cargo.toml
+++ b/crates/pcre2/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/pcre2"
 readme = "README.md"
 keywords = ["regex", "grep", "pcre", "backreference", "look"]
 license = "Unlicense OR MIT"
-edition = "2024"
-rust-version = "1.85"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 grep-matcher = { version = "0.1.8", path = "../matcher" }

--- a/crates/pcre2/Cargo.toml
+++ b/crates/pcre2/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords = ["regex", "grep", "pcre", "backreference", "look"]
 license = "Unlicense OR MIT"
 edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 grep-matcher = { version = "0.1.8", path = "../matcher" }

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 keywords = ["grep", "pattern", "print", "printer", "sink"]
 license = "Unlicense OR MIT"
 edition = "2024"
+rust-version = "1.85"
 
 [features]
 default = ["serde"]

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/printer"
 readme = "README.md"
 keywords = ["grep", "pattern", "print", "printer", "sink"]
 license = "Unlicense OR MIT"
-edition = "2024"
-rust-version = "1.85"
+edition.workspace = true
+rust-version.workspace = true
 
 [features]
 default = ["serde"]

--- a/crates/regex/Cargo.toml
+++ b/crates/regex/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords = ["regex", "grep", "search", "pattern", "line"]
 license = "Unlicense OR MIT"
 edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 bstr = "1.6.2"

--- a/crates/regex/Cargo.toml
+++ b/crates/regex/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/regex"
 readme = "README.md"
 keywords = ["regex", "grep", "search", "pattern", "line"]
 license = "Unlicense OR MIT"
-edition = "2024"
-rust-version = "1.85"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 bstr = "1.6.2"

--- a/crates/searcher/Cargo.toml
+++ b/crates/searcher/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords = ["regex", "grep", "egrep", "search", "pattern"]
 license = "Unlicense OR MIT"
 edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 bstr = { version = "1.6.2", default-features = false, features = ["std"] }

--- a/crates/searcher/Cargo.toml
+++ b/crates/searcher/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/searcher"
 readme = "README.md"
 keywords = ["regex", "grep", "egrep", "search", "pattern"]
 license = "Unlicense OR MIT"
-edition = "2024"
-rust-version = "1.85"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 bstr = { version = "1.6.2", default-features = false, features = ["std"] }


### PR DESCRIPTION
Fixes #3473

The workspace root `Cargo.toml` already declares `rust-version = "1.85"`, and every sub-crate uses `edition = "2024"` (which mechanically requires rustc >= 1.85), but none of the 9 published sub-crates carried their own `rust-version` field — so it was missing from their individual `Cargo.toml` on crates.io even though the workspace itself documents the MSRV.

Added `rust-version = "1.85"` to:
- `crates/cli` (grep-cli)
- `crates/globset` (globset)
- `crates/grep` (grep)
- `crates/ignore` (ignore)
- `crates/matcher` (grep-matcher)
- `crates/pcre2` (grep-pcre2)
- `crates/printer` (grep-printer)
- `crates/regex` (grep-regex)
- `crates/searcher` (grep-searcher)

Verified `cargo metadata --no-deps` and `cargo check --workspace` both succeed with no changes needed elsewhere.