### PR TITLE
Add experimental --grok-trace flag

### DIFF
--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -74,6 +74,7 @@ pub(super) const FLAGS: &[&dyn Flag] = &[
     &Generate,
     &Glob,
     &GlobCaseInsensitive,
+    &GrokTrace,
     &Heading,
     &Help,
     &Hidden,
@@ -2644,6 +2645,52 @@ fn test_glob_case_insensitive() {
     ])
     .unwrap();
     assert_eq!(true, args.glob_case_insensitive);
+}
+
+/// --grok-trace
+///
+/// Experimental flag that prints a fixed banner to stdout before search.
+#[derive(Debug)]
+struct GrokTrace;
+
+impl Flag for GrokTrace {
+    fn is_switch(&self) -> bool {
+        true
+    }
+    fn name_long(&self) -> &'static str {
+        "grok-trace"
+    }
+    fn doc_category(&self) -> Category {
+        Category::Logging
+    }
+    fn doc_short(&self) -> &'static str {
+        r"Experimental: print Grok trace banner."
+    }
+    fn doc_long(&self) -> &'static str {
+        r"
+Experimental flag. When set, print the string \fBGrok trace active\fP to
+stdout before executing a normal search.
+"
+    }
+
+    fn update(&self, v: FlagValue, args: &mut LowArgs) -> anyhow::Result<()> {
+        assert!(v.unwrap_switch(), "--grok-trace can only be enabled");
+        args.grok_trace = true;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_grok_trace() {
+    let args = parse_low_raw(None::<&str>).unwrap();
+    assert_eq!(false, args.grok_trace);
+
+    let args = parse_low_raw(["--grok-trace"]).unwrap();
+    assert_eq!(true, args.grok_trace);
+
+    let args = parse_low_raw(["--debug", "--grok-trace"]).unwrap();
+    assert_eq!(true, args.grok_trace);
 }
 
 /// --heading

--- a/crates/core/flags/hiargs.rs
+++ b/crates/core/flags/hiargs.rs
@@ -55,6 +55,7 @@ pub(crate) struct HiArgs {
     fixed_strings: bool,
     follow: bool,
     globs: ignore::overrides::Override,
+    grok_trace: bool,
     heading: bool,
     hidden: bool,
     hyperlink_config: grep::printer::HyperlinkConfig,
@@ -272,6 +273,7 @@ impl HiArgs {
             file_separator,
             fixed_strings: low.fixed_strings,
             follow: low.follow,
+            grok_trace: low.grok_trace,
             heading,
             hidden: low.hidden,
             hyperlink_config,
@@ -533,6 +535,11 @@ impl HiArgs {
     /// This is generally useful for determining what action ripgrep should
     /// take. The main mode is of course to "search," but there are other
     /// non-search modes such as `--type-list` and `--files`.
+    /// Returns true when the experimental `--grok-trace` flag is enabled.
+    pub(crate) fn grok_trace(&self) -> bool {
+        self.grok_trace
+    }
+
     pub(crate) fn mode(&self) -> Mode {
         self.mode
     }

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -57,6 +57,7 @@ pub(crate) struct LowArgs {
     pub(crate) follow: bool,
     pub(crate) glob_case_insensitive: bool,
     pub(crate) globs: Vec<String>,
+    pub(crate) grok_trace: bool,
     pub(crate) heading: Option<bool>,
     pub(crate) hidden: bool,
     pub(crate) hostname_bin: Option<PathBuf>,

--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -82,6 +82,10 @@ fn run(result: crate::flags::ParseResult<HiArgs>) -> anyhow::Result<ExitCode> {
         ParseResult::Special(mode) => return special(mode),
         ParseResult::Ok(args) => args,
     };
+    // Experimental --grok-trace: emit a fixed banner before normal search.
+    if args.grok_trace() {
+        println!("Grok trace active");
+    }
     let matched = match args.mode() {
         Mode::Search(_) if !args.matches_possible() => false,
         Mode::Search(mode) if args.threads() == 1 => search(&args, mode)?,


### PR DESCRIPTION
## Summary

- Adds a new experimental CLI flag `--grok-trace`.
- When the flag is passed, ripgrep prints the exact string `Grok trace active` to stdout before executing the normal search.
- Wired through the existing flag system: `LowArgs`, `HiArgs`, flag registry in `defs.rs`, and emission in `main.rs`.

## Test plan

- [x] `cargo test --workspace --lib --bins` (via file-watch monitor) — PASS
- [x] `cargo test --bin rg test_grok_trace` — PASS
- [x] Manual: `./target/debug/rg --grok-trace PATTERN PATH` prints `Grok trace active` before search results
- [x] Manual: without the flag, no banner is printed
- [x] `--help` documents `--grok-trace`