### PR TITLE
docs: remove $ prompt symbols from README code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,28 +243,28 @@ If you're a **macOS Homebrew** or a **Linuxbrew** user, then you can install
 ripgrep from homebrew-core:
 
 ```
-$ brew install ripgrep
+brew install ripgrep
 ```
 
 If you're a **MacPorts** user, then you can install ripgrep from the
 [official ports](https://www.macports.org/ports.php?by=name&substr=ripgrep):
 
 ```
-$ sudo port install ripgrep
+sudo port install ripgrep
 ```
 
 If you're a **Windows Chocolatey** user, then you can install ripgrep from the
 [official repo](https://chocolatey.org/packages/ripgrep):
 
 ```
-$ choco install ripgrep
+choco install ripgrep
 ```
 
 If you're a **Windows Scoop** user, then you can install ripgrep from the
 [official bucket](https://github.com/ScoopInstaller/Main/blob/master/bucket/ripgrep.json):
 
 ```
-$ scoop install ripgrep
+scoop install ripgrep
 ```
 
 If you're a **Windows Winget** user, then you can install ripgrep from the
@@ -272,80 +272,80 @@ If you're a **Windows Winget** user, then you can install ripgrep from the
 repository:
 
 ```
-$ winget install BurntSushi.ripgrep.MSVC
+winget install BurntSushi.ripgrep.MSVC
 ```
 
 If you're an **Arch Linux** user, then you can install ripgrep from the official repos:
 
 ```
-$ sudo pacman -S ripgrep
+sudo pacman -S ripgrep
 ```
 
 If you're a **Gentoo** user, you can install ripgrep from the
 [official repo](https://packages.gentoo.org/packages/sys-apps/ripgrep):
 
 ```
-$ sudo emerge sys-apps/ripgrep
+sudo emerge sys-apps/ripgrep
 ```
 
 If you're a **Fedora** user, you can install ripgrep from official
 repositories.
 
 ```
-$ sudo dnf install ripgrep
+sudo dnf install ripgrep
 ```
 
 If you're an **openSUSE** user, ripgrep is included in **openSUSE Tumbleweed**
 and **openSUSE Leap** since 15.1.
 
 ```
-$ sudo zypper install ripgrep
+sudo zypper install ripgrep
 ```
 
 If you're a **CentOS Stream 10** user, you can install ripgrep from the
 [EPEL](https://docs.fedoraproject.org/en-US/epel/getting-started/) repository:
 
 ```
-$ sudo dnf config-manager --set-enabled crb
-$ sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
-$ sudo dnf install ripgrep
+sudo dnf config-manager --set-enabled crb
+sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+sudo dnf install ripgrep
 ```
 
 If you're a **Red Hat 10** user, you can install ripgrep from the
 [EPEL](https://docs.fedoraproject.org/en-US/epel/getting-started/) repository:
 
 ```
-$ sudo subscription-manager repos --enable codeready-builder-for-rhel-10-$(arch)-rpms
-$ sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
-$ sudo dnf install ripgrep
+sudo subscription-manager repos --enable codeready-builder-for-rhel-10-$(arch)-rpms
+sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+sudo dnf install ripgrep
 ```
 
 If you're a **Rocky Linux 10** user, you can install ripgrep from the
 [EPEL](https://docs.fedoraproject.org/en-US/epel/getting-started/) repository:
 
 ```
-$ sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
-$ sudo dnf install ripgrep
+sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+sudo dnf install ripgrep
 ```
 
 If you're a **Nix** user, you can install ripgrep from
 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ri/ripgrep/package.nix):
 
 ```
-$ nix-env --install ripgrep
+nix-env --install ripgrep
 ```
 
 If you're a **Flox** user, you can install ripgrep as follows:
 
 ```
-$ flox install ripgrep
+flox install ripgrep
 ```
 
 If you're a **Guix** user, you can install ripgrep from the official
 package collection:
 
 ```
-$ guix install ripgrep
+guix install ripgrep
 ```
 
 If you're a **Debian** user (or a user of a Debian derivative like **Ubuntu**),
@@ -353,8 +353,8 @@ then ripgrep can be installed using a binary `.deb` file provided in each
 [ripgrep release](https://github.com/BurntSushi/ripgrep/releases).
 
 ```
-$ curl -LO https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep_14.1.1-1_amd64.deb
-$ sudo dpkg -i ripgrep_14.1.1-1_amd64.deb
+curl -LO https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep_14.1.1-1_amd64.deb
+sudo dpkg -i ripgrep_14.1.1-1_amd64.deb
 ```
 
 If you run Debian stable, ripgrep is [officially maintained by
@@ -362,7 +362,7 @@ Debian](https://tracker.debian.org/pkg/rust-ripgrep), although its version may
 be older than the `deb` package available in the previous step.
 
 ```
-$ sudo apt-get install ripgrep
+sudo apt-get install ripgrep
 ```
 
 If you're an **Ubuntu Cosmic (18.10)** (or newer) user, ripgrep is
@@ -370,7 +370,7 @@ If you're an **Ubuntu Cosmic (18.10)** (or newer) user, ripgrep is
 packaging as Debian:
 
 ```
-$ sudo apt-get install ripgrep
+sudo apt-get install ripgrep
 ```
 
 (N.B. Various snaps for ripgrep on Ubuntu are also available, but none of them
@@ -382,49 +382,49 @@ If you're an **ALT** user, you can install ripgrep from the
 [official repo](https://packages.altlinux.org/en/search?name=ripgrep):
 
 ```
-$ sudo apt-get install ripgrep
+sudo apt-get install ripgrep
 ```
 
 If you're a **FreeBSD** user, then you can install ripgrep from the
 [official ports](https://www.freshports.org/textproc/ripgrep/):
 
 ```
-$ sudo pkg install ripgrep
+sudo pkg install ripgrep
 ```
 
 If you're an **OpenBSD** user, then you can install ripgrep from the
 [official ports](https://openports.se/textproc/ripgrep):
 
 ```
-$ doas pkg_add ripgrep
+doas pkg_add ripgrep
 ```
 
 If you're a **NetBSD** user, then you can install ripgrep from
 [pkgsrc](https://pkgsrc.se/textproc/ripgrep):
 
 ```
-$ sudo pkgin install ripgrep
+sudo pkgin install ripgrep
 ```
 
 If you're a **Haiku x86_64** user, then you can install ripgrep from the
 [official ports](https://github.com/haikuports/haikuports/tree/master/sys-apps/ripgrep):
 
 ```
-$ sudo pkgman install ripgrep
+sudo pkgman install ripgrep
 ```
 
 If you're a **Haiku x86_gcc2** user, then you can install ripgrep from the
 same port as Haiku x86_64 using the x86 secondary architecture build:
 
 ```
-$ sudo pkgman install ripgrep_x86
+sudo pkgman install ripgrep_x86
 ```
 
 If you're a **Void Linux** user, then you can install ripgrep from the
 [official repository](https://voidlinux.org/packages/?arch=x86_64&q=ripgrep):
 
 ```
-$ sudo xbps-install -Syv ripgrep
+sudo xbps-install -Syv ripgrep
 ```
 
 If you're a **Rust programmer**, ripgrep can be installed with `cargo`.
@@ -436,7 +436,7 @@ If you're a **Rust programmer**, ripgrep can be installed with `cargo`.
   the file size, run `strip` on the binary.
 
 ```
-$ cargo install ripgrep
+cargo install ripgrep
 ```
 
 Alternatively, one can use [`cargo
@@ -444,7 +444,7 @@ binstall`](https://github.com/cargo-bins/cargo-binstall) to install a ripgrep
 binary directly from GitHub:
 
 ```
-$ cargo binstall ripgrep
+cargo binstall ripgrep
 ```
 
 
@@ -458,10 +458,10 @@ the latest stable release of the Rust compiler.
 To build ripgrep:
 
 ```
-$ git clone https://github.com/BurntSushi/ripgrep
-$ cd ripgrep
-$ cargo build --release
-$ ./target/release/rg --version
+git clone https://github.com/BurntSushi/ripgrep
+cd ripgrep
+cargo build --release
+./target/release/rg --version
 0.1.3
 ```
 
@@ -477,7 +477,7 @@ Finally, optional PCRE2 support can be built with ripgrep by enabling the
 `pcre2` feature:
 
 ```
-$ cargo build --release --features 'pcre2'
+cargo build --release --features 'pcre2'
 ```
 
 Enabling the PCRE2 feature works with a stable Rust compiler and will
@@ -494,8 +494,8 @@ Then you just need to add MUSL support to your Rust toolchain and rebuild
 ripgrep, which yields a fully static executable:
 
 ```
-$ rustup target add x86_64-unknown-linux-musl
-$ cargo build --release --target x86_64-unknown-linux-musl
+rustup target add x86_64-unknown-linux-musl
+cargo build --release --target x86_64-unknown-linux-musl
 ```
 
 Applying the `--features` flag from above works as expected. If you want to
@@ -510,7 +510,7 @@ ripgrep is relatively well-tested, including both unit tests and integration
 tests. To run the full test suite, use:
 
 ```
-$ cargo test --all
+cargo test --all
 ```
 
 from the repository root.


### PR DESCRIPTION
Fixes #3323
   
   Removed the `$` shell prompt symbols from all code blocks in README.md so commands can be copy-pasted directly.