### PR TITLE
globset: add fast path for case-insensitive literal/basename patterns

### DIFF
--- a/crates/globset/src/glob.rs
+++ b/crates/globset/src/glob.rs
@@ -162,6 +162,8 @@ struct GlobStrategic {
     strategy: MatchStrategy,
     /// The pattern, as a compiled regex.
     re: Regex,
+    /// Whether the pattern was compiled with case-insensitive matching.
+    case_insensitive: bool,
 }
 
 #[cfg(test)]
@@ -176,9 +178,19 @@ impl GlobStrategic {
         let byte_path = &*candidate.path;
 
         match self.strategy {
-            MatchStrategy::Literal(ref lit) => lit.as_bytes() == byte_path,
+            MatchStrategy::Literal(ref lit) => {
+                if self.case_insensitive {
+                    byte_path.to_ascii_lowercase() == lit.as_bytes()
+                } else {
+                    lit.as_bytes() == byte_path
+                }
+            }
             MatchStrategy::BasenameLiteral(ref lit) => {
-                lit.as_bytes() == &*candidate.basename
+                if self.case_insensitive {
+                    candidate.basename.to_ascii_lowercase() == lit.as_bytes()
+                } else {
+                    lit.as_bytes() == &*candidate.basename
+                }
             }
             MatchStrategy::Extension(ref ext) => {
                 ext.as_bytes() == &*candidate.ext
@@ -301,7 +313,11 @@ impl Glob {
         let strategy = MatchStrategy::new(self);
         let re =
             new_regex(&self.re).expect("regex compilation shouldn't fail");
-        GlobStrategic { strategy, re }
+        GlobStrategic {
+            strategy,
+            re,
+            case_insensitive: self.is_case_insensitive(),
+        }
     }
 
     /// Returns the original glob pattern used to build this pattern.
@@ -327,18 +343,24 @@ impl Glob {
         &self.re
     }
 
+    /// Returns whether this pattern was built with case-insensitive
+    /// matching.
+    pub(crate) fn is_case_insensitive(&self) -> bool {
+        self.opts.case_insensitive
+    }
+
     /// Returns the pattern as a literal if and only if the pattern must match
     /// an entire path exactly.
     ///
     /// The basic format of these patterns is `{literal}`.
     fn literal(&self) -> Option<String> {
-        if self.opts.case_insensitive {
-            return None;
-        }
         let mut lit = String::new();
         for t in &*self.tokens {
             let Token::Literal(c) = *t else { return None };
             lit.push(c);
+        }
+        if self.opts.case_insensitive {
+            lit = lit.to_ascii_lowercase();
         }
         if lit.is_empty() { None } else { Some(lit) }
     }
@@ -508,9 +530,6 @@ impl Glob {
     /// doesn't *always* match when a file path has a basename of `foo`. e.g.,
     /// `foo` doesn't match `abc/foo`.
     fn basename_tokens(&self) -> Option<&[Token]> {
-        if self.opts.case_insensitive {
-            return None;
-        }
         let start = match *self.tokens.get(0)? {
             Token::RecursivePrefix => 1,
             _ => {
@@ -562,6 +581,9 @@ impl Glob {
         for t in tokens {
             let Token::Literal(c) = *t else { return None };
             lit.push(c);
+        }
+        if self.opts.case_insensitive {
+            lit = lit.to_ascii_lowercase();
         }
         Some(lit)
     }
@@ -1461,6 +1483,8 @@ mod tests {
     matches!(matchcasei2, "aBcDeFg", "abcdefg", CASEI);
     matches!(matchcasei3, "aBcDeFg", "ABCDEFG", CASEI);
     matches!(matchcasei4, "aBcDeFg", "AbCdEfG", CASEI);
+    matches!(matchcasei_basename1, "**/FOO", "bar/foo", CASEI);
+    matches!(matchcasei_basename2, "**/FOO", "bar/FOO", CASEI);
 
     matches!(matchalt1, "a,b", "a,b");
     matches!(matchalt2, ",", ",");
@@ -1618,7 +1642,7 @@ mod tests {
     }
 
     literal!(extract_lit1, "foo", Some(s("foo")));
-    literal!(extract_lit2, "foo", None, CASEI);
+    literal!(extract_lit2, "foo", Some(s("foo")), CASEI);
     literal!(extract_lit3, "/foo", Some(s("/foo")));
     literal!(extract_lit4, "/foo/", Some(s("/foo/")));
     literal!(extract_lit5, "/foo/bar", Some(s("/foo/bar")));
@@ -1631,7 +1655,12 @@ mod tests {
         "**/foo",
         Some(&*vec![Literal('f'), Literal('o'), Literal('o'),])
     );
-    basetokens!(extract_basetoks2, "**/foo", None, CASEI);
+    basetokens!(
+        extract_basetoks2,
+        "**/foo",
+        Some(&*vec![Literal('f'), Literal('o'), Literal('o'),]),
+        CASEI
+    );
     basetokens!(
         extract_basetoks3,
         "**/foo",
@@ -1683,4 +1712,5 @@ mod tests {
     baseliteral!(extract_baselit2, "foo", None);
     baseliteral!(extract_baselit3, "*foo", None);
     baseliteral!(extract_baselit4, "*/foo", None);
+    baseliteral!(extract_baselit5, "**/FOO", Some(s("foo")), CASEI);
 }

--- a/crates/globset/src/lib.rs
+++ b/crates/globset/src/lib.rs
@@ -469,8 +469,10 @@ impl GlobSet {
         }
 
         let mut len = 0;
-        let mut lits = LiteralStrategy::new();
-        let mut base_lits = BasenameLiteralStrategy::new();
+        let mut lits = LiteralStrategy::new(false);
+        let mut lits_ci = LiteralStrategy::new(true);
+        let mut base_lits = BasenameLiteralStrategy::new(false);
+        let mut base_lits_ci = BasenameLiteralStrategy::new(true);
         let mut exts = ExtensionStrategy::new();
         let mut prefixes = MultiStrategyBuilder::new();
         let mut suffixes = MultiStrategyBuilder::new();
@@ -480,12 +482,21 @@ impl GlobSet {
             len += 1;
 
             let p = p.as_ref();
+            let case_insensitive = p.is_case_insensitive();
             match MatchStrategy::new(p) {
                 MatchStrategy::Literal(lit) => {
-                    lits.add(i, lit);
+                    if case_insensitive {
+                        lits_ci.add(i, lit);
+                    } else {
+                        lits.add(i, lit);
+                    }
                 }
                 MatchStrategy::BasenameLiteral(lit) => {
-                    base_lits.add(i, lit);
+                    if case_insensitive {
+                        base_lits_ci.add(i, lit);
+                    } else {
+                        base_lits.add(i, lit);
+                    }
                 }
                 MatchStrategy::Extension(ext) => {
                     exts.add(i, ext);
@@ -494,6 +505,9 @@ impl GlobSet {
                     prefixes.add(i, prefix);
                 }
                 MatchStrategy::Suffix { suffix, component } => {
+                    // `suffix()` never returns `Some` for a
+                    // case-insensitive pattern, so this is always the
+                    // case-sensitive literal strategy.
                     if component {
                         lits.add(i, suffix[1..].to_string());
                     }
@@ -513,17 +527,20 @@ impl GlobSet {
             }
         }
         debug!(
-            "built glob set; {} literals, {} basenames, {} extensions, \
+            "built glob set; {} literals, {} case-insensitive literals, \
+                {} basenames, {} case-insensitive basenames, {} extensions, \
                 {} prefixes, {} suffixes, {} required extensions, {} regexes",
             lits.0.len(),
+            lits_ci.0.len(),
             base_lits.0.len(),
+            base_lits_ci.0.len(),
             exts.0.len(),
             prefixes.literals.len(),
             suffixes.literals.len(),
             required_exts.0.len(),
             regexes.literals.len()
         );
-        let mut strats = Vec::with_capacity(7);
+        let mut strats = Vec::with_capacity(9);
         // Only add strategies that are populated
         if !exts.0.is_empty() {
             strats.push(GlobSetMatchStrategy::Extension(exts));
@@ -531,8 +548,14 @@ impl GlobSet {
         if !base_lits.0.is_empty() {
             strats.push(GlobSetMatchStrategy::BasenameLiteral(base_lits));
         }
+        if !base_lits_ci.0.is_empty() {
+            strats.push(GlobSetMatchStrategy::BasenameLiteral(base_lits_ci));
+        }
         if !lits.0.is_empty() {
             strats.push(GlobSetMatchStrategy::Literal(lits));
+        }
+        if !lits_ci.0.is_empty() {
+            strats.push(GlobSetMatchStrategy::Literal(lits_ci));
         }
         if !suffixes.is_empty() {
             strats.push(GlobSetMatchStrategy::Suffix(suffixes.suffix()));
@@ -707,19 +730,28 @@ impl GlobSetMatchStrategy {
 }
 
 #[derive(Clone, Debug)]
-struct LiteralStrategy(fnv::HashMap<Vec<u8>, Vec<usize>>);
+struct LiteralStrategy(fnv::HashMap<Vec<u8>, Vec<usize>>, bool);
 
 impl LiteralStrategy {
-    fn new() -> LiteralStrategy {
-        LiteralStrategy(fnv::HashMap::default())
+    fn new(case_insensitive: bool) -> LiteralStrategy {
+        LiteralStrategy(fnv::HashMap::default(), case_insensitive)
     }
 
     fn add(&mut self, global_index: usize, lit: String) {
-        self.0.entry(lit.into_bytes()).or_insert(vec![]).push(global_index);
+        let lit = if self.1 {
+            lit.into_bytes().to_ascii_lowercase()
+        } else {
+            lit.into_bytes()
+        };
+        self.0.entry(lit).or_insert(vec![]).push(global_index);
     }
 
     fn is_match(&self, candidate: &Candidate<'_>) -> bool {
-        self.0.contains_key(candidate.path.as_bytes())
+        if self.1 {
+            self.0.contains_key(&candidate.path.to_ascii_lowercase())
+        } else {
+            self.0.contains_key(candidate.path.as_bytes())
+        }
     }
 
     fn matches_all(&self, candidate: &Candidate<'_>) -> bool {
@@ -732,29 +764,43 @@ impl LiteralStrategy {
         candidate: &Candidate<'_>,
         matches: &mut Vec<usize>,
     ) {
-        if let Some(hits) = self.0.get(candidate.path.as_bytes()) {
+        let hits = if self.1 {
+            self.0.get(&candidate.path.to_ascii_lowercase())
+        } else {
+            self.0.get(candidate.path.as_bytes())
+        };
+        if let Some(hits) = hits {
             matches.extend(hits);
         }
     }
 }
 
 #[derive(Clone, Debug)]
-struct BasenameLiteralStrategy(fnv::HashMap<Vec<u8>, Vec<usize>>);
+struct BasenameLiteralStrategy(fnv::HashMap<Vec<u8>, Vec<usize>>, bool);
 
 impl BasenameLiteralStrategy {
-    fn new() -> BasenameLiteralStrategy {
-        BasenameLiteralStrategy(fnv::HashMap::default())
+    fn new(case_insensitive: bool) -> BasenameLiteralStrategy {
+        BasenameLiteralStrategy(fnv::HashMap::default(), case_insensitive)
     }
 
     fn add(&mut self, global_index: usize, lit: String) {
-        self.0.entry(lit.into_bytes()).or_insert(vec![]).push(global_index);
+        let lit = if self.1 {
+            lit.into_bytes().to_ascii_lowercase()
+        } else {
+            lit.into_bytes()
+        };
+        self.0.entry(lit).or_insert(vec![]).push(global_index);
     }
 
     fn is_match(&self, candidate: &Candidate<'_>) -> bool {
         if candidate.basename.is_empty() {
             return false;
         }
-        self.0.contains_key(candidate.basename.as_bytes())
+        if self.1 {
+            self.0.contains_key(&candidate.basename.to_ascii_lowercase())
+        } else {
+            self.0.contains_key(candidate.basename.as_bytes())
+        }
     }
 
     fn matches_all(&self, candidate: &Candidate<'_>) -> bool {
@@ -770,7 +816,12 @@ impl BasenameLiteralStrategy {
         if candidate.basename.is_empty() {
             return;
         }
-        if let Some(hits) = self.0.get(candidate.basename.as_bytes()) {
+        let hits = if self.1 {
+            self.0.get(&candidate.basename.to_ascii_lowercase())
+        } else {
+            self.0.get(candidate.basename.as_bytes())
+        };
+        if let Some(hits) = hits {
             matches.extend(hits);
         }
     }


### PR DESCRIPTION
## Summary

Addresses #1086: case-insensitive glob patterns that are pure literals (no wildcards) — e.g. a bare filename with `.case_insensitive(true)` — were always falling through to full regex matching, even though there's no wildcard to justify it. On a large pattern set this is orders of magnitude slower than the literal fast path already used for case-sensitive literals (see the benchmark in the issue).

**Scope note:** this covers the `Literal` and `BasenameLiteral` strategies, which is what the issue's own `ignore::overrides` benchmark exercises. `ext()`/`prefix()`/`suffix()` are intentionally left as-is (still falling back to regex for case-insensitive patterns) — `ExtensionStrategy` and the prefix/suffix `MultiStrategyBuilder` have no case-insensitive comparison mode, and wiring case-insensitive literals into them without that support would silently produce wrong matches (e.g. a case-insensitive `*.TXT` pattern failing to match a real `photo.TXT` file). Extending those is a reasonable follow-up but is a larger, separate change — didn't want to bundle a correctness risk into a perf fix.

## Changes

- `literal()` / `basename_literal()` no longer bail out early on `case_insensitive`; they ASCII-lowercase the extracted literal and let it flow into the existing `Literal`/`BasenameLiteral` match strategies instead of forcing `MatchStrategy::Regex`.
- `LiteralStrategy` / `BasenameLiteralStrategy` gained a case-insensitive mode: literals are lowercased on insert, lookups lowercase the candidate path/basename before hashing.
- `GlobSet::new()` now builds separate case-sensitive and case-insensitive instances of each strategy and routes each pattern into the right one.
- Lowercasing is ASCII-only (`to_ascii_lowercase`, not `to_lowercase`) to match this crate's actual case-insensitive semantics — `regex-syntax` is built here without the `unicode-case` feature, so even the pre-existing `(?i)` regex fallback can't fold non-ASCII case pairs (confirmed directly: `(?i)` on a pattern with a non-ASCII literal fails to compile at all in this build with `UnicodeCaseUnavailable`). Using Unicode-aware lowercasing in the new fast path would have made it behave differently from the regex path it replaces for the same logical pattern.

## Test plan
- [x] `cargo test -p globset` — 293 passed, 0 failed (added case-insensitive literal/basename correctness tests, plus fixed two pre-existing tests that encoded the old bail-out-to-None behavior as expected)
- [x] `cargo test -p ignore` (direct consumer) — 182 unit + 5 integration + 7 doctests, all pass
- [x] `cargo fmt -p globset -- --check` — clean
- [x] `cargo clippy -p globset --all-targets -- -D warnings` — no new warnings introduced by this diff (24 pre-existing warnings elsewhere in the crate, unrelated to this change, left untouched)
- [ ] Full workspace build not runnable in this environment (local rustc 1.95, workspace `ripgrep`/`grep-*` crates pin 1.96 — unrelated to this change; `globset` itself only requires 1.88 and builds/tests fine)