### PR TITLE
fix(ignore): preserve escaped trailing spaces in gitignore patterns

### DIFF
--- a/crates/ignore/src/gitignore.rs
+++ b/crates/ignore/src/gitignore.rs
@@ -465,9 +465,17 @@ impl GitignoreBuilder {
         if line.starts_with("#") {
             return Ok(self);
         }
-        if !line.ends_with("\\ ") {
-            line = line.trim_right();
+        // Only trim unescaped trailing spaces
+        let mut trimmed = line;
+        while trimmed.len() > 0 && trimmed.ends_with(' ') {
+            // Check if the space is escaped (preceded by backslash)
+            let before_space = trimmed.len() - 1;
+            if before_space > 0 && trimmed.as_bytes()[before_space - 1] == b'\\' {
+                break;  // Space is escaped, don't trim
+            }
+            trimmed = &trimmed[..before_space];
         }
+        line = trimmed;
         if line.is_empty() {
             return Ok(self);
         }

--- a/crates/ignore/src/gitignore.rs
+++ b/crates/ignore/src/gitignore.rs
@@ -454,9 +454,23 @@ impl GitignoreBuilder {
         if line.starts_with("#") {
             return Ok(self);
         }
-        if !line.ends_with("\\ ") {
-            line = line.trim_right();
+        // Only trim unescaped trailing spaces.
+        // A space is escaped only if preceded by an ODD number of backslashes.
+        let mut trimmed = line;
+        while trimmed.len() > 1 && trimmed.ends_with(' ') {
+            let before_space = trimmed.len() - 1;
+            let mut n_backslashes = 0usize;
+            let mut i = before_space;
+            while i > 0 && trimmed.as_bytes()[i - 1] == b'\\' {
+                n_backslashes += 1;
+                i -= 1;
+            }
+            if n_backslashes % 2 == 1 {
+                break; // Odd number of backslashes: space is escaped
+            }
+            trimmed = &trimmed[..before_space];
         }
+        line = trimmed;
         if line.is_empty() {
             return Ok(self);
         }


### PR DESCRIPTION
## Summary

`.gitignore` lines like `foo\   ` (escaped space followed by more spaces) were over-trimmed: only a single trailing `\ ` was preserved, so the pattern collapsed to `foo\` and failed with `dangling '\'`.

Git keeps the escaped trailing space. Match that by trimming only **unescaped** trailing spaces.

### Fix

- Replace `line.trim_right()` with logic that only trims unescaped trailing spaces
- Preserve escaped spaces (preceded by backslash) while removing unescaped ones

Fixes #3485