### PR TITLE
ci: attest build provenance for release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 # We need this to be able to create releases.
 permissions:
   contents: write
+  id-token: write # for build provenance signing
+  attestations: write # to record the attestation
 
 jobs:
   # The create-release job runs purely to initialize the GitHub release itself,
@@ -281,6 +283,11 @@ jobs:
         shasum -a 256 "$ARCHIVE.tar.gz" > "$ARCHIVE.tar.gz.sha256"
         echo "ASSET=$ARCHIVE.tar.gz" >> $GITHUB_ENV
         echo "ASSET_SUM=$ARCHIVE.tar.gz.sha256" >> $GITHUB_ENV
+
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: ${{ env.ASSET }}
 
     - name: Upload release archive
       env:


### PR DESCRIPTION
Hi, and thanks for ripgrep.

The release workflow already publishes a `.sha256` next to every archive, which covers integrity — if the bytes change, the sum stops matching. What it cannot say is where the bytes came from. A checksum computed and uploaded by the same job proves the archive matches what that job produced, not that the job was this workflow on this tag in this repository.

Given how ripgrep is distributed — the GitHub release archives are what a lot of package managers, Dockerfiles and `curl`-based install snippets fetch directly — that origin question seemed worth closing.

This PR adds GitHub's build attestation to the `build-release` job, immediately before the upload:

```yaml
permissions:
  contents: write
  id-token: write      # for build provenance signing
  attestations: write  # to record the attestation
...
    - name: Attest build provenance
      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
      with:
        subject-path: ${{ env.ASSET }}
```

It reuses the `ASSET` variable the job already sets, so it covers each matrix target's `.tar.gz` or `.zip` without duplicating the naming logic. After a release, anyone can run:

```
gh attestation verify ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz --repo BurntSushi/ripgrep
```

and get back the workflow, commit and run that built it. The existing checksums keep doing their job — this sits alongside them, it does not replace them.

A few things I deliberately did not do:

- **The `.deb` job is untouched.** Its upload does `cd "$DEB_DIR"` first, so a `subject-path` there needs a workspace-relative path rather than the bare `$DEB_NAME`, and I did not want to guess at it in a first PR. Happy to add it if you want the deb covered too.
- **I did not attest the `.sha256` files.** They are covered transitively and attesting them adds noise.
- **No SLSA level is claimed.** The attestation is what it is; what level the overall build qualifies for is a separate judgement I am not in a position to make for you.

The two added permissions are additive at the top level, so every job keeps the `contents: write` it has today.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the release workflow myself.
