### PR TITLE
ignore: prune directories outside positive glob prefixes

### DIFF
--- a/crates/ignore/src/incremental.rs
+++ b/crates/ignore/src/incremental.rs
@@ -758,31 +758,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn glob_overrides_prune_unreachable_rooted_directories() {
-        let td = tmpdir();
-        mkdirp(td.path().join("src/child"));
-        mkdirp(td.path().join("nested/src"));
-
-        for glob in ["/src/", "/src/   ", r"/src\/"] {
-            let mut overrides = OverrideBuilder::new(td.path());
-            overrides.add(glob).unwrap();
-            let mut b = builder(td.path());
-            b.overrides(overrides.build().unwrap());
-
-            let mut m = one_matcher(&b);
-            assert!(matchedd(&mut m, "src").is_whitelist(), "glob: {glob}");
-
-            let nested = matchedd(&mut m, "nested");
-            assert!(nested.is_ignore(), "glob: {glob}");
-            assert!(!nested.should_descend(), "glob: {glob}");
-            assert!(
-                matchedd(&mut m, "nested/src").is_ignore(),
-                "glob: {glob}"
-            );
-        }
-    }
-
     // Test that file type selections are applied to files, but not
     // directories.
     #[test]

--- a/crates/ignore/src/incremental.rs
+++ b/crates/ignore/src/incremental.rs
@@ -726,6 +726,14 @@ mod tests {
         let mut m = one_matcher(&b);
 
         assert!(matchedf(&mut m, "blocked/keep.rs").is_ignore());
+
+        let mut overrides = OverrideBuilder::new("a/b");
+        overrides.add("c/**/*.rs").unwrap();
+        let mut b = builder(".");
+        b.standard_filters(false).overrides(overrides.build().unwrap());
+        let mut m = one_matcher(&b);
+        assert!(matchedd(&mut m, "a").is_none());
+        assert!(matchedf(&mut m, "a/b/c/file.rs").is_whitelist());
     }
 
     #[test]

--- a/crates/ignore/src/incremental.rs
+++ b/crates/ignore/src/incremental.rs
@@ -728,6 +728,61 @@ mod tests {
         assert!(matchedf(&mut m, "blocked/keep.rs").is_ignore());
     }
 
+    #[test]
+    fn glob_overrides_preserve_nested_basename_directories() {
+        let td = tmpdir();
+        mkdirp(td.path().join("src"));
+        mkdirp(td.path().join("nested/src"));
+
+        for glob in ["src/", "src/   ", r"src\/"] {
+            let mut overrides = OverrideBuilder::new(td.path());
+            overrides.add(glob).unwrap();
+            let mut b = builder(td.path());
+            b.overrides(overrides.build().unwrap());
+
+            let mut m = one_matcher(&b);
+            let nested = matchedd(&mut m, "nested");
+            assert!(nested.is_none(), "glob: {glob}");
+            assert!(nested.should_descend(), "glob: {glob}");
+            assert!(
+                matchedd(&mut m, "nested/src").is_whitelist(),
+                "glob: {glob}"
+            );
+
+            let mut m = one_matcher(&b);
+            assert!(
+                matchedd(&mut m, "nested/src").is_whitelist(),
+                "glob: {glob}"
+            );
+            assert!(matchedd(&mut m, "nested").is_none(), "glob: {glob}");
+        }
+    }
+
+    #[test]
+    fn glob_overrides_prune_unreachable_rooted_directories() {
+        let td = tmpdir();
+        mkdirp(td.path().join("src/child"));
+        mkdirp(td.path().join("nested/src"));
+
+        for glob in ["/src/", "/src/   ", r"/src\/"] {
+            let mut overrides = OverrideBuilder::new(td.path());
+            overrides.add(glob).unwrap();
+            let mut b = builder(td.path());
+            b.overrides(overrides.build().unwrap());
+
+            let mut m = one_matcher(&b);
+            assert!(matchedd(&mut m, "src").is_whitelist(), "glob: {glob}");
+
+            let nested = matchedd(&mut m, "nested");
+            assert!(nested.is_ignore(), "glob: {glob}");
+            assert!(!nested.should_descend(), "glob: {glob}");
+            assert!(
+                matchedd(&mut m, "nested/src").is_ignore(),
+                "glob: {glob}"
+            );
+        }
+    }
+
     // Test that file type selections are applied to files, but not
     // directories.
     #[test]

--- a/crates/ignore/src/overrides.rs
+++ b/crates/ignore/src/overrides.rs
@@ -44,12 +44,12 @@ impl<'a> Glob<'a> {
 
 /// Manages a set of overrides provided explicitly by the end user.
 #[derive(Clone, Debug)]
-pub struct Override(Gitignore);
+pub struct Override(Gitignore, Option<Gitignore>);
 
 impl Override {
     /// Returns an empty matcher that never matches any file path.
     pub fn empty() -> Override {
-        Override(Gitignore::empty())
+        Override(Gitignore::empty(), None)
     }
 
     /// Returns the directory of this override set.
@@ -88,6 +88,9 @@ impl Override {
     /// this never returns `Match::None`, since non-matches are interpreted as
     /// ignored.
     ///
+    /// A directory may also be ignored if its path cannot contain a match for
+    /// any whitelist override.
+    ///
     /// The given path is matched to the globs relative to the path given
     /// when building the override matcher. Specifically, before matching
     /// `path`, its prefix (as determined by a common suffix of the directory
@@ -102,9 +105,16 @@ impl Override {
         if self.is_empty() {
             return Match::None;
         }
+        let path = path.as_ref();
         let mat = self.0.matched(path, is_dir).invert();
-        if mat.is_none() && self.num_whitelists() > 0 && !is_dir {
-            return Match::Ignore(Glob::unmatched());
+        if mat.is_none() && self.num_whitelists() > 0 {
+            if !is_dir
+                || self.1.as_ref().is_some_and(|prefixes| {
+                    prefixes.matched(path, true).is_none()
+                })
+            {
+                return Match::Ignore(Glob::unmatched());
+            }
         }
         mat.map(move |giglob| Glob(GlobInner::Matched(giglob)))
     }
@@ -114,6 +124,8 @@ impl Override {
 #[derive(Clone, Debug)]
 pub struct OverrideBuilder {
     builder: GitignoreBuilder,
+    directory_prefixes: Option<GitignoreBuilder>,
+    case_insensitive: bool,
 }
 
 impl OverrideBuilder {
@@ -121,16 +133,26 @@ impl OverrideBuilder {
     ///
     /// Matching is done relative to the directory path provided.
     pub fn new<P: AsRef<Path>>(path: P) -> OverrideBuilder {
+        let path = path.as_ref();
         let mut builder = GitignoreBuilder::new(path);
         builder.allow_unclosed_class(false);
-        OverrideBuilder { builder }
+        OverrideBuilder {
+            builder,
+            directory_prefixes: Some(GitignoreBuilder::new(path)),
+            case_insensitive: false,
+        }
     }
 
     /// Builds a new override matcher from the globs added so far.
     ///
     /// Once a matcher is built, no new globs can be added to it.
     pub fn build(&self) -> Result<Override, Error> {
-        Ok(Override(self.builder.build()?))
+        let directory_prefixes = self
+            .directory_prefixes
+            .as_ref()
+            .map(GitignoreBuilder::build)
+            .transpose()?;
+        Ok(Override(self.builder.build()?, directory_prefixes))
     }
 
     /// Add a glob to the set of overrides.
@@ -141,6 +163,34 @@ impl OverrideBuilder {
     /// all matches of the glob provided are treated as whitelist matches.
     pub fn add(&mut self, glob: &str) -> Result<&mut OverrideBuilder, Error> {
         self.builder.add_line(None, glob)?;
+        if glob.starts_with('!')
+            || glob.starts_with('#')
+            || glob.trim_end().is_empty()
+        {
+            return Ok(self);
+        }
+        if self.case_insensitive {
+            self.directory_prefixes = None;
+            return Ok(self);
+        }
+        if let Some(prefixes) = &mut self.directory_prefixes {
+            let glob = glob.strip_prefix('/').unwrap_or(glob);
+            match glob.split_once('/') {
+                Some((component, _))
+                    if !component.is_empty()
+                        && component != "."
+                        && component != ".."
+                        && component.bytes().all(|byte| {
+                            byte.is_ascii_alphanumeric()
+                                || matches!(byte, b'_' | b'-' | b'.')
+                        }) =>
+                {
+                    prefixes.add_line(None, &format!("/{component}"))?;
+                    prefixes.add_line(None, &format!("/{component}/**"))?;
+                }
+                _ => self.directory_prefixes = None,
+            }
+        }
         Ok(self)
     }
 
@@ -157,6 +207,7 @@ impl OverrideBuilder {
         // TODO: This should not return a `Result`. Fix this in the next semver
         // release.
         self.builder.case_insensitive(yes)?;
+        self.case_insensitive = yes;
         Ok(self)
     }
 
@@ -258,6 +309,89 @@ mod tests {
         assert!(ov.matched("src/foo.c", false).is_ignore());
         assert!(ov.matched("src/foo", false).is_ignore());
         assert!(ov.matched("src/foo", true).is_none());
+    }
+
+    #[test]
+    fn literal_prefix_prunes_unmatched_directories() {
+        let ov = ov(&["src/**/*.rs"]);
+
+        assert!(ov.matched("src", true).is_none());
+        assert!(ov.matched("src/nested", true).is_none());
+        assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
+        assert!(ov.matched("outside", true).is_ignore());
+        assert!(ov.matched("outside/nested", true).is_ignore());
+    }
+
+    #[test]
+    fn literal_prefixes_preserve_all_matching_roots() {
+        let ov = ov(&["src/**/*.rs", "tests/**/*.rs", "!tests/generated.rs"]);
+
+        assert!(ov.matched("src", true).is_none());
+        assert!(ov.matched("tests", true).is_none());
+        assert!(ov.matched("tests/nested", true).is_none());
+        assert!(ov.matched("tests/nested/main.rs", false).is_whitelist());
+        assert!(ov.matched("tests/generated.rs", false).is_ignore());
+        assert!(ov.matched("outside", true).is_ignore());
+    }
+
+    #[test]
+    fn unsupported_positive_glob_disables_directory_pruning() {
+        let ov = ov(&["src/**/*.rs", "*.py"]);
+
+        assert!(ov.matched("src", true).is_none());
+        assert!(ov.matched("outside", true).is_none());
+        assert!(ov.matched("outside/nested", true).is_none());
+        assert!(ov.matched("outside/nested/main.py", false).is_whitelist());
+        assert!(ov.matched("outside/nested/main.rs", false).is_ignore());
+    }
+
+    #[test]
+    fn absolute_literal_prefix_prunes_unmatched_directories() {
+        let ov = ov(&["/src/**/*.rs"]);
+
+        assert!(ov.matched("src", true).is_none());
+        assert!(ov.matched("src/nested", true).is_none());
+        assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
+        assert!(ov.matched("outside", true).is_ignore());
+    }
+
+    #[test]
+    fn dot_components_disable_directory_pruning() {
+        for glob in ["./src/**/*.rs", "../src/**/*.rs", "//src/**/*.rs"] {
+            let ov = ov(&[glob]);
+
+            assert!(ov.matched("outside", true).is_none(), "glob: {glob}");
+        }
+    }
+
+    #[test]
+    fn changing_case_mode_preserves_existing_literal_prefix() {
+        let ov = OverrideBuilder::new(ROOT)
+            .add("src/**/*.rs")
+            .unwrap()
+            .case_insensitive(true)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert!(ov.matched("src", true).is_none());
+        assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
+        assert!(ov.matched("outside", true).is_ignore());
+    }
+
+    #[test]
+    fn case_insensitive_positive_disables_directory_pruning() {
+        let ov = OverrideBuilder::new(ROOT)
+            .case_insensitive(true)
+            .unwrap()
+            .add("src/**/*.rs")
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert!(ov.matched("SRC", true).is_none());
+        assert!(ov.matched("SRC/nested/main.RS", false).is_whitelist());
+        assert!(ov.matched("outside", true).is_none());
     }
 
     #[test]

--- a/crates/ignore/src/overrides.rs
+++ b/crates/ignore/src/overrides.rs
@@ -115,14 +115,15 @@ impl Override {
                 || self.1.as_ref().is_some_and(|prefixes| {
                     let normalized = crate::pathutil::strip_prefix("./", path)
                         .unwrap_or(path);
-                    if path == self.path() || normalized == self.path() {
+                    let root = self.path();
+                    if path == root || root.starts_with(normalized) {
                         return false;
                     }
                     let path = normalized;
-                    let path = if self.path() == Path::new(".") {
+                    let path = if root == Path::new(".") {
                         path
                     } else if let Some(relative) =
-                        crate::pathutil::strip_prefix(self.path(), path)
+                        crate::pathutil::strip_prefix(root, path)
                     {
                         crate::pathutil::strip_prefix("/", relative)
                             .unwrap_or(relative)
@@ -376,6 +377,8 @@ mod tests {
             ("./src/", "./src"),
             ("././src", "./src"),
             ("././src", "././src"),
+            ("a/b", "a"),
+            ("./a/b", "a"),
         ] {
             let matcher = ov_at(root, &["2/**/*.rs"]);
             assert!(

--- a/crates/ignore/src/overrides.rs
+++ b/crates/ignore/src/overrides.rs
@@ -111,6 +111,11 @@ impl Override {
             if !is_dir
                 || self.1.as_ref().is_some_and(|prefixes| {
                     prefixes.matched(path, true).is_none()
+                        && !path.as_os_str().is_empty()
+                        && path != Path::new(".")
+                        && path != self.path()
+                        && !crate::pathutil::strip_prefix("./", path)
+                            .is_some_and(|relative| relative == self.path())
                 })
             {
                 return Match::Ignore(Glob::unmatched());
@@ -339,6 +344,70 @@ mod tests {
         assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
         assert!(ov.matched("outside", true).is_ignore());
         assert!(ov.matched("outside/nested", true).is_ignore());
+    }
+
+    #[test]
+    fn literal_prefix_preserves_override_root() {
+        let cases = [
+            (ROOT, ROOT),
+            (ROOT, ""),
+            (ROOT, "."),
+            (ROOT, "./"),
+            (".", "."),
+            (".", ""),
+            (".", "./"),
+            ("", ""),
+            ("", "."),
+            ("", "./"),
+            ("repo", "repo"),
+            ("repo", "./repo"),
+            ("./repo", "repo"),
+            ("./repo", "./repo"),
+        ];
+
+        for (root, path) in cases {
+            let ov = OverrideBuilder::new(root)
+                .add("src/**/*.rs")
+                .unwrap()
+                .build()
+                .unwrap();
+
+            assert!(
+                ov.matched(path, true).is_none(),
+                "root: {root:?}, path: {path:?}"
+            );
+            assert!(ov.matched("src", true).is_none());
+            assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
+            assert!(ov.matched("outside", true).is_ignore());
+        }
+    }
+
+    #[test]
+    fn literal_prefix_preserves_explicit_root_ignores() {
+        let cases = [
+            ("repo", "repo"),
+            ("repo", "./repo"),
+            ("./repo", "repo"),
+            ("./repo", "./repo"),
+        ];
+
+        for (root, path) in cases {
+            let ov = OverrideBuilder::new(root)
+                .add("src/**/*.rs")
+                .unwrap()
+                .add("!repo")
+                .unwrap()
+                .build()
+                .unwrap();
+
+            assert!(
+                ov.matched(path, true).is_ignore(),
+                "root: {root:?}, path: {path:?}"
+            );
+            assert!(ov.matched("src", true).is_none());
+            assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
+            assert!(ov.matched("outside", true).is_ignore());
+        }
     }
 
     #[test]

--- a/crates/ignore/src/overrides.rs
+++ b/crates/ignore/src/overrides.rs
@@ -5,7 +5,10 @@ This provides functionality similar to `--include` or `--exclude` in command
 line tools.
 */
 
-use std::{collections::HashSet, path::Path};
+use std::{
+    collections::HashSet,
+    path::{Component, Path},
+};
 
 use crate::{
     Error, Match,
@@ -44,7 +47,7 @@ impl<'a> Glob<'a> {
 
 /// Manages a set of overrides provided explicitly by the end user.
 #[derive(Clone, Debug)]
-pub struct Override(Gitignore, Option<Gitignore>);
+pub struct Override(Gitignore, Option<HashSet<String>>);
 
 impl Override {
     /// Returns an empty matcher that never matches any file path.
@@ -110,12 +113,29 @@ impl Override {
         if mat.is_none() && self.num_whitelists() > 0 {
             if !is_dir
                 || self.1.as_ref().is_some_and(|prefixes| {
-                    prefixes.matched(path, true).is_none()
-                        && !path.as_os_str().is_empty()
-                        && path != Path::new(".")
-                        && path != self.path()
-                        && !crate::pathutil::strip_prefix("./", path)
-                            .is_some_and(|relative| relative == self.path())
+                    let normalized = crate::pathutil::strip_prefix("./", path)
+                        .unwrap_or(path);
+                    if path == self.path() || normalized == self.path() {
+                        return false;
+                    }
+                    let path = normalized;
+                    let path = if self.path() == Path::new(".") {
+                        path
+                    } else if let Some(relative) =
+                        crate::pathutil::strip_prefix(self.path(), path)
+                    {
+                        crate::pathutil::strip_prefix("/", relative)
+                            .unwrap_or(relative)
+                    } else {
+                        path
+                    };
+                    path.components()
+                        .next()
+                        .and_then(|component| match component {
+                            Component::Normal(component) => component.to_str(),
+                            _ => None,
+                        })
+                        .is_some_and(|component| !prefixes.contains(component))
                 })
             {
                 return Match::Ignore(Glob::unmatched());
@@ -129,8 +149,7 @@ impl Override {
 #[derive(Clone, Debug)]
 pub struct OverrideBuilder {
     builder: GitignoreBuilder,
-    directory_prefixes: Option<GitignoreBuilder>,
-    directory_prefix_components: HashSet<String>,
+    directory_prefixes: Option<HashSet<String>>,
     case_insensitive: bool,
 }
 
@@ -139,13 +158,11 @@ impl OverrideBuilder {
     ///
     /// Matching is done relative to the directory path provided.
     pub fn new<P: AsRef<Path>>(path: P) -> OverrideBuilder {
-        let path = path.as_ref();
         let mut builder = GitignoreBuilder::new(path);
         builder.allow_unclosed_class(false);
         OverrideBuilder {
             builder,
-            directory_prefixes: Some(GitignoreBuilder::new(path)),
-            directory_prefix_components: HashSet::new(),
+            directory_prefixes: Some(HashSet::new()),
             case_insensitive: false,
         }
     }
@@ -154,12 +171,7 @@ impl OverrideBuilder {
     ///
     /// Once a matcher is built, no new globs can be added to it.
     pub fn build(&self) -> Result<Override, Error> {
-        let directory_prefixes = self
-            .directory_prefixes
-            .as_ref()
-            .map(GitignoreBuilder::build)
-            .transpose()?;
-        Ok(Override(self.builder.build()?, directory_prefixes))
+        Ok(Override(self.builder.build()?, self.directory_prefixes.clone()))
     }
 
     /// Add a glob to the set of overrides.
@@ -203,14 +215,7 @@ impl OverrideBuilder {
                                 || matches!(byte, b'_' | b'-' | b'.')
                         }) =>
                 {
-                    if self
-                        .directory_prefix_components
-                        .insert(component.to_owned())
-                    {
-                        prefixes.add_line(None, &format!("/{component}"))?;
-                        prefixes
-                            .add_line(None, &format!("/{component}/**"))?;
-                    }
+                    prefixes.insert(component.to_owned());
                 }
                 _ => self.directory_prefixes = None,
             }
@@ -265,7 +270,11 @@ mod tests {
     const ROOT: &'static str = "/home/andrew/foo";
 
     fn ov(globs: &[&str]) -> Override {
-        let mut builder = OverrideBuilder::new(ROOT);
+        ov_at(ROOT, globs)
+    }
+
+    fn ov_at(root: &str, globs: &[&str]) -> Override {
+        let mut builder = OverrideBuilder::new(root);
         for glob in globs {
             builder.add(glob).unwrap();
         }
@@ -337,159 +346,70 @@ mod tests {
 
     #[test]
     fn literal_prefix_prunes_unmatched_directories() {
-        let ov = ov(&["src/**/*.rs"]);
+        let matcher = ov(&["src/**/*.rs", "src/**/*.py", "!src/generated.rs"]);
+        assert_eq!(matcher.1.as_ref().unwrap().len(), 1);
+        assert!(matcher.matched("src/nested", true).is_none());
+        assert!(matcher.matched("src/nested/main.rs", false).is_whitelist());
+        assert!(matcher.matched("src/generated.rs", false).is_ignore());
+        assert!(matcher.matched("outside", true).is_ignore());
 
-        assert!(ov.matched("src", true).is_none());
-        assert!(ov.matched("src/nested", true).is_none());
-        assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
-        assert!(ov.matched("outside", true).is_ignore());
-        assert!(ov.matched("outside/nested", true).is_ignore());
+        for glob in ["/src/**/*.rs", "/src/", "/src/   ", r"/src\/"] {
+            let matcher = ov(&[glob]);
+            assert!(!matcher.matched("src", true).is_ignore(), "{glob}");
+            assert!(matcher.matched("outside", true).is_ignore(), "{glob}");
+        }
     }
 
     #[test]
-    fn literal_prefix_preserves_override_root() {
-        let cases = [
+    fn literal_prefix_preserves_override_root_and_explicit_ignores() {
+        for (root, path) in [
             (ROOT, ROOT),
             (ROOT, ""),
             (ROOT, "."),
-            (ROOT, "./"),
-            (".", "."),
-            (".", ""),
             (".", "./"),
             ("", ""),
-            ("", "."),
-            ("", "./"),
             ("repo", "repo"),
             ("repo", "./repo"),
             ("./repo", "repo"),
             ("./repo", "./repo"),
-        ];
-
-        for (root, path) in cases {
-            let ov = OverrideBuilder::new(root)
-                .add("src/**/*.rs")
-                .unwrap()
-                .build()
-                .unwrap();
-
+            ("src/", "./src"),
+            ("./src/", "./src"),
+            ("././src", "./src"),
+            ("././src", "././src"),
+        ] {
+            let matcher = ov_at(root, &["2/**/*.rs"]);
             assert!(
-                ov.matched(path, true).is_none(),
+                matcher.matched(path, true).is_none(),
                 "root: {root:?}, path: {path:?}"
             );
-            assert!(ov.matched("src", true).is_none());
-            assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
-            assert!(ov.matched("outside", true).is_ignore());
+        }
+        for root in ["repo", "./repo"] {
+            let matcher = ov_at(root, &["src/**/*.rs", "!repo"]);
+            assert!(matcher.matched("repo", true).is_ignore());
         }
     }
 
     #[test]
-    fn literal_prefix_preserves_explicit_root_ignores() {
-        let cases = [
-            ("repo", "repo"),
-            ("repo", "./repo"),
-            ("./repo", "repo"),
-            ("./repo", "./repo"),
-        ];
-
-        for (root, path) in cases {
-            let ov = OverrideBuilder::new(root)
-                .add("src/**/*.rs")
-                .unwrap()
-                .add("!repo")
-                .unwrap()
-                .build()
-                .unwrap();
-
-            assert!(
-                ov.matched(path, true).is_ignore(),
-                "root: {root:?}, path: {path:?}"
-            );
-            assert!(ov.matched("src", true).is_none());
-            assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
-            assert!(ov.matched("outside", true).is_ignore());
+    fn unsupported_positive_globs_disable_directory_pruning() {
+        for glob in [
+            "*.py",
+            "src/",
+            "src/   ",
+            r"src\/",
+            "./src/**/*.rs",
+            "../src/**/*.rs",
+            "//src/**/*.rs",
+        ] {
+            let matcher = ov(&["src/**/*.rs", glob]);
+            assert!(matcher.matched("outside", true).is_none(), "{glob}");
         }
-    }
-
-    #[test]
-    fn literal_prefixes_preserve_all_matching_roots() {
-        let ov = ov(&["src/**/*.rs", "tests/**/*.rs", "!tests/generated.rs"]);
-
-        assert!(ov.matched("src", true).is_none());
-        assert!(ov.matched("tests", true).is_none());
-        assert!(ov.matched("tests/nested", true).is_none());
-        assert!(ov.matched("tests/nested/main.rs", false).is_whitelist());
-        assert!(ov.matched("tests/generated.rs", false).is_ignore());
-        assert!(ov.matched("outside", true).is_ignore());
-    }
-
-    #[test]
-    fn unsupported_positive_glob_disables_directory_pruning() {
-        let ov = ov(&["src/**/*.rs", "*.py"]);
-
-        assert!(ov.matched("src", true).is_none());
-        assert!(ov.matched("outside", true).is_none());
-        assert!(ov.matched("outside/nested", true).is_none());
-        assert!(ov.matched("outside/nested/main.py", false).is_whitelist());
-        assert!(ov.matched("outside/nested/main.rs", false).is_ignore());
-    }
-
-    #[test]
-    fn absolute_literal_prefix_prunes_unmatched_directories() {
-        let ov = ov(&["/src/**/*.rs"]);
-
-        assert!(ov.matched("src", true).is_none());
-        assert!(ov.matched("src/nested", true).is_none());
-        assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
-        assert!(ov.matched("outside", true).is_ignore());
-    }
-
-    #[test]
-    fn basename_directory_globs_preserve_nested_directories() {
         for glob in ["src/", "src/   ", r"src\/"] {
-            let ov = ov(&[glob]);
-
-            assert!(ov.matched("nested", true).is_none(), "glob: {glob}");
-            assert!(
-                ov.matched("nested/src", true).is_whitelist(),
-                "glob: {glob}"
-            );
-            assert!(ov.matched("outside", true).is_none(), "glob: {glob}");
+            assert!(ov(&[glob]).matched("nested/src", true).is_whitelist());
         }
     }
 
     #[test]
-    fn rooted_directory_globs_prune_unmatched_directories() {
-        for glob in ["/src/", "/src/   ", r"/src\/"] {
-            let ov = ov(&[glob]);
-
-            assert!(ov.matched("src", true).is_whitelist(), "glob: {glob}");
-            assert!(ov.matched("nested", true).is_ignore(), "glob: {glob}");
-            assert!(ov.matched("outside", true).is_ignore(), "glob: {glob}");
-        }
-    }
-
-    #[test]
-    fn duplicate_literal_prefixes_are_added_once() {
-        let ov = ov(&["src/**/*.rs", "src/**/*.py", "src/lib/**"]);
-
-        assert_eq!(ov.1.as_ref().unwrap().len(), 2);
-        assert!(ov.matched("src", true).is_none());
-        assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
-        assert!(ov.matched("src/nested/main.py", false).is_whitelist());
-        assert!(ov.matched("outside", true).is_ignore());
-    }
-
-    #[test]
-    fn dot_components_disable_directory_pruning() {
-        for glob in ["./src/**/*.rs", "../src/**/*.rs", "//src/**/*.rs"] {
-            let ov = ov(&[glob]);
-
-            assert!(ov.matched("outside", true).is_none(), "glob: {glob}");
-        }
-    }
-
-    #[test]
-    fn changing_case_mode_preserves_existing_literal_prefix() {
+    fn literal_prefix_respects_case_mode() {
         let ov = OverrideBuilder::new(ROOT)
             .add("src/**/*.rs")
             .unwrap()
@@ -497,14 +417,8 @@ mod tests {
             .unwrap()
             .build()
             .unwrap();
-
-        assert!(ov.matched("src", true).is_none());
-        assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
         assert!(ov.matched("outside", true).is_ignore());
-    }
 
-    #[test]
-    fn case_insensitive_positive_disables_directory_pruning() {
         let ov = OverrideBuilder::new(ROOT)
             .case_insensitive(true)
             .unwrap()
@@ -512,10 +426,31 @@ mod tests {
             .unwrap()
             .build()
             .unwrap();
-
-        assert!(ov.matched("SRC", true).is_none());
         assert!(ov.matched("SRC/nested/main.RS", false).is_whitelist());
         assert!(ov.matched("outside", true).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn literal_prefix_preserves_relative_root_collisions() {
+        for root in ["src", "./src"] {
+            let matcher = ov_at(root, &["2/**/*.rs"]);
+            assert!(matcher.matched("src2", true).is_none());
+            assert!(matcher.matched("src2/other.rs", false).is_whitelist());
+            assert!(matcher.matched("outside", true).is_ignore());
+        }
+    }
+
+    #[test]
+    fn many_literal_prefixes_do_not_exceed_regex_limits() {
+        let mut builder = OverrideBuilder::new(".");
+        let suffix = "a".repeat(242);
+        for index in 0..1_300 {
+            builder.add(&format!("p{index:06}_{suffix}/needle.rs")).unwrap();
+        }
+        let matcher = builder.build().unwrap();
+        assert_eq!(matcher.1.as_ref().unwrap().len(), 1_300);
+        assert!(matcher.matched("outside", true).is_ignore());
     }
 
     #[test]

--- a/crates/ignore/src/overrides.rs
+++ b/crates/ignore/src/overrides.rs
@@ -5,7 +5,7 @@ This provides functionality similar to `--include` or `--exclude` in command
 line tools.
 */
 
-use std::path::Path;
+use std::{collections::HashSet, path::Path};
 
 use crate::{
     Error, Match,
@@ -125,6 +125,7 @@ impl Override {
 pub struct OverrideBuilder {
     builder: GitignoreBuilder,
     directory_prefixes: Option<GitignoreBuilder>,
+    directory_prefix_components: HashSet<String>,
     case_insensitive: bool,
 }
 
@@ -139,6 +140,7 @@ impl OverrideBuilder {
         OverrideBuilder {
             builder,
             directory_prefixes: Some(GitignoreBuilder::new(path)),
+            directory_prefix_components: HashSet::new(),
             case_insensitive: false,
         }
     }
@@ -174,9 +176,20 @@ impl OverrideBuilder {
             return Ok(self);
         }
         if let Some(prefixes) = &mut self.directory_prefixes {
+            let glob =
+                if glob.ends_with("\\ ") { glob } else { glob.trim_end() };
+            let is_absolute = glob.starts_with('/');
             let glob = glob.strip_prefix('/').unwrap_or(glob);
-            match glob.split_once('/') {
-                Some((component, _))
+            let (glob, is_only_dir) = match glob.strip_suffix('/') {
+                Some(glob) => (glob.strip_suffix('\\').unwrap_or(glob), true),
+                None => (glob, false),
+            };
+            let component = glob
+                .split_once('/')
+                .map(|(component, _)| component)
+                .or_else(|| (is_absolute && is_only_dir).then_some(glob));
+            match component {
+                Some(component)
                     if !component.is_empty()
                         && component != "."
                         && component != ".."
@@ -185,8 +198,14 @@ impl OverrideBuilder {
                                 || matches!(byte, b'_' | b'-' | b'.')
                         }) =>
                 {
-                    prefixes.add_line(None, &format!("/{component}"))?;
-                    prefixes.add_line(None, &format!("/{component}/**"))?;
+                    if self
+                        .directory_prefix_components
+                        .insert(component.to_owned())
+                    {
+                        prefixes.add_line(None, &format!("/{component}"))?;
+                        prefixes
+                            .add_line(None, &format!("/{component}/**"))?;
+                    }
                 }
                 _ => self.directory_prefixes = None,
             }
@@ -352,6 +371,42 @@ mod tests {
         assert!(ov.matched("src", true).is_none());
         assert!(ov.matched("src/nested", true).is_none());
         assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
+        assert!(ov.matched("outside", true).is_ignore());
+    }
+
+    #[test]
+    fn basename_directory_globs_preserve_nested_directories() {
+        for glob in ["src/", "src/   ", r"src\/"] {
+            let ov = ov(&[glob]);
+
+            assert!(ov.matched("nested", true).is_none(), "glob: {glob}");
+            assert!(
+                ov.matched("nested/src", true).is_whitelist(),
+                "glob: {glob}"
+            );
+            assert!(ov.matched("outside", true).is_none(), "glob: {glob}");
+        }
+    }
+
+    #[test]
+    fn rooted_directory_globs_prune_unmatched_directories() {
+        for glob in ["/src/", "/src/   ", r"/src\/"] {
+            let ov = ov(&[glob]);
+
+            assert!(ov.matched("src", true).is_whitelist(), "glob: {glob}");
+            assert!(ov.matched("nested", true).is_ignore(), "glob: {glob}");
+            assert!(ov.matched("outside", true).is_ignore(), "glob: {glob}");
+        }
+    }
+
+    #[test]
+    fn duplicate_literal_prefixes_are_added_once() {
+        let ov = ov(&["src/**/*.rs", "src/**/*.py", "src/lib/**"]);
+
+        assert_eq!(ov.1.as_ref().unwrap().len(), 2);
+        assert!(ov.matched("src", true).is_none());
+        assert!(ov.matched("src/nested/main.rs", false).is_whitelist());
+        assert!(ov.matched("src/nested/main.py", false).is_whitelist());
         assert!(ov.matched("outside", true).is_ignore());
     }
 

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -2300,40 +2300,20 @@ mod tests {
     }
 
     #[test]
-    fn override_literal_prefix_prunes_unreachable_directories() {
+    fn override_literal_prefix_prunes_after_case_insensitive_toggle() {
         let td = tmpdir();
-        mkdirp(td.path().join("target/nested"));
-        mkdirp(td.path().join("outside/nested"));
-        wfile(td.path().join("target/nested/keep.rs"), "");
-        wfile(td.path().join("target/nested/skip.txt"), "");
-        wfile(td.path().join("outside/nested/skip.rs"), "");
+        mkdirp(td.path().join("target"));
+        mkdirp(td.path().join("second"));
+        mkdirp(td.path().join("outside"));
+        wfile(td.path().join("target/keep.rs"), "");
+        wfile(td.path().join("target/generated.rs"), "");
+        wfile(td.path().join("second/keep.rs"), "");
+        wfile(td.path().join("outside/skip.rs"), "");
 
         let overrides = OverrideBuilder::new(td.path())
             .add("target/**/*.rs")
             .unwrap()
-            .build()
-            .unwrap();
-        let mut builder = WalkBuilder::new(td.path());
-        builder.overrides(overrides);
-
-        assert_paths(
-            td.path(),
-            &builder,
-            &["target", "target/nested", "target/nested/keep.rs"],
-        );
-    }
-
-    #[test]
-    fn override_literal_prefix_prunes_after_case_insensitive_toggle() {
-        let td = tmpdir();
-        mkdirp(td.path().join("target/nested"));
-        mkdirp(td.path().join("outside/nested"));
-        wfile(td.path().join("target/nested/keep.rs"), "");
-        wfile(td.path().join("target/nested/generated.rs"), "");
-        wfile(td.path().join("outside/nested/skip.rs"), "");
-
-        let overrides = OverrideBuilder::new(td.path())
-            .add("target/**/*.rs")
+            .add("second/**/*.rs")
             .unwrap()
             .case_insensitive(true)
             .unwrap()
@@ -2347,74 +2327,20 @@ mod tests {
         assert_paths(
             td.path(),
             &builder,
-            &["target", "target/nested", "target/nested/keep.rs"],
+            &["target", "target/keep.rs", "second", "second/keep.rs"],
         );
     }
 
     #[test]
-    fn override_basename_glob_keeps_nested_directories() {
+    fn override_unrooted_globs_disable_literal_prefix_pruning() {
         let td = tmpdir();
-        mkdirp(td.path().join("alpha/nested"));
-        mkdirp(td.path().join("beta/nested"));
-        wfile(td.path().join("alpha/nested/keep.rs"), "");
-        wfile(td.path().join("alpha/nested/skip.txt"), "");
-        wfile(td.path().join("beta/nested/keep.rs"), "");
-
-        let overrides = OverrideBuilder::new(td.path())
-            .add("alpha/**/*.rs")
-            .unwrap()
-            .add("*.rs")
-            .unwrap()
-            .build()
-            .unwrap();
-        let mut builder = WalkBuilder::new(td.path());
-        builder.overrides(overrides);
-
-        assert_paths(
-            td.path(),
-            &builder,
-            &[
-                "alpha",
-                "alpha/nested",
-                "alpha/nested/keep.rs",
-                "beta",
-                "beta/nested",
-                "beta/nested/keep.rs",
-            ],
-        );
-    }
-
-    #[test]
-    fn override_basename_directory_glob_keeps_nested_directories() {
-        let td = tmpdir();
-        mkdirp(td.path().join("src"));
+        mkdirp(td.path().join("target"));
         mkdirp(td.path().join("nested/src"));
+        mkdirp(td.path().join("nested/GOOD"));
+        wfile(td.path().join("target/keep.rs"), "");
+        wfile(td.path().join("nested/GOOD/keep.log"), "");
 
-        for glob in ["src/", "src/   ", r"src\/"] {
-            let overrides = OverrideBuilder::new(td.path())
-                .add(glob)
-                .unwrap()
-                .build()
-                .unwrap();
-            let mut builder = WalkBuilder::new(td.path());
-            builder.overrides(overrides);
-
-            assert_paths(
-                td.path(),
-                &builder,
-                &["src", "nested", "nested/src"],
-            );
-        }
-    }
-
-    #[test]
-    fn override_basename_directory_glob_disables_literal_prefix_pruning() {
-        let td = tmpdir();
-        mkdirp(td.path().join("target/nested"));
-        mkdirp(td.path().join("nested/src"));
-        wfile(td.path().join("target/nested/keep.rs"), "");
-
-        for glob in ["src/", "src/   ", r"src\/"] {
+        for glob in ["src/", "src/   ", r"src\/", "*.rs", "*/GOOD/*.log"] {
             let overrides = OverrideBuilder::new(td.path())
                 .add("target/**/*.rs")
                 .unwrap()
@@ -2425,136 +2351,18 @@ mod tests {
             let mut builder = WalkBuilder::new(td.path());
             builder.overrides(overrides);
 
-            assert_paths(
-                td.path(),
-                &builder,
-                &[
-                    "target",
-                    "target/nested",
-                    "target/nested/keep.rs",
-                    "nested",
-                    "nested/src",
-                ],
-            );
+            let mut expected = vec![
+                "target",
+                "target/keep.rs",
+                "nested",
+                "nested/src",
+                "nested/GOOD",
+            ];
+            if glob == "*/GOOD/*.log" {
+                expected.push("nested/GOOD/keep.log");
+            }
+            assert_paths(td.path(), &builder, &expected);
         }
-    }
-
-    #[test]
-    fn override_rooted_directory_glob_prunes_unreachable_directories() {
-        let td = tmpdir();
-        mkdirp(td.path().join("src/child"));
-        mkdirp(td.path().join("nested/src"));
-
-        for glob in ["/src/", "/src/   ", r"/src\/"] {
-            let overrides = OverrideBuilder::new(td.path())
-                .add(glob)
-                .unwrap()
-                .build()
-                .unwrap();
-            let mut builder = WalkBuilder::new(td.path());
-            builder.overrides(overrides);
-
-            assert_paths(td.path(), &builder, &["src", "src/child"]);
-        }
-    }
-
-    #[test]
-    fn override_wildcard_prefix_keeps_matching_descendants() {
-        let td = tmpdir();
-        mkdirp(td.path().join("first/GOOD"));
-        mkdirp(td.path().join("first/blah/nested"));
-        mkdirp(td.path().join("second/GOOD"));
-        mkdirp(td.path().join("second/blah"));
-        wfile(td.path().join("first/GOOD/keep.log"), "");
-        wfile(td.path().join("first/blah/nested/skip.log"), "");
-        wfile(td.path().join("second/GOOD/keep.log"), "");
-
-        let overrides = OverrideBuilder::new(td.path())
-            .add("*/GOOD/*.log")
-            .unwrap()
-            .build()
-            .unwrap();
-        let mut builder = WalkBuilder::new(td.path());
-        builder.overrides(overrides);
-
-        assert_paths(
-            td.path(),
-            &builder,
-            &[
-                "first",
-                "first/GOOD",
-                "first/GOOD/keep.log",
-                "first/blah",
-                "first/blah/nested",
-                "second",
-                "second/GOOD",
-                "second/GOOD/keep.log",
-                "second/blah",
-            ],
-        );
-    }
-
-    #[test]
-    fn override_multiple_prefixes_preserve_negation() {
-        let td = tmpdir();
-        mkdirp(td.path().join("alpha/src"));
-        mkdirp(td.path().join("beta/src"));
-        mkdirp(td.path().join("outside/src"));
-        wfile(td.path().join("alpha/src/keep.rs"), "");
-        wfile(td.path().join("beta/src/keep.rs"), "");
-        wfile(td.path().join("beta/src/generated.rs"), "");
-        wfile(td.path().join("outside/src/skip.rs"), "");
-
-        let overrides = OverrideBuilder::new(td.path())
-            .add("alpha/**/*.rs")
-            .unwrap()
-            .add("beta/**/*.rs")
-            .unwrap()
-            .add("!beta/**/generated.rs")
-            .unwrap()
-            .build()
-            .unwrap();
-        let mut builder = WalkBuilder::new(td.path());
-        builder.overrides(overrides);
-
-        assert_paths(
-            td.path(),
-            &builder,
-            &[
-                "alpha",
-                "alpha/src",
-                "alpha/src/keep.rs",
-                "beta",
-                "beta/src",
-                "beta/src/keep.rs",
-            ],
-        );
-    }
-
-    #[test]
-    fn override_prefix_respects_case_insensitive_and_ignore_files() {
-        let td = tmpdir();
-        mkdirp(td.path().join("SRC/allowed"));
-        mkdirp(td.path().join("SRC/blocked"));
-        wfile(td.path().join(".ignore"), "SRC/blocked/\n");
-        wfile(td.path().join("SRC/allowed/keep.RS"), "");
-        wfile(td.path().join("SRC/blocked/skip.RS"), "");
-
-        let overrides = OverrideBuilder::new(td.path())
-            .case_insensitive(true)
-            .unwrap()
-            .add("src/**/*.rs")
-            .unwrap()
-            .build()
-            .unwrap();
-        let mut builder = WalkBuilder::new(td.path());
-        builder.overrides(overrides);
-
-        assert_paths(
-            td.path(),
-            &builder,
-            &["SRC", "SRC/allowed", "SRC/allowed/keep.RS"],
-        );
     }
 
     #[test]

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -2192,7 +2192,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use super::{DirEntry, WalkBuilder, WalkState};
-    use crate::tests::TempDir;
+    use crate::{overrides::OverrideBuilder, tests::TempDir};
 
     fn wfile<P: AsRef<Path>>(path: P, contents: &str) {
         let mut file = File::create(path).unwrap();
@@ -2296,6 +2296,190 @@ mod tests {
             td.path(),
             &WalkBuilder::new(td.path()),
             &["x", "x/y", "x/y/foo", "a", "a/b", "a/b/foo", "a/b/c"],
+        );
+    }
+
+    #[test]
+    fn override_literal_prefix_prunes_unreachable_directories() {
+        let td = tmpdir();
+        mkdirp(td.path().join("target/nested"));
+        mkdirp(td.path().join("outside/nested"));
+        wfile(td.path().join("target/nested/keep.rs"), "");
+        wfile(td.path().join("target/nested/skip.txt"), "");
+        wfile(td.path().join("outside/nested/skip.rs"), "");
+
+        let overrides = OverrideBuilder::new(td.path())
+            .add("target/**/*.rs")
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut builder = WalkBuilder::new(td.path());
+        builder.overrides(overrides);
+
+        assert_paths(
+            td.path(),
+            &builder,
+            &["target", "target/nested", "target/nested/keep.rs"],
+        );
+    }
+
+    #[test]
+    fn override_literal_prefix_prunes_after_case_insensitive_toggle() {
+        let td = tmpdir();
+        mkdirp(td.path().join("target/nested"));
+        mkdirp(td.path().join("outside/nested"));
+        wfile(td.path().join("target/nested/keep.rs"), "");
+        wfile(td.path().join("target/nested/generated.rs"), "");
+        wfile(td.path().join("outside/nested/skip.rs"), "");
+
+        let overrides = OverrideBuilder::new(td.path())
+            .add("target/**/*.rs")
+            .unwrap()
+            .case_insensitive(true)
+            .unwrap()
+            .add("!TARGET/**/GENERATED.RS")
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut builder = WalkBuilder::new(td.path());
+        builder.overrides(overrides);
+
+        assert_paths(
+            td.path(),
+            &builder,
+            &["target", "target/nested", "target/nested/keep.rs"],
+        );
+    }
+
+    #[test]
+    fn override_basename_glob_keeps_nested_directories() {
+        let td = tmpdir();
+        mkdirp(td.path().join("alpha/nested"));
+        mkdirp(td.path().join("beta/nested"));
+        wfile(td.path().join("alpha/nested/keep.rs"), "");
+        wfile(td.path().join("alpha/nested/skip.txt"), "");
+        wfile(td.path().join("beta/nested/keep.rs"), "");
+
+        let overrides = OverrideBuilder::new(td.path())
+            .add("alpha/**/*.rs")
+            .unwrap()
+            .add("*.rs")
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut builder = WalkBuilder::new(td.path());
+        builder.overrides(overrides);
+
+        assert_paths(
+            td.path(),
+            &builder,
+            &[
+                "alpha",
+                "alpha/nested",
+                "alpha/nested/keep.rs",
+                "beta",
+                "beta/nested",
+                "beta/nested/keep.rs",
+            ],
+        );
+    }
+
+    #[test]
+    fn override_wildcard_prefix_keeps_matching_descendants() {
+        let td = tmpdir();
+        mkdirp(td.path().join("first/GOOD"));
+        mkdirp(td.path().join("first/blah/nested"));
+        mkdirp(td.path().join("second/GOOD"));
+        mkdirp(td.path().join("second/blah"));
+        wfile(td.path().join("first/GOOD/keep.log"), "");
+        wfile(td.path().join("first/blah/nested/skip.log"), "");
+        wfile(td.path().join("second/GOOD/keep.log"), "");
+
+        let overrides = OverrideBuilder::new(td.path())
+            .add("*/GOOD/*.log")
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut builder = WalkBuilder::new(td.path());
+        builder.overrides(overrides);
+
+        assert_paths(
+            td.path(),
+            &builder,
+            &[
+                "first",
+                "first/GOOD",
+                "first/GOOD/keep.log",
+                "first/blah",
+                "first/blah/nested",
+                "second",
+                "second/GOOD",
+                "second/GOOD/keep.log",
+                "second/blah",
+            ],
+        );
+    }
+
+    #[test]
+    fn override_multiple_prefixes_preserve_negation() {
+        let td = tmpdir();
+        mkdirp(td.path().join("alpha/src"));
+        mkdirp(td.path().join("beta/src"));
+        mkdirp(td.path().join("outside/src"));
+        wfile(td.path().join("alpha/src/keep.rs"), "");
+        wfile(td.path().join("beta/src/keep.rs"), "");
+        wfile(td.path().join("beta/src/generated.rs"), "");
+        wfile(td.path().join("outside/src/skip.rs"), "");
+
+        let overrides = OverrideBuilder::new(td.path())
+            .add("alpha/**/*.rs")
+            .unwrap()
+            .add("beta/**/*.rs")
+            .unwrap()
+            .add("!beta/**/generated.rs")
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut builder = WalkBuilder::new(td.path());
+        builder.overrides(overrides);
+
+        assert_paths(
+            td.path(),
+            &builder,
+            &[
+                "alpha",
+                "alpha/src",
+                "alpha/src/keep.rs",
+                "beta",
+                "beta/src",
+                "beta/src/keep.rs",
+            ],
+        );
+    }
+
+    #[test]
+    fn override_prefix_respects_case_insensitive_and_ignore_files() {
+        let td = tmpdir();
+        mkdirp(td.path().join("SRC/allowed"));
+        mkdirp(td.path().join("SRC/blocked"));
+        wfile(td.path().join(".ignore"), "SRC/blocked/\n");
+        wfile(td.path().join("SRC/allowed/keep.RS"), "");
+        wfile(td.path().join("SRC/blocked/skip.RS"), "");
+
+        let overrides = OverrideBuilder::new(td.path())
+            .case_insensitive(true)
+            .unwrap()
+            .add("src/**/*.rs")
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut builder = WalkBuilder::new(td.path());
+        builder.overrides(overrides);
+
+        assert_paths(
+            td.path(),
+            &builder,
+            &["SRC", "SRC/allowed", "SRC/allowed/keep.RS"],
         );
     }
 

--- a/crates/ignore/src/walk.rs
+++ b/crates/ignore/src/walk.rs
@@ -2385,6 +2385,80 @@ mod tests {
     }
 
     #[test]
+    fn override_basename_directory_glob_keeps_nested_directories() {
+        let td = tmpdir();
+        mkdirp(td.path().join("src"));
+        mkdirp(td.path().join("nested/src"));
+
+        for glob in ["src/", "src/   ", r"src\/"] {
+            let overrides = OverrideBuilder::new(td.path())
+                .add(glob)
+                .unwrap()
+                .build()
+                .unwrap();
+            let mut builder = WalkBuilder::new(td.path());
+            builder.overrides(overrides);
+
+            assert_paths(
+                td.path(),
+                &builder,
+                &["src", "nested", "nested/src"],
+            );
+        }
+    }
+
+    #[test]
+    fn override_basename_directory_glob_disables_literal_prefix_pruning() {
+        let td = tmpdir();
+        mkdirp(td.path().join("target/nested"));
+        mkdirp(td.path().join("nested/src"));
+        wfile(td.path().join("target/nested/keep.rs"), "");
+
+        for glob in ["src/", "src/   ", r"src\/"] {
+            let overrides = OverrideBuilder::new(td.path())
+                .add("target/**/*.rs")
+                .unwrap()
+                .add(glob)
+                .unwrap()
+                .build()
+                .unwrap();
+            let mut builder = WalkBuilder::new(td.path());
+            builder.overrides(overrides);
+
+            assert_paths(
+                td.path(),
+                &builder,
+                &[
+                    "target",
+                    "target/nested",
+                    "target/nested/keep.rs",
+                    "nested",
+                    "nested/src",
+                ],
+            );
+        }
+    }
+
+    #[test]
+    fn override_rooted_directory_glob_prunes_unreachable_directories() {
+        let td = tmpdir();
+        mkdirp(td.path().join("src/child"));
+        mkdirp(td.path().join("nested/src"));
+
+        for glob in ["/src/", "/src/   ", r"/src\/"] {
+            let overrides = OverrideBuilder::new(td.path())
+                .add(glob)
+                .unwrap()
+                .build()
+                .unwrap();
+            let mut builder = WalkBuilder::new(td.path());
+            builder.overrides(overrides);
+
+            assert_paths(td.path(), &builder, &["src", "src/child"]);
+        }
+    }
+
+    #[test]
     fn override_wildcard_prefix_keeps_matching_descendants() {
         let td = tmpdir();
         mkdirp(td.path().join("first/GOOD"));


### PR DESCRIPTION
Basically, if `-g 'codex/**/*.rs'` can only match files under `codex/`, there’s no reason to walk the rest of the repo.

This adds conservative directory pruning for positive globs with a fixed prefix. Prefixes are tracked in a `HashSet`, so there’s no extra glob matcher or NFA. Basename globs, wildcard prefixes, exclusions, and case-insensitive globs keep their existing behavior.

Benchmarks on a ~1M-file repo:

- Rust: `3.74s → 45ms` (83×)
- Python: `3.91s → 71ms` (55×)
- Rust + Python: `4.30s → 77ms` (56×)
- `--files`: `4.32s → 53ms` (82×)

Same results and exit codes in all benchmark scenarios.

Refs #2789