### PR TITLE
docs: clarify -r replacement flag

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -470,6 +470,11 @@ $ rg fast README.md -r FAST
 [snip]
 ```
 
+Here, `-r` is short for `--replace`, not recursive search. ripgrep already
+searches directories recursively by default. For example, `rg -rn PATTERN`
+replaces each match with `n`; use `rg -n PATTERN` to show line numbers without
+replacing matches.
+
 In essence, the `--replace` flag applies *only* to the matching portion of text
 in the output. If you instead wanted to replace an entire line of text, then
 you need to include the entire line in your match. For example:

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -6371,6 +6371,11 @@ impl Flag for Replace {
 Replaces every match with the text given when printing results. Neither this
 flag nor any other ripgrep flag will modify your files.
 .sp
+Unlike grep, ripgrep searches directories recursively by default. The
+\fB-r\fP flag is short for \fB--replace\fP, not recursive search. For example,
+\fBrg -rn PATTERN\fP replaces each match with \fBn\fP. To show line numbers
+without replacing matches, use \fBrg -n PATTERN\fP.
+.sp
 Capture group indices (e.g., \fB$\fP\fI5\fP) and names (e.g., \fB$\fP\fIfoo\fP)
 are supported in the replacement string. Capture group indices are numbered
 based on the position of the opening parenthesis of the group, where the


### PR DESCRIPTION
Kept typing rg -rn PATTERN out of grep habit, expecting recursive search with line numbers — but ripgrep reads -r as --replace and swaps every match for the literal n. Recursion is already the default. This change just documents that gotcha in the guide and the --replace help, with contrasting examples. No behavior change. Validated with formatting checks, 118 binary tests, 10 replacement integration tests, and by generating and inspecting the help/man output.