### PR TITLE
ci: fix binary discovery

### DIFF
--- a/tests/util.rs
+++ b/tests/util.rs
@@ -177,7 +177,11 @@ impl Dir {
 
     /// Returns the path to the ripgrep executable.
     pub fn bin(&self) -> process::Command {
-        let rg = self.root.join(format!("../rg{}", env::consts::EXE_SUFFIX));
+        let rg = std::env::var_os("CARGO_BIN_EXE_rg")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                self.root.join(format!("../rg{}", env::consts::EXE_SUFFIX))
+            });
         match cross_runner() {
             None => process::Command::new(rg),
             Some(runner) => {


### PR DESCRIPTION
It looks like the location of executables is changing in Cargo's test
runner, so use the blessed way of discovering an executable. That is,
for ripgrep, consult the `CARGO_BIN_EXE_rg` environment variable.
