### PR TITLE
ignore,globset: increase pool capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -97,7 +97,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs_io"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
 dependencies = [
  "encoding_rs",
 ]
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
@@ -296,9 +296,9 @@ checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "log"
@@ -351,18 +351,18 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -442,38 +442,38 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -493,6 +493,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/globset/Cargo.toml
+++ b/crates/globset/Cargo.toml
@@ -33,7 +33,7 @@ default-features = false
 features = ["std"]
 
 [dependencies.regex-automata]
-version = "0.4.0"
+version = "0.4.18"
 default-features = false
 features = ["std", "perf", "syntax", "meta", "nfa", "hybrid"]
 

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -28,7 +28,7 @@ same-file = "1.0.6"
 walkdir = "2.4.0"
 
 [dependencies.regex-automata]
-version = "0.4.0"
+version = "0.4.18"
 default-features = false
 features = ["std", "perf", "syntax", "meta", "nfa", "hybrid", "dfa-onepass"]
 

--- a/crates/ignore/src/gitignore.rs
+++ b/crates/ignore/src/gitignore.rs
@@ -359,7 +359,9 @@ impl GitignoreBuilder {
             globs: self.globs.clone(),
             num_ignores: nignore as u64,
             num_whitelists: nwhite as u64,
-            matches: Some(Arc::new(Pool::new(|| vec![]))),
+            matches: Some(Arc::new(
+                Pool::with_available_parallelism_capacity(|| vec![]),
+            )),
         })
     }
 

--- a/crates/ignore/src/types.rs
+++ b/crates/ignore/src/types.rs
@@ -231,7 +231,9 @@ impl Types {
             has_selected: false,
             glob_to_selection: vec![],
             set: GlobSetBuilder::new().build().unwrap(),
-            matches: Arc::new(Pool::new(|| vec![])),
+            matches: Arc::new(Pool::with_available_parallelism_capacity(
+                || vec![],
+            )),
         }
     }
 
@@ -357,7 +359,9 @@ impl TypesBuilder {
             has_selected,
             glob_to_selection,
             set,
-            matches: Arc::new(Pool::new(|| vec![])),
+            matches: Arc::new(Pool::with_available_parallelism_capacity(
+                || vec![],
+            )),
         })
     }
 


### PR DESCRIPTION
When do matching inside of `ignore` or `globset`, we sometimes need a
reusable mutable scratch space for matching. To do this, we use a `Pool`
abstraction from `regex-automata` to do this heavy lifting for us.

It turns out that this can be a limiting factor in some scenarios when
gitignore matching dominates. For example, in my checkout of the
Chromium repository:

```
$ hyperfine 'rg-master -j32 --files' 'rg-bigger-pool -j32 --files' 'rg-master -j32 --files --no-ignore'
Benchmark 1: rg-master -j32 --files
  Time (mean ± σ):     156.3 ms ±   5.5 ms    [User: 2356.4 ms, System: 380.8 ms]
  Range (min … max):   147.6 ms … 164.5 ms    19 runs

Benchmark 2: rg-bigger-pool -j32 --files
  Time (mean ± σ):     131.6 ms ±   2.1 ms    [User: 1628.2 ms, System: 310.1 ms]
  Range (min … max):   128.8 ms … 136.3 ms    22 runs

Benchmark 3: rg-master -j32 --files --no-ignore
  Time (mean ± σ):     107.4 ms ±   1.0 ms    [User: 664.7 ms, System: 304.7 ms]
  Range (min … max):   104.9 ms … 109.6 ms    28 runs

Summary
  rg-master -j32 --files --no-ignore ran
    1.22 ± 0.02 times faster than rg-bigger-pool -j32 --files
    1.45 ± 0.05 times faster than rg-master -j32 --files
```

The `--no-ignore` benchmark is our baseline. It doesn't process
gitignore files, so it's quite a bit faster. But with this change,
processing gitignore files gets faster than what is currently on master.
Specifically, re-running the above without the baseline:

```
$ hyperfine 'rg-master -j32 --files' 'rg-bigger-pool -j32 --files'
Benchmark 1: rg-master -j32 --files
  Time (mean ± σ):     154.1 ms ±   5.1 ms    [User: 2287.4 ms, System: 378.2 ms]
  Range (min … max):   144.1 ms … 163.9 ms    19 runs

Benchmark 2: rg-bigger-pool -j32 --files
  Time (mean ± σ):     131.7 ms ±   2.1 ms    [User: 1618.6 ms, System: 314.1 ms]
  Range (min … max):   128.4 ms … 135.3 ms    22 runs

Summary
  rg-bigger-pool -j32 --files ran
    1.17 ± 0.04 times faster than rg-master -j32 --files
```

I've used `-j32` here because this change is best observed as improving
the *scaling* properties. (And my system has 32 cores, so it's the best
case scenario.) If we just let ripgrep use its default thread heuristic
(which caps itself at a lower value), then the improvement here is a
bit more modest:

```
$ hyperfine 'rg-master --files' 'rg-bigger-pool --files'
Benchmark 1: rg-master --files
  Time (mean ± σ):     150.0 ms ±   8.5 ms    [User: 1139.6 ms, System: 237.7 ms]
  Range (min … max):   131.1 ms … 162.4 ms    22 runs

Benchmark 2: rg-bigger-pool --files
  Time (mean ± σ):     136.0 ms ±  12.1 ms    [User: 1034.4 ms, System: 236.0 ms]
  Range (min … max):   117.7 ms … 157.6 ms    22 runs

Summary
  rg-bigger-pool --files ran
    1.10 ± 0.12 times faster than rg-master --files
```

This improves scaling because the underlying change here now uses a
cache line for each available thread instead of limiting itself to a
fixed value of `8`. The cost is that ripgrep may use a bit more memory
storing cached values per thread.
