### PR TITLE
ci: pin actions to commit shas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
           rust: nightly
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Install packages (Ubuntu)
       if: matrix.os == 'ubuntu-latest'
@@ -125,7 +125,7 @@ jobs:
         ci/ubuntu-install-packages
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
       with:
         toolchain: ${{ matrix.rust }}
 
@@ -208,9 +208,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
       with:
         toolchain: stable
     - name: Add wasm32-wasip1 target
@@ -222,9 +222,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
       with:
         toolchain: stable
         components: rustfmt
@@ -235,9 +235,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: stable
       - name: Check documentation
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install required packages (Ubuntu)
         run: |
@@ -258,7 +258,7 @@ jobs:
           sudo apt-get install g++ --yes
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     name: create-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Get the release version from the tag
         if: env.VERSION == ''
         run: echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
@@ -139,7 +139,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Install packages (Ubuntu)
       if: matrix.os == 'ubuntu-latest'
@@ -148,7 +148,7 @@ jobs:
         ci/ubuntu-install-packages
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
       with:
         toolchain: ${{ matrix.rust }}
         target: ${{ matrix.target }}
@@ -311,7 +311,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Install packages (Ubuntu)
       shell: bash
@@ -319,7 +319,7 @@ jobs:
         ci/ubuntu-install-packages
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
       with:
         toolchain: nightly
         target: ${{ env.TARGET }}


### PR DESCRIPTION
Hi, one commit, one logical change, found with the Plumber CLI (https://github.com/getplumber/plumber) and verified on master.

You already pin `actions/attest-build-provenance` by commit sha; this finishes the job for `actions/checkout` and `dtolnay/rust-toolchain`, same comment style. The path that motivated it is `release.yml`: its jobs create the release and upload the binaries people download while holding a contents write token, and a tag like `@v4` or `@master` is a movable pointer, whoever controls (or compromises) the action repo can re-point it and the next run executes their code. That is how the tj-actions/changed-files compromise spread in March 2025 (CVE-2025-30066): re-pointed version tags on a trusted action, and every tag-referenced use ran the payload on its next build, while sha-pinned refs were untouched.

Every rust-toolchain site already passes an explicit `toolchain:` input, so pinning `@master` changes nothing about which toolchain installs. Each sha was resolved from the upstream repo and cross checked against its tag, and both dependabot and renovate bump sha pins with the comment kept in sync if you ever want that automated.

One heads up: if an Actions allowlist is configured in settings, patterns written against tags (like `owner/action@v4`) stop matching once refs are shas and workflows refuse to start. Entries need the `owner/action@*` form.

I can also open a PR which adds the tool to CI so this does not quietly drift back; that one is a bonus, this PR stands on its own.