### PR TITLE
ci: add plumber workflow security check

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,35 @@
+name: plumber
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - uses: getplumber/plumber@95c19b0d5cf54d1aeecbd78ceda33cc32581b093 # v0.4.30
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,21 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: '2.0'
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the rust-toolchain
+      # action this repo already uses on top of it.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - dtolnay/rust-toolchain
+
+    # Off for now: the finding is rustup's own install script inside
+    # rust-toolchain, the standard way every Rust CI bootstraps a
+    # toolchain. Nothing repo-side to fix until upstream ships a
+    # checksummed install path.
+    actionsMustNotExecuteMutableRemoteCode:
+      enabled: false

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ other popular search tools like The Silver Searcher, ack and grep.
 [![Build status](https://github.com/BurntSushi/ripgrep/workflows/ci/badge.svg)](https://github.com/BurntSushi/ripgrep/actions)
 [![Crates.io](https://img.shields.io/crates/v/ripgrep.svg)](https://crates.io/crates/ripgrep)
 [![Packaging status](https://repology.org/badge/tiny-repos/ripgrep.svg)](https://repology.org/project/ripgrep/badges)
+[![Plumber Score](https://score.getplumber.io/github.com/BurntSushi/ripgrep.svg)](https://score.getplumber.io/github.com/BurntSushi/ripgrep)
 
 Dual-licensed under MIT or the [UNLICENSE](https://unlicense.org).
 


### PR DESCRIPTION
Companion to https://github.com/BurntSushi/ripgrep/pull/3504, merge that one first: the check added here flags the unpinned actions until the hardening lands, then it goes green.

This adds [Plumber](https://github.com/getplumber/plumber) to CI, the tool I used to find the unpinned refs. It scans the workflows on each push to master and on each PR, and fails when something regresses: an unpinned action, a job without a permissions block, an unverified remote script, that kind of thing. The gate passes at 85 of 100 points, so one small finding does not block PRs.

- `plumber.yml`: pinned by sha, minimal permissions, findings go to the Security tab as SARIF (skipped on PRs from forks, the report stays as a workflow artifact there).
- `.plumber.yaml`: a small overlay that inherits the tool's built-in baseline; only what differs for this repo is written. rust-toolchain is trusted on top of the curated default source list, and one control is off with a comment because its only finding is rustup's own install script, which is how every Rust CI bootstraps. Everything else, including new controls in future releases, follows the defaults automatically.
- `README.md`: one line, the score badge next to the existing ones.

**Score badge**
I enabled `score-push` on the action. It works like OpenSSF Scorecard's published results: every run, on any branch, publishes the score to score.getplumber.io, and that feeds the badge in the README. Scores are public and the badge always shows the state of master. A failed publish never fails your CI. Until the first run the badge reads UNKNOWN in gray, then it flips to the grade. If you would rather not have it, drop the README line and the `score-push` input, the rest works the same.

With the hardening in, this runs green with a score of A. Set `soft-fail: true` if you prefer report only, without gating PRs.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, say so and I close this PR, the hardening PR stands on its own.