### PR TITLE
fix: report column for multiline lookahead matches

### DIFF
--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -739,7 +739,9 @@ impl<'p, 's, M: Matcher, W: WriteColor> StandardSink<'p, 's, M, W> {
         // a synthetic match spanning the entire match range so that
         // column reporting (and other match-granularity output) still
         // works instead of silently dropping the column.
-        if matches.is_empty() && searcher.multi_line_with_matcher(&self.matcher) {
+        if matches.is_empty()
+            && searcher.multi_line_with_matcher(&self.matcher)
+        {
             matches.push(Match::new(0, range.len()));
         }
         Ok(())

--- a/crates/printer/src/standard.rs
+++ b/crates/printer/src/standard.rs
@@ -731,6 +731,17 @@ impl<'p, 's, M: Matcher, W: WriteColor> StandardSink<'p, 's, M, W> {
         {
             matches.pop().unwrap();
         }
+        // When the re-search fails to find any match, it is typically
+        // because the regex uses lookahead that requires content beyond
+        // the match boundary. find_iter_at_in_context extends the search
+        // buffer by only MAX_LOOK_AHEAD bytes in multi-line mode, which
+        // may not be enough when the lookahead spans many lines. Insert
+        // a synthetic match spanning the entire match range so that
+        // column reporting (and other match-granularity output) still
+        // works instead of silently dropping the column.
+        if matches.is_empty() && searcher.multi_line_with_matcher(&self.matcher) {
+            matches.push(Match::new(0, range.len()));
+        }
         Ok(())
     }
 


### PR DESCRIPTION
When a multiline regex uses a zero-width lookahead whose content spans more than MAX_LOOK_AHEAD bytes beyond the match boundary, the re-search in record_matches fails to find the match again and the printer drops the column number entirely.

Insert a synthetic match covering the whole match range when the re-search yields no matches in multiline mode, so column reporting and other match-granularity output remain consistent.

Closes #3503

## Tests

- cargo test -p grep-printer
- cargo test -p grep-searcher

## AI Disclosure

The fix was produced with the assistance of an AI coding agent. I have reviewed and understood the change as the contributor.