### PR TITLE
flags: add nushell completions via --generate complete-nushell

### DIFF
--- a/crates/core/flags/complete/mod.rs
+++ b/crates/core/flags/complete/mod.rs
@@ -6,5 +6,6 @@ static ENCODINGS: &'static str = include_str!("encodings.sh");
 
 pub(super) mod bash;
 pub(super) mod fish;
+pub(super) mod nushell;
 pub(super) mod powershell;
 pub(super) mod zsh;

--- a/crates/core/flags/complete/nushell.rs
+++ b/crates/core/flags/complete/nushell.rs
@@ -1,0 +1,78 @@
+/*!
+Provides completions for ripgrep's CLI for the nushell shell.
+*/
+
+use crate::flags::{CompletionType, defs::FLAGS};
+
+const PRELUDE: &'static str = "\
+def \"nu-complete rg types\" [] {
+  ^rg --type-list
+  | lines
+  | split column \": \"
+  | rename value description
+  | update value { str trim }
+}
+
+export extern \"rg\" [
+  pattern?: string # The pattern to search for
+  ...paths: path # The paths to search
+";
+
+const TEMPLATE_CHOICES: &'static str =
+    "def \"nu-complete rg !LONG!\" [] { [!CHOICES!] }\n";
+
+/// Generate completions for Nushell.
+///
+/// Reference: <https://www.nushell.sh/book/custom_completions.html>
+pub(crate) fn generate() -> String {
+    let mut helpers = String::new();
+    let mut flags = String::new();
+    for flag in FLAGS.iter() {
+        let doc = flag.doc_short().replace('\n', " ");
+        let short = match flag.name_short() {
+            None => "".to_string(),
+            Some(byte) => format!("(-{})", char::from(byte)),
+        };
+        let long = flag.name_long();
+
+        let mut completion = format!("  --{long}{short}");
+        if !flag.is_switch() {
+            let value_type = match flag.completion_type() {
+                CompletionType::Filename => "path".to_string(),
+                CompletionType::Filetype => {
+                    "string@\"nu-complete rg types\"".to_string()
+                }
+                CompletionType::Other if !flag.doc_choices().is_empty() => {
+                    let choices = flag
+                        .doc_choices()
+                        .iter()
+                        .map(|choice| format!("\"{choice}\""))
+                        .collect::<Vec<String>>()
+                        .join(", ");
+                    helpers.push_str(
+                        &TEMPLATE_CHOICES
+                            .replace("!LONG!", long)
+                            .replace("!CHOICES!", &choices),
+                    );
+                    format!("string@\"nu-complete rg {long}\"")
+                }
+                _ => "string".to_string(),
+            };
+            completion.push_str(&format!(": {value_type}"));
+        }
+        completion.push_str(&format!(" # {doc}"));
+        completion.push('\n');
+        flags.push_str(&completion);
+
+        if let Some(negated) = flag.name_negated() {
+            flags.push_str(&format!("  --{negated} # {doc}\n"));
+        }
+    }
+
+    let mut out = String::new();
+    out.push_str(&helpers);
+    out.push_str(PRELUDE);
+    out.push_str(&flags);
+    out.push_str("]\n");
+    out
+}

--- a/crates/core/flags/defs.rs
+++ b/crates/core/flags/defs.rs
@@ -2512,6 +2512,9 @@ Generates a completion script for the \fBfish\fP shell.
 .TP 15
 \fBcomplete\-powershell\fP
 Generates a completion script for PowerShell.
+.TP 15
+\fBcomplete\-nushell\fP
+Generates a completion script for the \fBnushell\fP shell.
 .PP
 The output is written to \fBstdout\fP. The list above may expand over time.
 "
@@ -2523,6 +2526,7 @@ The output is written to \fBstdout\fP. The list above may expand over time.
             "complete-zsh",
             "complete-fish",
             "complete-powershell",
+            "complete-nushell",
         ]
     }
 
@@ -2533,6 +2537,7 @@ The output is written to \fBstdout\fP. The list above may expand over time.
             "complete-zsh" => GenerateMode::CompleteZsh,
             "complete-fish" => GenerateMode::CompleteFish,
             "complete-powershell" => GenerateMode::CompletePowerShell,
+            "complete-nushell" => GenerateMode::CompleteNushell,
             unk => anyhow::bail!("choice '{unk}' is unrecognized"),
         };
         args.mode.update(Mode::Generate(genmode));
@@ -2560,6 +2565,9 @@ fn test_generate() {
 
     let args = parse_low_raw(["--generate", "complete-powershell"]).unwrap();
     assert_eq!(Mode::Generate(GenerateMode::CompletePowerShell), args.mode);
+
+    let args = parse_low_raw(["--generate", "complete-nushell"]).unwrap();
+    assert_eq!(Mode::Generate(GenerateMode::CompleteNushell), args.mode);
 
     let args =
         parse_low_raw(["--generate", "complete-bash", "--generate=man"])

--- a/crates/core/flags/lowargs.rs
+++ b/crates/core/flags/lowargs.rs
@@ -236,6 +236,8 @@ pub(crate) enum GenerateMode {
     CompleteZsh,
     /// Completions for fish.
     CompleteFish,
+    /// Completions for nushell.
+    CompleteNushell,
     /// Completions for PowerShell.
     CompletePowerShell,
 }

--- a/crates/core/flags/mod.rs
+++ b/crates/core/flags/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use crate::flags::{
     complete::{
         bash::generate as generate_complete_bash,
         fish::generate as generate_complete_fish,
+        nushell::generate as generate_complete_nushell,
         powershell::generate as generate_complete_powershell,
         zsh::generate as generate_complete_zsh,
     },

--- a/crates/core/main.rs
+++ b/crates/core/main.rs
@@ -366,6 +366,7 @@ fn generate(mode: crate::flags::GenerateMode) -> anyhow::Result<ExitCode> {
         GenerateMode::CompleteBash => flags::generate_complete_bash(),
         GenerateMode::CompleteZsh => flags::generate_complete_zsh(),
         GenerateMode::CompleteFish => flags::generate_complete_fish(),
+        GenerateMode::CompleteNushell => flags::generate_complete_nushell(),
         GenerateMode::CompletePowerShell => {
             flags::generate_complete_powershell()
         }


### PR DESCRIPTION
Adds a `complete-nushell` option to `--generate`, following the same pattern as the existing bash/zsh/fish/powershell generators.

Closes #3425

The generated script defines an `export extern` block for `rg` where flags with fixed choices get a small `nu-complete` helper, `--type`/`--type-not` complete from `rg --type-list`, and filename-taking flags use `path` so nushell completes paths natively. Negated flags (`--no-*`) are listed as separate entries, same as the fish generator.

Tested by loading the generated script in nushell 0.114.1 and checking that flag names and file types complete with descriptions.