### PR TITLE
ignore/types: add more PowerShell file types and aliases

### DIFF
--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -215,7 +215,10 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["postscript"], &["*.eps", "*.ps"]),
     (&["prolog"], &["*.pl", "*.pro", "*.prolog", "*.P"]),
     (&["proto", "protobuf"], &["*.proto"]),
-    (&["ps"], &["*.cdxml", "*.ps1", "*.ps1xml", "*.psd1", "*.psm1"]),
+    (&["powershell", "ps", "pwsh"], &[
+        "*.cdxml", "*.ps1", "*.ps1xml", "*.psc1", "*.psd1", "*.psm1", "*.psr",
+         "*.psrc", "*.pssc", "*.psxml"
+    ]),
     (&["puppet"], &["*.epp", "*.erb", "*.pp", "*.rb"]),
     (&["purs"], &["*.purs"]),
     (&["py", "python"], &["*.py", "*.pyi"]),

--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -213,12 +213,12 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["po"], &["*.po"]),
     (&["pod"], &["*.pod"]),
     (&["postscript"], &["*.eps", "*.ps"]),
-    (&["prolog"], &["*.pl", "*.pro", "*.prolog", "*.P"]),
-    (&["proto", "protobuf"], &["*.proto"]),
     (&["powershell", "ps", "pwsh"], &[
         "*.cdxml", "*.ps1", "*.ps1xml", "*.psc1", "*.psd1", "*.psm1", "*.psr",
          "*.psrc", "*.pssc", "*.psxml"
     ]),
+    (&["prolog"], &["*.pl", "*.pro", "*.prolog", "*.P"]),
+    (&["proto", "protobuf"], &["*.proto"]),
     (&["puppet"], &["*.epp", "*.erb", "*.pp", "*.rb"]),
     (&["purs"], &["*.purs"]),
     (&["py", "python"], &["*.py", "*.pyi"]),


### PR DESCRIPTION
- `*.psc1`: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/export-console
- `*.psrc`: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/new-psrolecapabilityfile
- `*.pssc`: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_session_configuration_files
- `powershell`: full name
- `pwsh`: common used shorthand, executable name for PowerShell Core, https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh